### PR TITLE
Temporarily link to dev rustworkx documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![arXiv](https://img.shields.io/badge/arXiv-2110.15221-b31b1b.svg)](https://arxiv.org/abs/2110.15221)
 
   - You can see the full rendered docs at:
-    <https://qiskit.org/documentation/rustworkx>
+    <https://qiskit.org/documentation/rustworkx/dev>
 
 |:warning:| The retworkx project has been renamed to **rustworkx**. The use of the
 retworkx package will still work for the time being but starting in the 1.0.0


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Closes #674, Related to #670

We link to the `dev` documentation until the release. We haven't released under the new name yet but I do understand people want a clickable documentation link