### PR TITLE
Remove coreutils build from retworkx backwards compat tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,15 +117,16 @@ jobs:
           default: true
       - name: 'Install dependencies'
         run: python -m pip install --upgrade tox
-      - name: 'Install coreutils to set environment variable'
-        run: cargo install coreutils
       - name: 'Install binary dependencies'
         run: sudo apt-get install -y graphviz
         if: runner.os == 'Linux'
-      - name: 'Run tests'
+      - name: 'Build rustworkx'
         run: |
           tox -epy --notest
-          coreutils env RUSTWORKX_PKG_NAME="retworkx" tox -epy -- -t ./retworkx_backwards_compat
+      - name: 'Run retworkx tests'
+        env:
+          RUSTWORKX_PKG_NAME: "retworkx"
+        run: tox -epy -- -t ./retworkx_backwards_compat
   coverage:
     needs: [tests]
     name: Coverage


### PR DESCRIPTION
In #644 we added the build/install of the rust coreutils package to the
retworkx backwards compat CI job  to have a consistent cross platform
way to set environment variables between different OSes. However, this
adds significant time to the CI job while we build this package. This
commit reconfigures the job to leverage github actions native
environment variable handling and drops the coreutils usage. This should
speed up the backwards compat jobs since we no longer are compiling
coreutils from source.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
