### PR TITLE
Fix visualization failure with matplotlib 3.6.0

### DIFF
--- a/docs/source/tutorial/betweenness_centrality.rst
+++ b/docs/source/tutorial/betweenness_centrality.rst
@@ -81,7 +81,7 @@ centrality:
         vmin=min(centrality.values()),
         vmax=max(centrality.values())
     ))
-    plt.colorbar(sm)
+    plt.colorbar(sm, ax=ax)
     plt.title("Betweenness Centrality of a 4 x 4 Hexagonal Lattice Graph")
     mpl_draw(graph, node_color=colors, ax=ax)
 

--- a/rustworkx/visualization/matplotlib.py
+++ b/rustworkx/visualization/matplotlib.py
@@ -209,10 +209,10 @@ def mpl_draw(graph, pos=None, ax=None, arrows=True, with_labels=False, **kwds):
         cf = ax.get_figure()
     cf.set_facecolor("w")
     if ax is None:
-        if cf._axstack() is None:
-            ax = cf.add_axes((0, 0, 1, 1))
-        else:
+        if cf.axes:
             ax = cf.gca()
+        else:
+            ax = cf.add_axes((0, 0, 1, 1))
 
     draw_graph(graph, pos=pos, ax=ax, arrows=arrows, with_labels=with_labels, **kwds)
     ax.set_axis_off()


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Fixes #680 
Port of https://github.com/networkx/networkx/pull/5937

Avoids `TypeError: '_AxesStack' object is not callable` when calling `mpl_draw` in a graph object
