### PR TITLE
Improve introductory documentation materials

### DIFF
--- a/docs/source/README.rst
+++ b/docs/source/README.rst
@@ -1,1 +1,0 @@
-.. mdinclude:: ../../README.md

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,7 +52,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
-   Installation and Getting Started <install.rst>
+   Installation and Getting Started <install>
    Rustworkx Tutorials and Guides <tutorial/index>
    Rustworkx API <api>
    Visualization <visualization>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,8 +40,8 @@ Project history
 
 rustworkx was originally called retworkx and was created to be a high
 performance replacement for the Qiskit project's internal usage of the
-`NetworkX <https://networkx.org/>`__ library (which is where the name comes
-from Rust + NetworkX = rustworkx) but it is not a drop-in replacement for
+`NetworkX <https://networkx.org/>`__ library (which is where the name came
+from: Rust + NetworkX = rustworkx) but it is not a drop-in replacement for
 NetworkX (see :ref:`networkx` for more details). However, since it was
 originally created it has grown to be an independent high performance general
 purpose graph library that can be used for any application that needs to
@@ -52,7 +52,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
-   Overview and Installation <README>
+   Installation and Getting Started <install.rst>
    Rustworkx Tutorials and Guides <tutorial/index>
    Rustworkx API <api>
    Visualization <visualization>

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -18,7 +18,7 @@ simple as running::
 This will install a precompiled version of rustworkx into your python
 environment.
 
-.. install-unsupported::
+.. _install-unsupported::
 
 Installing on a platform without precompiled binaries
 -----------------------------------------------------
@@ -48,7 +48,7 @@ just as it would if there was a prebuilt binary available.
     ``pip install -U pip`` or manually install ``setuptools-rust`` with:
     ``pip install setuptools-rust`` and try again.
 
-.. platform-suppport::
+.. _platform-suppport::
 
 Platform Support
 ================
@@ -105,7 +105,7 @@ source.
      - :ref:`tier-2` (Python < 3.10), :ref:`tier-3` (Python >= 3.10)
      -
 
-.. tier-1::
+.. _tier-1::
 
 Tier 1
 ------
@@ -116,7 +116,7 @@ binaries are built, tested, and published to PyPI as part of the release
 process. These platforms are expected to be installable with just a functioning
 Python environment.
 
-.. tier-2::
+.. _tier-2::
 
 Tier 2
 ------
@@ -126,7 +126,7 @@ However, pre-compiled binaries are built, tested, and published to PyPI as part
 of the release process and these packages can be expected to be installed with
 just a functioning Python environment.
 
-.. tier-3::
+.. _tier-3::
 
 Tier 3
 ------
@@ -137,7 +137,7 @@ part of the release process. However, they may not installable with just a
 functioning Python environment and you may be required to build Numpy from
 source, which requires a C/C++ compiler, as part of the installation process.
 
