### PR TITLE
Add retry for flaky tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Download grcov
         run: curl -L https://github.com/mozilla/grcov/releases/download/v0.8.7/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
       - name: Install deps
-        run: pip install -U setuptools-rust networkx testtools fixtures
+        run: pip install -U setuptools-rust networkx testtools fixtures tenacity
       - name: Build retworkx
         run: python setup.py develop
         env:

--- a/tests/retworkx_backwards_compat/digraph/test_edgelist.py
+++ b/tests/retworkx_backwards_compat/digraph/test_edgelist.py
@@ -16,6 +16,7 @@ import unittest
 
 import retworkx
 
+from tenacity import retry, stop_after_attempt
 
 class TestEdgeList(unittest.TestCase):
     def test_empty_edge_list_digraph(self):
@@ -147,6 +148,7 @@ class TestEdgeList(unittest.TestCase):
         self.assertTrue(graph.has_edge(0, 2))
         self.assertEqual(graph.edges(), ["0", "1", None])
 
+    @retry(stop=stop_after_attempt(5))
     def test_write_edge_list_empty_digraph(self):
         path = os.path.join(tempfile.gettempdir(), "empty.txt")
         graph = retworkx.PyDiGraph()
@@ -155,6 +157,7 @@ class TestEdgeList(unittest.TestCase):
         with open(path, "rt") as edge_file:
             self.assertEqual("", edge_file.read())
 
+    @retry(stop=stop_after_attempt(5))
     def test_write_edge_list_round_trip(self):
         path = os.path.join(tempfile.gettempdir(), "round_trip.txt")
         graph = retworkx.generators.directed_star_graph(5)

--- a/tests/retworkx_backwards_compat/digraph/test_edgelist.py
+++ b/tests/retworkx_backwards_compat/digraph/test_edgelist.py
@@ -18,6 +18,7 @@ import retworkx
 
 from tenacity import retry, stop_after_attempt
 
+
 class TestEdgeList(unittest.TestCase):
     def test_empty_edge_list_digraph(self):
         with tempfile.NamedTemporaryFile() as fd:

--- a/tests/retworkx_backwards_compat/graph/test_edgelist.py
+++ b/tests/retworkx_backwards_compat/graph/test_edgelist.py
@@ -16,6 +16,7 @@ import unittest
 
 import retworkx
 
+from tenacity import retry, stop_after_attempt
 
 class TestEdgeList(unittest.TestCase):
     def test_empty_edge_list_graph(self):
@@ -143,6 +144,7 @@ class TestEdgeList(unittest.TestCase):
         self.assertTrue(graph.has_edge(0, 2))
         self.assertEqual(graph.edges(), ["0", "1", None])
 
+    @retry(stop=stop_after_attempt(5))
     def test_write_edge_list_empty_digraph(self):
         path = os.path.join(tempfile.gettempdir(), "empty.txt")
         graph = retworkx.PyGraph()
@@ -151,6 +153,7 @@ class TestEdgeList(unittest.TestCase):
         with open(path, "rt") as edge_file:
             self.assertEqual("", edge_file.read())
 
+    @retry(stop=stop_after_attempt(5))
     def test_write_edge_list_round_trip(self):
         path = os.path.join(tempfile.gettempdir(), "round_trip.txt")
         graph = retworkx.generators.star_graph(5)

--- a/tests/retworkx_backwards_compat/graph/test_edgelist.py
+++ b/tests/retworkx_backwards_compat/graph/test_edgelist.py
@@ -18,6 +18,7 @@ import retworkx
 
 from tenacity import retry, stop_after_attempt
 
+
 class TestEdgeList(unittest.TestCase):
     def test_empty_edge_list_graph(self):
         with tempfile.NamedTemporaryFile() as fd:

--- a/tests/rustworkx_tests/digraph/test_edgelist.py
+++ b/tests/rustworkx_tests/digraph/test_edgelist.py
@@ -18,6 +18,7 @@ import rustworkx
 
 from tenacity import retry, stop_after_attempt
 
+
 class TestEdgeList(unittest.TestCase):
     def test_empty_edge_list_digraph(self):
         with tempfile.NamedTemporaryFile() as fd:

--- a/tests/rustworkx_tests/digraph/test_edgelist.py
+++ b/tests/rustworkx_tests/digraph/test_edgelist.py
@@ -16,6 +16,7 @@ import unittest
 
 import rustworkx
 
+from tenacity import retry, stop_after_attempt
 
 class TestEdgeList(unittest.TestCase):
     def test_empty_edge_list_digraph(self):
@@ -147,6 +148,7 @@ class TestEdgeList(unittest.TestCase):
         self.assertTrue(graph.has_edge(0, 2))
         self.assertEqual(graph.edges(), ["0", "1", None])
 
+    @retry(stop=stop_after_attempt(5))
     def test_write_edge_list_empty_digraph(self):
         path = os.path.join(tempfile.gettempdir(), "empty.txt")
         graph = rustworkx.PyDiGraph()
@@ -155,6 +157,7 @@ class TestEdgeList(unittest.TestCase):
         with open(path, "rt") as edge_file:
             self.assertEqual("", edge_file.read())
 
+    @retry(stop=stop_after_attempt(5))
     def test_write_edge_list_round_trip(self):
         path = os.path.join(tempfile.gettempdir(), "round_trip.txt")
         graph = rustworkx.generators.directed_star_graph(5)

--- a/tests/rustworkx_tests/graph/test_edgelist.py
+++ b/tests/rustworkx_tests/graph/test_edgelist.py
@@ -18,6 +18,7 @@ import rustworkx
 
 from tenacity import retry, stop_after_attempt
 
+
 class TestEdgeList(unittest.TestCase):
     def test_empty_edge_list_graph(self):
         with tempfile.NamedTemporaryFile() as fd:

--- a/tests/rustworkx_tests/graph/test_edgelist.py
+++ b/tests/rustworkx_tests/graph/test_edgelist.py
@@ -16,6 +16,7 @@ import unittest
 
 import rustworkx
 
+from tenacity import retry, stop_after_attempt
 
 class TestEdgeList(unittest.TestCase):
     def test_empty_edge_list_graph(self):
@@ -143,6 +144,7 @@ class TestEdgeList(unittest.TestCase):
         self.assertTrue(graph.has_edge(0, 2))
         self.assertEqual(graph.edges(), ["0", "1", None])
 
+    @retry(stop=stop_after_attempt(5))
     def test_write_edge_list_empty_digraph(self):
         path = os.path.join(tempfile.gettempdir(), "empty.txt")
         graph = rustworkx.PyGraph()
@@ -151,6 +153,7 @@ class TestEdgeList(unittest.TestCase):
         with open(path, "rt") as edge_file:
             self.assertEqual("", edge_file.read())
 
+    @retry(stop=stop_after_attempt(5))
     def test_write_edge_list_round_trip(self):
         path = os.path.join(tempfile.gettempdir(), "round_trip.txt")
         graph = rustworkx.generators.star_graph(5)

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
   testtools>=2.5.0
   networkx>=2.5
   stestr
+  tenacity
 passenv = RETWORKX_TEST_PRESERVE_IMAGES RUSTWORKX_PKG_NAME
 changedir = {toxinidir}/tests
 commands =


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

We add retry attemps to the test that writes the edge list

This specific flaky test has made the CI fail multiple times. Instead of manually having to retrigger all of our CI everytime it fails, we attempt to execute the specific test multiple times using `tenacity`.
