### PR TITLE
Push docs to both retworkx and rustworkx domains

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -35,5 +35,7 @@ STABLE_VERSION=${VERSION[0]}.${VERSION[1]}
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to website"
 rclone sync --progress --exclude-from ./tools/other-builds.txt ./docs/build/html IBMCOS:qiskit-org-web-resources/documentation/retworkx
+rclone sync --progress --exclude-from ./tools/other-builds.txt ./docs/build/html IBMCOS:qiskit-org-web-resources/documentation/rustworkx
 echo "Pushing built docs to stable site"
 rclone sync --progress ./docs/build/html IBMCOS:qiskit-org-web-resources/documentation/retworkx/stable/"$STABLE_VERSION"
+rclone sync --progress ./docs/build/html IBMCOS:qiskit-org-web-resources/documentation/rustworkx/stable/"$STABLE_VERSION"

--- a/tools/deploy_documentation_dev.sh
+++ b/tools/deploy_documentation_dev.sh
@@ -30,3 +30,4 @@ pwd
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to website"
 rclone sync --progress ./docs/build/html IBMCOS:qiskit-org-web-resources/documentation/retworkx/dev
+rclone sync --progress ./docs/build/html IBMCOS:qiskit-org-web-resources/documentation/rustworkx/dev


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Fixes #664 

Pushes the documentation to both [https://qiskit.org/documentation/rustworkx](https://qiskit.org/documentation/rustworkx) and [https://qiskit.org/documentation/retworkx](https://qiskit.org/documentation/retworkx)