-.. tier-4::
+.. _tier-4::
 
 Tier 4
 ------

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -86,7 +86,7 @@ source.
      - Distributions compatible with the [manylinux 2014](https://peps.python.org/pep-0599/) packaging specification
    * - Linux
      - s390x
-     - :ref:`tier-3
+     - :ref:`tier-3`
      - Distributions compatible with the [manylinux 2014](https://peps.python.org/pep-0599/) packaging specification
    * - macOS (10.9 or newer)
      - x86_64

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -18,7 +18,7 @@ simple as running::
 This will install a precompiled version of rustworkx into your python
 environment.
 
-.. _install-unsupported::
+.. _install-unsupported:
 
 Installing on a platform without precompiled binaries
 -----------------------------------------------------
@@ -48,7 +48,7 @@ just as it would if there was a prebuilt binary available.
     ``pip install -U pip`` or manually install ``setuptools-rust`` with:
     ``pip install setuptools-rust`` and try again.
 
-.. _platform-suppport::
+.. _platform-suppport:
 
 Platform Support
 ================
@@ -105,7 +105,7 @@ source.
      - :ref:`tier-2` (Python < 3.10), :ref:`tier-3` (Python >= 3.10)
      -
 
-.. _tier-1::
+.. _tier-1:
 
 Tier 1
 ------
@@ -116,7 +116,7 @@ binaries are built, tested, and published to PyPI as part of the release
 process. These platforms are expected to be installable with just a functioning
 Python environment.
 
-.. _tier-2::
+.. _tier-2:
 
 Tier 2
 ------
@@ -126,7 +126,7 @@ However, pre-compiled binaries are built, tested, and published to PyPI as part
 of the release process and these packages can be expected to be installed with
 just a functioning Python environment.
 
-.. _tier-3::
+.. _tier-3:
 
 Tier 3
 ------
@@ -137,7 +137,7 @@ part of the release process. However, they may not installable with just a
 functioning Python environment and you may be required to build Numpy from
 source, which requires a C/C++ compiler, as part of the installation process.
 
-.. _tier-4::
+.. _tier-4:
 
 Tier 4
 ------

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,0 +1,176 @@
+Getting Started
+===============
+
+rustworkx is a general purpose graph library for Python written in Rust to take
+advantage of the performance and safety that Rust provides. It is designed to
+provide a high performance general purpose graph library for any Python
+application.
+
+Installing Rustworkx
+====================
+
+rustworkx is published on pypi so on x86_64, i686, ppc64le, s390x, and aarch64
+Linux systems, x86_64 on Mac OSX, and 32 and 64 bit Windows installing is as
+simple as running::
+
+    pip install rustworkx
+
+This will install a precompiled version of rustworkx into your python
+environment.
+
+.. install-unsupported::
+
+Installing on a platform without precompiled binaries
+-----------------------------------------------------
+
+If there are no precompiled binaries published for your system you'll have to
+build the package from source. However, to be able able to build the package from
+the published source package you need to have Rust >= 1.48.0 installed (and also
+cargo which is normally included with rust) You can use
+`rustup <https://rustup.rs/>`_ (a cross platform installer for rust) to make this
+simpler, or rely on
+`other installation methods <https://forge.rust-lang.org/infra/other-installation-methods.html>`__.
+A source package is also published on PyPI, so you still can run ``pip`` to install
+it. Once you have Rust properly installed, running::
+
+    pip install rustworkx
+
+will build rustworkx for your local system from the source package and install it
+just as it would if there was a prebuilt binary available.
+
+
+.. note::
+
+    To build from source you will need to ensure you have pip >=19.0.0
+    installed, which supports PEP-517, or that you have manually installed
+    setuptools-rust prior to running pip install rustworkx. If you recieve an
+    error about ``setuptools-rust`` not being found you should upgrade pip with
+    ``pip install -U pip`` or manually install ``setuptools-rust`` with:
+    ``pip install setuptools-rust`` and try again.
+
+.. platform-suppport::
+
+Platform Support
+================
+
+Rustworkx strives to support as many platforms as possible, but due to
+limitations in available testing resources and platform availability, not all
+platforms can be supported. Platform support for rustworkx is broken into 4
+tiers with different levels of support for each tier. For platforms outside
+these, rustworkx is probably still installable, but it’s not tested and you will
+need a Rust compiler and have to build retworkx (and likely Numpy too) from
+source.
+
+.. list-table:: Platform Support
+   :header-rows: 1
+
+   * - Operating System
+     - CPU Architecture
+     - Support Tier
+     - Notes 
+   * - Linux
+     - x86_64
+     - :ref:`tier-1`
+     - Distributions compatible with the [manylinux 2010](https://peps.python.org/pep-0571/) packaging specification
+   * - Linux
+     - i686 
+     - :ref:`tier-2` (Python < 3.10), :ref:`tier-3` (Python >= 3.10)
+     - Distributions compatible with the [manylinux 2010](https://peps.python.org/pep-0571/) packaging specification
+   * - Linux
+     - aarch64
+     - :ref:`tier-2`
+     - Distributions compatible with the [manylinux 2014](https://peps.python.org/pep-0599/) packaging specification
+   * - Linux
+     - pp64le
+     - :ref:`tier-3`
+     - Distributions compatible with the [manylinux 2014](https://peps.python.org/pep-0599/) packaging specification
+   * - Linux
+     - s390x
+     - :ref:`tier-3
+     - Distributions compatible with the [manylinux 2014](https://peps.python.org/pep-0599/) packaging specification
+   * - macOS (10.9 or newer)
+     - x86_64
+     - :ref:`tier-1`
+     -
+   * - macOS (10.15 or newer)
+     - arm64
+     - :ref:`tier-4`
+     -
+   * - Windows 64bit
+     - x86_64
+     - :ref:`tier-1`
+     -
+   * - Windows 32bit 
+     - i686 or x86_64
+     - :ref:`tier-2` (Python < 3.10), :ref:`tier-3` (Python >= 3.10)
+     -
+
+.. tier-1::
+
+Tier 1
+------
+
+Tier 1 supported platforms are fully tested upstream as part of the development
+process to ensure any proposed change will function correctly. Pre-compiled
+binaries are built, tested, and published to PyPI as part of the release
+process. These platforms are expected to be installable with just a functioning
+Python environment.
+
+.. tier-2::
+
+Tier 2
+------
+
+Tier 2 platforms are not tested upstream as part of the development process.
+However, pre-compiled binaries are built, tested, and published to PyPI as part
+of the release process and these packages can be expected to be installed with
+just a functioning Python environment.
+
+.. tier-3::
+
+Tier 3
+------
+
+Tier 3 platforms are not tested upstream as part of the development process.
+Pre-compiled binaries are built, tested and published to PyPI as
+part of the release process. However, they may not installable with just a
+functioning Python environment and you may be required to build Numpy from
+source, which requires a C/C++ compiler, as part of the installation process.
+
+.. tier-4::
+
+Tier 4
+------
+
+Tier 4 platforms are not tested upstream as part of the development process.
+Pre-compiled binaries are built and published to PyPI as part of the release
+process, with no testing at all. They may not be installable with just a
+functioning Python environment and may require a C/C++ compiler or additional
+programs to build dependencies from source as part of the installation process.
+Support for these platforms are best effort only.
+
+Using rustworkx
+===============
+
+Once you have rustworkx installed you can use it by importing rustworkx. All the
+functions and graph classes are off the root of the package. For example,
+calculating the shortest path between A and C would be::
+
+    import rustworkx as rx
+    
+    graph = rx.PyGraph()
+    
+    # Each time add node is called, it returns a new node index
+    a = graph.add_node("A")
+    b = graph.add_node("B")
+    c = graph.add_node("C")
+    
+    # add_edges_from takes tuples of node indices and weights,
+    # and returns edge indices
+    graph.add_edges_from([(a, b, 1.5), (a, c, 5.0), (b, c, 2.5)])
+    
+    # Returns the path A -> B -> C
+    rx.dijkstra_shortest_paths(graph, a, c, weight_fn=float)
+
+You can refer to the :ref:`intro-tutorial` for more details on getting started
+with rustworkx.

--- a/docs/source/tutorial/introduction.rst
+++ b/docs/source/tutorial/introduction.rst
@@ -2,6 +2,8 @@
    introduction tutorial in  NetworkX's documentation which can be found here:
    https://networkx.org/documentation/networkx-2.6.2/tutorial.html
 
+.. _intro-tutorial:
+
 #########################
 Introduction to rustworkx
 #########################

--- a/docs/source/tutorial/introduction.rst
+++ b/docs/source/tutorial/introduction.rst
@@ -6,10 +6,36 @@
 Introduction to rustworkx
 #########################
 
+The rustworkx library is a Python library for working with graphs (or networks)
+and graph theory.
+
 This guide serves as an introduction to working with rustworkx. If you're a
 current or past `NetworkX <https:://networkx.org>`__ user who is looking at
 using rustworkx as a replacement for NetworkX, you can also refer to
 :ref:`networkx` for a detailed comparison.
+
+Installing rustworkx
+====================
+
+To install rustworkx you need a Python installation. Rustworkx works in any
+Python environment. If you already have Python, you can install rustworkx with::
+
+    pip install rustworkx
+
+(if you're running on a supported platform, if you're not you will need to
+refer to the :ref:`install-unsupported` on how to build and install)
+
+How to import rustworkx
+=======================
+
+To access rustworkx and its functions import it into your Python code like this:
+
+.. jupyter-execute::
+
+    import rustworkx as rx
+
+We shorten the name to ``rx`` for better readability of code using Rustworkx.
+This is a widely adopted convention that you can follow.
 
 Creating a Graph
 ================
@@ -19,7 +45,6 @@ can run the following code:
 
 .. jupyter-execute::
 
-    import rustworkx as rx
     G = rx.PyGraph()
 
 A :class:`~rustworkx.PyGraph` is comprised of nodes (vertices)
@@ -171,8 +196,6 @@ lists of indices for nodes and edges in the graph. For example:
 
 .. jupyter-execute::
 
-    import rustworkx
-
     graph = rustworkx.PyGraph()
     graph.add_nodes_from(list(range(5)))
     graph.add_nodes_from(list(range(2)))
@@ -308,8 +331,6 @@ accessed and modified after creation with the :attr:`~.PyGraph.attrs` attribute.
 This attribute can be any Python object and defaults to being ``None`` if not
 specified at graph object creation time. For example::
 
-    import rustworkx as rx
-
     graph = rx.PyGraph(attrs=dict(day="Friday"))
     graph.attrs['day'] = "Monday"
 
@@ -335,7 +356,6 @@ directed graphs. For example:
 
 .. jupyter-execute::
 
-    import rustworkx as rx
     from rustworkx.visualization import mpl_draw
 
     path_graph = rx.generators.directed_path_graph(5)

--- a/docs/source/tutorial/introduction.rst
+++ b/docs/source/tutorial/introduction.rst
@@ -196,7 +196,7 @@ lists of indices for nodes and edges in the graph. For example:
 
 .. jupyter-execute::
 
-    graph = rustworkx.PyGraph()
+    graph = rx.PyGraph()
     graph.add_nodes_from(list(range(5)))
     graph.add_nodes_from(list(range(2)))
     graph.remove_node(2)

--- a/rustworkx/__init__.py
+++ b/rustworkx/__init__.py
@@ -36,9 +36,9 @@ class PyDAG(PyDiGraph):
 
     .. jupyter-execute::
 
-        import rustworkx
+        import rustworkx as rx
 
-        graph = rustworkx.PyDAG()
+        graph = rx.PyDAG()
         graph.add_nodes_from(list(range(5)))
         graph.add_nodes_from(list(range(2)))
         graph.remove_node(2)
@@ -54,9 +54,9 @@ class PyDAG(PyDiGraph):
 
     .. jupyter-execute::
 
-        import rustworkx
+        import rustworkx as rx
 
-        graph = rustworkx.PyDAG()
+        graph = rx.PyDAG()
         data_payload = "An arbitrary Python object"
         node_index = graph.add_node(data_payload)
         print("Node Index: %s" % node_index)
@@ -67,9 +67,9 @@ class PyDAG(PyDiGraph):
 
     .. jupyter-execute::
 
-        import rustworkx
+        import rustworkx as rx
 
-        graph = rustworkx.PyDAG()
+        graph = rx.PyDAG()
         data_payload = "An arbitrary Python object"
         node_index = graph.add_node(data_payload)
         graph[node_index] = "New Payload"
@@ -82,14 +82,14 @@ class PyDAG(PyDiGraph):
     performance, however you can enable it by setting the ``check_cycle``
     attribute to True. For example::
 
-        import rustworkx
-        dag = rustworkx.PyDAG()
+        import rustworkx as rx
+        dag = rx.PyDAG()
         dag.check_cycle = True
 
     or at object creation::
 
-        import rustworkx
-        dag = rustworkx.PyDAG(check_cycle=True)
+        import rustworkx as rx
+        dag = rx.PyDAG(check_cycle=True)
 
     With check_cycle set to true any calls to :meth:`PyDAG.add_edge` will
     ensure that no cycles are added, ensuring that the PyDAG class truly
@@ -107,8 +107,8 @@ class PyDAG(PyDiGraph):
     ``multigraph`` kwarg to ``False`` when calling the ``PyDAG`` constructor.
     For example::
 
-        import rustworkx
-        dag = rustworkx.PyDAG(multigraph=False)
+        import rustworkx as rx
+        dag = rx.PyDAG(multigraph=False)
 
     This can only be set at ``PyDiGraph`` initialization and not adjusted after
     creation. When :attr:`~rustworkx.PyDiGraph.multigraph` is set to ``False``
@@ -1951,7 +1951,7 @@ def bfs_search(graph, source, visitor):
 
     .. jupyter-execute::
 
-        import rustworkx
+        import rustworkx as rx
         from rustworkx.visit import BFSVisitor
 
 
@@ -1963,10 +1963,10 @@ def bfs_search(graph, source, visitor):
             def tree_edge(self, edge):
                 self.edges.append(edge)
 
-        graph = rustworkx.PyDiGraph()
+        graph = rx.PyDiGraph()
         graph.extend_from_edge_list([(1, 3), (0, 1), (2, 1), (0, 2)])
         vis = TreeEdgesRecorder()
-        rustworkx.bfs_search(graph, [0], vis)
+        rx.bfs_search(graph, [0], vis)
         print('Tree edges:', vis.edges)
 
     .. note::
@@ -2033,7 +2033,7 @@ def dfs_search(graph, source, visitor):
 
     .. jupyter-execute::
 
-           import rustworkx
+           import rustworkx as rx
            from rustworkx.visit import DFSVisitor
 
            class TreeEdgesRecorder(DFSVisitor):
@@ -2044,10 +2044,10 @@ def dfs_search(graph, source, visitor):
                def tree_edge(self, edge):
                    self.edges.append(edge)
 
-           graph = rustworkx.PyGraph()
+           graph = rx.PyGraph()
            graph.extend_from_edge_list([(1, 3), (0, 1), (2, 1), (0, 2)])
            vis = TreeEdgesRecorder()
-           rustworkx.dfs_search(graph, [0], vis)
+           rx.dfs_search(graph, [0], vis)
            print('Tree edges:', vis.edges)
 
     .. note::

--- a/rustworkx/visualization/graphviz.py
+++ b/rustworkx/visualization/graphviz.py
@@ -127,7 +127,7 @@ def graphviz_draw(
 
     .. jupyter-execute::
 
-        import rustworkx
+        import rustworkx as rx
         from rustworkx.visualization import graphviz_draw
 
         def node_attr(node):
@@ -138,7 +138,7 @@ def graphviz_draw(
           else:
             return {'color': 'red', 'fillcolor': 'red', 'style': 'filled'}
 
-        graph = rustworkx.generators.directed_star_graph(weights=list(range(32)))
+        graph = rx.generators.directed_star_graph(weights=list(range(32)))
         graphviz_draw(graph, node_attr_fn=node_attr, method='sfdp')
 
     """

--- a/rustworkx/visualization/matplotlib.py
+++ b/rustworkx/visualization/matplotlib.py
@@ -188,10 +188,10 @@ def mpl_draw(graph, pos=None, ax=None, arrows=True, with_labels=False, **kwds):
 
         import matplotlib.pyplot as plt
 
-        import rustworkx
+        import rustworkx as rx
         from rustworkx.visualization import mpl_draw
 
-        G = rustworkx.generators.directed_path_graph(25)
+        G = rx.generators.directed_path_graph(25)
         mpl_draw(G)
         plt.draw()
     """

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -67,9 +67,9 @@ use super::dag_algo::is_directed_acyclic_graph;
 ///
 /// .. jupyter-execute::
 ///
-///        import rustworkx
+///        import rustworkx as rx
 ///
-///        graph = rustworkx.PyDiGraph()
+///        graph = rx.PyDiGraph()
 ///        graph.add_nodes_from(list(range(5)))
 ///        graph.add_nodes_from(list(range(2)))
 ///        graph.remove_node(2)
@@ -83,9 +83,9 @@ use super::dag_algo::is_directed_acyclic_graph;
 ///
 /// .. jupyter-execute::
 ///
-///     import rustworkx
+///     import rustworkx as rx
 ///
-///     graph = rustworkx.PyDiGraph()
+///     graph = rx.PyDiGraph()
 ///     data_payload = "An arbitrary Python object"
 ///     node_index = graph.add_node(data_payload)
 ///     print("Node Index: %s" % node_index)
@@ -96,9 +96,9 @@ use super::dag_algo::is_directed_acyclic_graph;
 ///
 /// .. jupyter-execute::
 ///
-///     import rustworkx
+///     import rustworkx as rx
 ///
-///     graph = rustworkx.PyDiGraph()
+///     graph = rx.PyDiGraph()
 ///     data_payload = "An arbitrary Python object"
 ///     node_index = graph.add_node(data_payload)
 ///     graph[node_index] = "New Payload"
@@ -111,14 +111,14 @@ use super::dag_algo::is_directed_acyclic_graph;
 /// however you can enable it by setting the ``check_cycle`` attribute to True.
 /// For example::
 ///
-///     import rustworkx
-///     dag = rustworkx.PyDiGraph()
+///     import rustworkx as rx
+///     dag = rx.PyDiGraph()
 ///     dag.check_cycle = True
 ///
 /// or at object creation::
 ///
-///     import rustworkx
-///     dag = rustworkx.PyDiGraph(check_cycle=True)
+///     import rustworkx as rx
+///     dag = rx.PyDiGraph(check_cycle=True)
 ///
 /// With check_cycle set to true any calls to :meth:`PyDiGraph.add_edge` will
 /// ensure that no cycles are added, ensuring that the PyDiGraph class truly
@@ -136,8 +136,8 @@ use super::dag_algo::is_directed_acyclic_graph;
 /// ``multigraph`` kwarg to ``False`` when calling the ``PyDiGraph``
 /// constructor. For example::
 ///
-///     import rustworkx
-///     graph = rustworkx.PyDiGraph(multigraph=False)
+///     import rustworkx as rx
+///     graph = rx.PyDiGraph(multigraph=False)
 ///
 /// This can only be set at ``PyDiGraph`` initialization and not adjusted after
 /// creation. When :attr:`~rustworkx.PyDiGraph.multigraph` is set to ``False``
@@ -1759,9 +1759,9 @@ impl PyDiGraph {
     ///   import pydot
     ///   from PIL import Image
     ///
-    ///   import rustworkx
+    ///   import rustworkx as rx
     ///
-    ///   graph = rustworkx.directed_gnp_random_graph(15, .25)
+    ///   graph = rx.directed_gnp_random_graph(15, .25)
     ///   dot_str = graph.to_dot(
     ///       lambda node: dict(
     ///           color='black', fillcolor='lightblue', style='filled'))
@@ -1823,7 +1823,7 @@ impl PyDiGraph {
     ///
     ///   import tempfile
     ///
-    ///   import rustworkx
+    ///   import rustworkx as rx
     ///   from rustworkx.visualization import mpl_draw
     ///
     ///   with tempfile.NamedTemporaryFile('wt') as fd:
@@ -1834,7 +1834,7 @@ impl PyDiGraph {
     ///       fd.write('1 2\n')
     ///       fd.write('2 3\n')
     ///       fd.flush()
-    ///       graph = rustworkx.PyDiGraph.read_edge_list(path)
+    ///       graph = rx.PyDiGraph.read_edge_list(path)
     ///   mpl_draw(graph)
     ///
     #[staticmethod]
@@ -1943,9 +1943,9 @@ impl PyDiGraph {
     ///     import os
     ///     import tempfile
     ///
-    ///     import rustworkx
+    ///     import rustworkx as rx
     ///
-    ///     graph = rustworkx.generators.directed_path_graph(5)
+    ///     graph = rx.generators.directed_path_graph(5)
     ///     path = os.path.join(tempfile.gettempdir(), "edge_list")
     ///     graph.write_edge_list(path, deliminator=',')
     ///     # Print file contents
@@ -2093,11 +2093,11 @@ impl PyDiGraph {
     ///
     /// .. jupyter-execute::
     ///
-    ///   import rustworkx
+    ///   import rustworkx as rx
     ///   from rustworkx.visualization import mpl_draw
     ///
     ///   # Build first graph and visualize:
-    ///   graph = rustworkx.PyDiGraph()
+    ///   graph = rx.PyDiGraph()
     ///   node_a = graph.add_node('A')
     ///   node_b = graph.add_child(node_a, 'B', 'A to B')
     ///   node_c = graph.add_child(node_b, 'C', 'B to C')
@@ -2108,7 +2108,7 @@ impl PyDiGraph {
     /// .. jupyter-execute::
     ///
     ///   # Build second graph and visualize:
-    ///   other_graph = rustworkx.PyDiGraph()
+    ///   other_graph = rx.PyDiGraph()
     ///   node_d = other_graph.add_node('D')
     ///   other_graph.add_child(node_d, 'E', 'D to E')
     ///   mpl_draw(other_graph, with_labels=True, labels=str, edge_labels=str)

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -58,9 +58,9 @@ use petgraph::visit::{
 ///
 /// .. jupyter-execute::
 ///
-///        import rustworkx
+///        import rustworkx as rx
 ///
-///        graph = rustworkx.PyGraph()
+///        graph = rx.PyGraph()
 ///        graph.add_nodes_from(list(range(5)))
 ///        graph.add_nodes_from(list(range(2)))
 ///        graph.remove_node(2)
@@ -74,9 +74,9 @@ use petgraph::visit::{
 ///
 /// .. jupyter-execute::
 ///
-///     import rustworkx
+///     import rustworkx as rx
 ///
-///     graph = rustworkx.PyGraph()
+///     graph = rx.PyGraph()
 ///     data_payload = "An arbitrary Python object"
 ///     node_index = graph.add_node(data_payload)
 ///     print("Node Index: %s" % node_index)
@@ -87,9 +87,9 @@ use petgraph::visit::{
 ///
 /// .. jupyter-execute::
 ///
-///     import rustworkx
+///     import rustworkx as rx
 ///
-///     graph = rustworkx.PyGraph()
+///     graph = rx.PyGraph()
 ///     data_payload = "An arbitrary Python object"
 ///     node_index = graph.add_node(data_payload)
 ///     graph[node_index] = "New Payload"
@@ -101,8 +101,8 @@ use petgraph::visit::{
 /// ``multigraph`` kwarg to ``False`` when calling the ``PyGraph``
 /// constructor. For example::
 ///
-///     import rustworkx
-///     graph = rustworkx.PyGraph(multigraph=False)
+///     import rustworkx as rx
+///     graph = rx.PyGraph(multigraph=False)
 ///
 /// This can only be set at ``PyGraph`` initialization and not adjusted after
 /// creation. When :attr:`~rustworkx.PyGraph.multigraph` is set to ``False``
@@ -1123,9 +1123,9 @@ impl PyGraph {
     ///   import pydot
     ///   from PIL import Image
     ///
-    ///   import rustworkx
+    ///   import rustworkx as rx
     ///
-    ///   graph = rustworkx.undirected_gnp_random_graph(15, .25)
+    ///   graph = rx.undirected_gnp_random_graph(15, .25)
     ///   dot_str = graph.to_dot(
     ///       lambda node: dict(
     ///           color='black', fillcolor='lightblue', style='filled'))
@@ -1187,7 +1187,7 @@ impl PyGraph {
     ///
     ///   import tempfile
     ///
-    ///   import rustworkx
+    ///   import rustworkx as rx
     ///   from rustworkx.visualization import mpl_draw
     ///
     ///   with tempfile.NamedTemporaryFile('wt') as fd:
@@ -1198,7 +1198,7 @@ impl PyGraph {
     ///       fd.write('1 2\n')
     ///       fd.write('2 3\n')
     ///       fd.flush()
-    ///       graph = rustworkx.PyGraph.read_edge_list(path)
+    ///       graph = rx.PyGraph.read_edge_list(path)
     ///   mpl_draw(graph)
     ///
     #[staticmethod]
@@ -1305,9 +1305,9 @@ impl PyGraph {
     ///     import os
     ///     import tempfile
     ///
-    ///     import rustworkx
+    ///     import rustworkx as rx
     ///
-    ///     graph = rustworkx.generators.path_graph(5)
+    ///     graph = rx.generators.path_graph(5)
     ///     path = os.path.join(tempfile.gettempdir(), "edge_list")
     ///     graph.write_edge_list(path, deliminator=',')
     ///     # Print file contents
@@ -1461,11 +1461,11 @@ impl PyGraph {
     ///   import pydot
     ///   from PIL import Image
     ///
-    ///   import rustworkx
+    ///   import rustworkx as rx
     ///   from rustworkx.visualization import mpl_draw
     ///
     ///   # Build first graph and visualize:
-    ///   graph = rustworkx.PyGraph()
+    ///   graph = rx.PyGraph()
     ///   node_a, node_b, node_c = graph.add_nodes_from(['A', 'B', 'C'])
     ///   graph.add_edges_from([(node_a, node_b, 'A to B'),
     ///                         (node_b, node_c, 'B to C')])
@@ -1476,7 +1476,7 @@ impl PyGraph {
     /// .. jupyter-execute::
     ///
     ///   # Build second graph and visualize:
-    ///   other_graph = rustworkx.PyGraph()
+    ///   other_graph = rx.PyGraph()
     ///   node_d, node_e = other_graph.add_nodes_from(['D', 'E'])
     ///   other_graph.add_edge(node_d, node_e, 'D to E')
     ///   mpl_draw(other_graph, with_labels=True, labels=str, edge_labels=str)

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -554,10 +554,10 @@ custom_vec_iter_impl!(
 
     For example::
 
-        import rustworkx
+        import rustworkx as rx
 
-        graph = rustworkx.generators.directed_path_graph(5)
-        bfs_succ = rustworkx.bfs_successors(0)
+        graph = rx.generators.directed_path_graph(5)
+        bfs_succ = rx.bfs_successors(0)
         # Index based access
         third_element = bfs_succ[2]
         # Use as iterator
@@ -601,10 +601,10 @@ custom_vec_iter_impl!(
 
     For example::
 
-        import rustworkx
+        import rustworkx as rx
 
-        graph = rustworkx.generators.directed_path_graph(5)
-        nodes = rustworkx.node_indices(0)
+        graph = rx.generators.directed_path_graph(5)
+        nodes = rx.node_indices(0)
         # Index based access
         third_element = nodes[2]
         # Use as iterator
@@ -639,9 +639,9 @@ custom_vec_iter_impl!(
 
     For example::
 
-        import rustworkx
+        import rustworkx as rx
 
-        graph = rustworkx.generators.directed_path_graph(5)
+        graph = rx.generators.directed_path_graph(5)
         edges = graph.edge_list()
         # Index based access
         third_element = edges[2]
@@ -677,9 +677,9 @@ custom_vec_iter_impl!(
 
     For example::
 
-        import rustworkx
+        import rustworkx as rx
 
-        graph = rustworkx.generators.directed_path_graph(5)
+        graph = rx.generators.directed_path_graph(5)
         edges = graph.weighted_edge_list()
         # Index based access
         third_element = edges[2]
@@ -721,10 +721,10 @@ custom_vec_iter_impl!(
 
     For example::
 
-        import rustworkx
+        import rustworkx as rx
 
-        graph = rustworkx.generators.directed_path_graph(5)
-        edges = rustworkx.edge_indices()
+        graph = rx.generators.directed_path_graph(5)
+        edges = rx.edge_indices()
         # Index based access
         third_element = edges[2]
         # Use as iterator
@@ -773,10 +773,10 @@ custom_vec_iter_impl!(
 
     For example::
 
-        import rustworkx
+        import rustworkx as rx
 
-        graph = rustworkx.generators.hexagonal_lattice_graph(2, 2)
-        chains = rustworkx.chain_decomposition(graph)
+        graph = rx.generators.hexagonal_lattice_graph(2, 2)
+        chains = rx.chain_decomposition(graph)
         # Index based access
         third_chain = chains[2]
         # Use as iterator
@@ -1006,10 +1006,10 @@ impl PyGCProtocol for EdgeIndexMap {
 ///
 /// For example::
 ///
-///     import rustworkx
+///     import rustworkx as rx
 ///
-///     graph = rustworkx.generators.directed_path_graph(5)
-///     edges = rustworkx.dijkstra_shortest_paths(0)
+///     graph = rx.generators.directed_path_graph(5)
+///     edges = rx.dijkstra_shortest_paths(0)
 ///     # Target node access
 ///     third_element = edges[2]
 ///     # Use as iterator
@@ -1343,10 +1343,10 @@ custom_hash_map_iter_impl!(
 
     For example::
 
-        import rustworkx
+        import rustworkx as rx
 
-        graph = rustworkx.generators.directed_path_graph(5)
-        edges = rustworkx.dijkstra_shortest_path_lengths(0)
+        graph = rx.generators.directed_path_graph(5)
+        edges = rx.dijkstra_shortest_path_lengths(0)
         # Target node access
         third_element = edges[2]
         # Use as iterator
@@ -1428,10 +1428,10 @@ custom_hash_map_iter_impl!(
 
     For example::
 
-        import rustworkx
+        import rustworkx as rx
 
-        graph = rustworkx.generators.directed_path_graph(5)
-        edges = rustworkx.num_shortest_paths_unweighted(0)
+        graph = rx.generators.directed_path_graph(5)
+        edges = rx.num_shortest_paths_unweighted(0)
         # Target node access
         third_element = edges[2]
         # Use as iterator
@@ -1494,10 +1494,10 @@ custom_hash_map_iter_impl!(
 
     For example::
 
-        import rustworkx
+        import rustworkx as rx
 
-        graph = rustworkx.generators.directed_path_graph(5)
-        edges = rustworkx.all_pairs_dijkstra_shortest_path_lengths(graph)
+        graph = rx.generators.directed_path_graph(5)
+        edges = rx.all_pairs_dijkstra_shortest_path_lengths(graph)
         # Target node access
         third_node_shortest_path_lengths = edges[2]
 
@@ -1530,10 +1530,10 @@ custom_hash_map_iter_impl!(
 
     For example::
 
-        import rustworkx
+        import rustworkx as rx
 
-        graph = rustworkx.generators.directed_path_graph(5)
-        edges = rustworkx.all_pairs_dijkstra_shortest_paths(graph)
+        graph = rx.generators.directed_path_graph(5)
+        edges = rx.all_pairs_dijkstra_shortest_paths(graph)
         # Target node access
         third_node_shortest_paths = edges[2]
 

--- a/src/toposort.rs
+++ b/src/toposort.rs
@@ -43,10 +43,10 @@ enum NodeState {
 ///
 /// .. jupyter-execute::
 ///
-///   import rustworkx
+///   import rustworkx as rx
 ///
-///   graph = rustworkx.generators.directed_path_graph(5)
-///   sorter = rustworkx.TopologicalSorter(graph)
+///   graph = rx.generators.directed_path_graph(5)
+///   sorter = rx.TopologicalSorter(graph)
 ///   while sorter.is_active():
 ///       nodes = sorter.get_ready()
 ///       print(nodes)

--- a/src/traversal/mod.rs
+++ b/src/traversal/mod.rs
@@ -256,7 +256,7 @@ pub fn descendants(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
 ///
 /// .. jupyter-execute::
 ///
-///        import rustworkx
+///        import rustworkx as rx
 ///        from rustworkx.visit import BFSVisitor
 ///   
 ///        class TreeEdgesRecorder(BFSVisitor):
@@ -267,10 +267,10 @@ pub fn descendants(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
 ///            def tree_edge(self, edge):
 ///                self.edges.append(edge)
 ///
-///        graph = rustworkx.PyDiGraph()
+///        graph = rx.PyDiGraph()
 ///        graph.extend_from_edge_list([(1, 3), (0, 1), (2, 1), (0, 2)])
 ///        vis = TreeEdgesRecorder()
-///        rustworkx.bfs_search(graph, [0], vis)
+///        rx.bfs_search(graph, [0], vis)
 ///        print('Tree edges:', vis.edges)
 ///
 /// .. note::
@@ -342,7 +342,7 @@ pub fn digraph_bfs_search(
 ///
 /// .. jupyter-execute::
 ///
-///        import rustworkx
+///        import rustworkx as rx
 ///        from rustworkx.visit import BFSVisitor
 ///   
 ///        class TreeEdgesRecorder(BFSVisitor):
@@ -353,10 +353,10 @@ pub fn digraph_bfs_search(
 ///            def tree_edge(self, edge):
 ///                self.edges.append(edge)
 ///
-///        graph = rustworkx.PyGraph()
+///        graph = rx.PyGraph()
 ///        graph.extend_from_edge_list([(1, 3), (0, 1), (2, 1), (0, 2)])
 ///        vis = TreeEdgesRecorder()
-///        rustworkx.bfs_search(graph, [0], vis)
+///        rx.bfs_search(graph, [0], vis)
 ///        print('Tree edges:', vis.edges)
 ///
 /// .. note::
@@ -426,7 +426,7 @@ pub fn graph_bfs_search(
 ///
 /// .. jupyter-execute::
 ///
-///        import rustworkx
+///        import rustworkx as rx
 ///        from rustworkx.visit import DFSVisitor
 ///   
 ///        class TreeEdgesRecorder(DFSVisitor):
@@ -437,10 +437,10 @@ pub fn graph_bfs_search(
 ///            def tree_edge(self, edge):
 ///                self.edges.append(edge)
 ///
-///        graph = rustworkx.PyGraph()
+///        graph = rx.PyGraph()
 ///        graph.extend_from_edge_list([(1, 3), (0, 1), (2, 1), (0, 2)])
 ///        vis = TreeEdgesRecorder()
-///        rustworkx.dfs_search(graph, [0], vis)
+///        rx.dfs_search(graph, [0], vis)
 ///        print('Tree edges:', vis.edges)
 ///
 /// .. note::
@@ -510,7 +510,7 @@ pub fn digraph_dfs_search(
 ///
 /// .. jupyter-execute::
 ///
-///        import rustworkx
+///        import rustworkx as rx
 ///        from rustworkx.visit import DFSVisitor
 ///   
 ///        class TreeEdgesRecorder(DFSVisitor):
@@ -521,10 +521,10 @@ pub fn digraph_dfs_search(
 ///            def tree_edge(self, edge):
 ///                self.edges.append(edge)
 ///
-///        graph = rustworkx.PyGraph()
+///        graph = rx.PyGraph()
 ///        graph.extend_from_edge_list([(1, 3), (0, 1), (2, 1), (0, 2)])
 ///        vis = TreeEdgesRecorder()
-///        rustworkx.dfs_search(graph, [0], vis)
+///        rx.dfs_search(graph, [0], vis)
 ///        print('Tree edges:', vis.edges)
 ///
 /// .. note::


### PR DESCRIPTION
This commit improves some of the introductory material for the rustworkx
documentation. The introductory guides for rustworkx were a bit lacking,
partially because it inherited the basic install guide from the readme
and also because the introduction tutorial didn't cover the very
beginning of what rustworkx is or how to use it. This commit addresses
this by adding a dedicated install/getting started page which includes
a platform support table and adding a couple sections to the
introduction tutorial to cover basic installation and importing.
Additionally, the imports in the documentation are standardized on
aliasing rustworkx as rx.

This commit superscedes #559 which added the platform support table to
the readme.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
