### PR TITLE
Fix cargo clippy failures from Rust 1.63

### DIFF
--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -10,6 +10,8 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
+#![allow(clippy::borrow_deref_ref)]
+
 use std::cmp;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -10,6 +10,8 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
+#![allow(clippy::borrow_deref_ref)]
+
 use std::cmp;
 use std::collections::BTreeMap;
 use std::fs::File;

--- a/src/graphml.rs
+++ b/src/graphml.rs
@@ -10,6 +10,8 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
+#![allow(clippy::borrow_deref_ref)]
+
 use std::convert::From;
 use std::io::BufRead;
 use std::iter::FromIterator;
@@ -477,12 +479,10 @@ impl GraphML {
                 self.key_for_all.insert(id, key);
                 Ok(Domain::All)
             }
-            _ => {
-                return Err(Error::InvalidDoc(format!(
-                    "Invalid 'for' attribute in key with id={}.",
-                    id,
-                )));
-            }
+            _ => Err(Error::InvalidDoc(format!(
+                "Invalid 'for' attribute in key with id={}.",
+                id,
+            ))),
         }
     }
 


### PR DESCRIPTION
In the recently released Rust 1.63 clippy added some new rules and also
improved detection on other rules. The new borrow_deref_ref rule is
being triggered by PyO3 macros and we need to wait for PyO3 0.17 to be
released to fix these errors.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
