### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         rust: [stable]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
         platform: [
           { os: "macOS-latest", python-architecture: "x64", rust-target: "x86_64-apple-darwin" },
           { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" },

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@
 name: CI Jobs
 on:
   push:
-    branches: [ 'stable/*' ]
+    branches: [ main, 'stable/*' ]
   pull_request:
-    branches: [ 'stable/*' ]
+    branches: [ main, 'stable/*' ]
 concurrency:
   group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
   cancel-in-progress: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         rust: [stable]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11.0-rc.2"]
         platform: [
           { os: "macOS-latest", python-architecture: "x64", rust-target: "x86_64-apple-darwin" },
           { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" },

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@
 name: CI Jobs
 on:
   push:
-    branches: [ main, 'stable/*' ]
+    branches: [ 'stable/*' ]
   pull_request:
-    branches: [ main, 'stable/*' ]
+    branches: [ 'stable/*' ]
 concurrency:
   group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
   cancel-in-progress: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,32 +1,9 @@
 ---
 name: Wheel Builds
 on:
-  push:
-    tags:
-      - '*'
+  pull_request:
+    branches: [ main, 'stable/*' ]
 jobs:
-  sdist:
-    name: Build sdist
-    runs-on: ubuntu-latest
-    needs: ["build_wheels", "build-win32-wheels"]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.7'
-      - name: Install deps
-        run: pip install -U twine setuptools-rust
-      - name: Build sdist
-        run: python setup.py sdist
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./dist/*
-      - name: Upload to PyPI
-        run: twine upload ./dist/*
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -62,11 +39,6 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   build_wheels_aarch64:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -107,11 +79,6 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   build_wheels_ppc64le:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -152,11 +119,6 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   build_wheels_ppc64le_part2:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -197,11 +159,6 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   build_wheels_s390x:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -242,11 +199,6 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   build_wheels_s390x_part2:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -287,11 +239,6 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   build-mac-arm-wheels:
     name: Build wheels on macos for arm and universal2
     runs-on: macos-10.15
@@ -314,11 +261,6 @@ jobs:
       - name: Install twine
         run: |
           python -m pip install twine
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   build-win32-wheels:
     name: Build wheels on win32
     runs-on: windows-latest
@@ -351,8 +293,3 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -35,7 +35,7 @@ jobs:
           CIBW_SKIP: cp36-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
-          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
+          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
@@ -74,7 +74,7 @@ jobs:
           CIBW_SKIP: cp36-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
-          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
+          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
           CIBW_ARCHS_LINUX: aarch64
       - uses: actions/upload-artifact@v2
         with:
@@ -114,7 +114,7 @@ jobs:
           CIBW_SKIP: cp36-* cp39-* cp310-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
-          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
+          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
           CIBW_ARCHS_LINUX: ppc64le
       - uses: actions/upload-artifact@v2
         with:
@@ -154,7 +154,7 @@ jobs:
           CIBW_SKIP: cp36-* cp37-* cp38-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
-          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
+          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
           CIBW_ARCHS_LINUX: ppc64le
       - uses: actions/upload-artifact@v2
         with:
@@ -194,7 +194,7 @@ jobs:
           CIBW_SKIP: cp36-* cp39-* cp310-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
-          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
+          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
           CIBW_ARCHS_LINUX: s390x
       - uses: actions/upload-artifact@v2
         with:
@@ -234,7 +234,7 @@ jobs:
           CIBW_SKIP: cp36-* cp37-* cp38-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
-          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
+          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
           CIBW_ARCHS_LINUX: s390x
       - uses: actions/upload-artifact@v2
         with:
@@ -289,7 +289,7 @@ jobs:
           CIBW_SKIP: cp36-* pp* *amd64 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
-          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
+          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,9 +1,32 @@
 ---
 name: Wheel Builds
 on:
-  pull_request:
-    branches: [ main, 'stable/*' ]
+  push:
+    tags:
+      - '*'
 jobs:
+  sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    needs: ["build_wheels", "build-win32-wheels"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+      - name: Install deps
+        run: pip install -U twine setuptools-rust
+      - name: Build sdist
+        run: python setup.py sdist
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./dist/*
+      - name: Upload to PyPI
+        run: twine upload ./dist/*
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -39,6 +62,11 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build_wheels_aarch64:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -79,6 +107,11 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build_wheels_ppc64le:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -119,6 +152,11 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build_wheels_ppc64le_part2:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -159,6 +197,11 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build_wheels_s390x:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -199,6 +242,11 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build_wheels_s390x_part2:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -239,6 +287,11 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build-mac-arm-wheels:
     name: Build wheels on macos for arm and universal2
     runs-on: macos-10.15
@@ -261,6 +314,11 @@ jobs:
       - name: Install twine
         run: |
           python -m pip install twine
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build-win32-wheels:
     name: Build wheels on win32
     runs-on: windows-latest
@@ -293,3 +351,8 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -45,7 +45,7 @@ jobs:
           toolchain: stable
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.1.2 twine
+          python -m pip install cibuildwheel==2.10.1 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -55,7 +55,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64:latest
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
-          CIBW_SKIP: cp36-* pp* *win32
+          CIBW_SKIP: cp36-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
@@ -89,7 +89,7 @@ jobs:
           platforms: all
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.1.2 twine
+          python -m pip install cibuildwheel==2.10.1 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -99,7 +99,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64:latest
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
-          CIBW_SKIP: cp36-* pp* *win32
+          CIBW_SKIP: cp36-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
@@ -134,7 +134,7 @@ jobs:
           platforms: all
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.1.2 twine
+          python -m pip install cibuildwheel==2.10.1 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -144,7 +144,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64:latest
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
-          CIBW_SKIP: cp36-* cp39-* cp310-* pp* *win32
+          CIBW_SKIP: cp36-* cp39-* cp310-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
@@ -179,7 +179,7 @@ jobs:
           platforms: all
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.1.2 twine
+          python -m pip install cibuildwheel==2.10.1 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -189,7 +189,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64:latest
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
-          CIBW_SKIP: cp36-* cp37-* cp38-* pp* *win32
+          CIBW_SKIP: cp36-* cp37-* cp38-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
@@ -224,7 +224,7 @@ jobs:
           platforms: all
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.1.2 twine
+          python -m pip install cibuildwheel==2.10.1 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -234,7 +234,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64:latest
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
-          CIBW_SKIP: cp36-* cp39-* cp310-* pp* *win32
+          CIBW_SKIP: cp36-* cp39-* cp310-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
@@ -269,7 +269,7 @@ jobs:
           platforms: all
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.1.2 twine
+          python -m pip install cibuildwheel==2.10.1 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -279,7 +279,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64:latest
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
-          CIBW_SKIP: cp36-* cp37-* cp38-* pp* *win32
+          CIBW_SKIP: cp36-* cp37-* cp38-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests
@@ -298,7 +298,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build wheels
-        uses: joerick/cibuildwheel@v2.0.1
+        uses: joerick/cibuildwheel@v2.10.1
         env:
           CIBW_BEFORE_ALL: rustup target add aarch64-apple-darwin
           CIBW_ARCHS_MACOS: arm64 universal2
@@ -338,13 +338,13 @@ jobs:
         run: rustup default stable-i686-pc-windows-msvc
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.1.2 twine
+          python -m pip install cibuildwheel==2.10.1 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
-          CIBW_SKIP: cp36-* pp* *amd64
+          CIBW_SKIP: cp36-* pp* *amd64 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,8 +30,8 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: "yum install -y wget && {package}/tools/install_rust.sh"
           CIBW_ENVIRONMENT_LINUX: 'PATH="$PATH:$HOME/.cargo/bin"'
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64:latest
-          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
+          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
           CIBW_SKIP: cp36-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
@@ -69,8 +69,8 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: "yum install -y wget && {package}/tools/install_rust.sh"
           CIBW_ENVIRONMENT_LINUX: 'PATH="$PATH:$HOME/.cargo/bin"'
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64:latest
-          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
+          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
           CIBW_SKIP: cp36-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
@@ -109,8 +109,8 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: "yum install -y wget && {package}/tools/install_rust.sh"
           CIBW_ENVIRONMENT_LINUX: 'PATH="$PATH:$HOME/.cargo/bin"'
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64:latest
-          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
+          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
           CIBW_SKIP: cp36-* cp39-* cp310-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
@@ -149,8 +149,8 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: "yum install -y wget && {package}/tools/install_rust.sh"
           CIBW_ENVIRONMENT_LINUX: 'PATH="$PATH:$HOME/.cargo/bin"'
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64:latest
-          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
+          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
           CIBW_SKIP: cp36-* cp37-* cp38-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
@@ -189,8 +189,8 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: "yum install -y wget && {package}/tools/install_rust.sh"
           CIBW_ENVIRONMENT_LINUX: 'PATH="$PATH:$HOME/.cargo/bin"'
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64:latest
-          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
+          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
           CIBW_SKIP: cp36-* cp39-* cp310-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
@@ -229,8 +229,8 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: "yum install -y wget && {package}/tools/install_rust.sh"
           CIBW_ENVIRONMENT_LINUX: 'PATH="$PATH:$HOME/.cargo/bin"'
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2010_x86_64:latest
-          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2010_i686:latest
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
+          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
           CIBW_SKIP: cp36-* cp37-* cp38-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -71,11 +71,11 @@ source.
    * - Linux
      - x86_64
      - :ref:`tier-1`
-     - Distributions compatible with the [manylinux 2010](https://peps.python.org/pep-0571/) packaging specification
+     - Distributions compatible with the [manylinux 2014](https://peps.python.org/pep-0599/) packaging specification
    * - Linux
      - i686 
      - :ref:`tier-2` (Python < 3.10), :ref:`tier-3` (Python >= 3.10)
-     - Distributions compatible with the [manylinux 2010](https://peps.python.org/pep-0571/) packaging specification
+     - Distributions compatible with the [manylinux 2014](https://peps.python.org/pep-0599/) packaging specification
    * - Linux
      - aarch64
      - :ref:`tier-2`

--- a/releasenotes/notes/manylinux2010-last-release-b649d25612cb80b8.yaml
+++ b/releasenotes/notes/manylinux2010-last-release-b649d25612cb80b8.yaml
@@ -1,11 +1,14 @@
 ---
 upgrade:
   - |
-    This release 0.12.0 is the last release that will provide binaries that
-    support the `manylinux2010 <https://peps.python.org/pep-0571/>`__ packaging
-    specification. Starting in Rustworkx 0.13.0 all the precompiled binaries
-    will be built against manylinux2014. This change is required due to
-    changes in the GLIBC versions supported by the Rust compiler. If you need
-    to run Rustworkx on a platform only compatible with manylinux2010 for
-    future releases you will need to build from source and also use a
-    Rust compiler with a version < 1.64.0.
+    This release no longer provides binaries that support the
+    `manylinux2010 <https://peps.python.org/pep-0571/>`__ packaging specification.
+    All the precompiled binaries for Linux platforms are built against
+    `manylinux2014 <https://peps.python.org/pep-0599/>`__. This change is required
+    due to changes in the GLIBC versions supported by the latest versions of the
+    Rust compiler in addition to the manylinux2010 platform no longer being
+    supported. If you need to run Rustworkx on a platform only compatible with
+    manylinux2010 starting with this release you will need to build and install
+    from source (which includes the sdist published to PyPI, so
+    `pip install rustworkx` will continue to work assuming you have a Rust compiler
+    installed) and also use a Rust compiler with a version < 1.64.0.

--- a/releasenotes/notes/manylinux2010-last-release-b649d25612cb80b8.yaml
+++ b/releasenotes/notes/manylinux2010-last-release-b649d25612cb80b8.yaml
@@ -1,0 +1,11 @@
+---
+upgrade:
+  - |
+    This release 0.12.0 is the last release that will provide binaries that
+    support the `manylinux2010 <https://peps.python.org/pep-0571/>`__ packaging
+    specification. Starting in Rustworkx 0.13.0 all the precompiled binaries
+    will be built against manylinux2014. This change is required due to
+    changes in the GLIBC versions supported by the Rust compiler. If you need
+    to run Rustworkx on a platform only compatible with manylinux2010 for
+    future releases you will need to build from source and also use a
+    Rust compiler with a version < 1.64.0.

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX :: Linux",

--- a/tools/install_rust.sh
+++ b/tools/install_rust.sh
@@ -1,5 +1,5 @@
 if [ ! -d rust-installer ]; then
     mkdir rust-installer
     wget https://sh.rustup.rs -O rust-installer/rustup.sh
-    sh rust-installer/rustup.sh -y --default-toolchain 1.63
+    sh rust-installer/rustup.sh -y
 fi

--- a/tools/install_rust.sh
+++ b/tools/install_rust.sh
@@ -1,5 +1,5 @@
 if [ ! -d rust-installer ]; then
     mkdir rust-installer
     wget https://sh.rustup.rs -O rust-installer/rustup.sh
-    sh rust-installer/rustup.sh -y
+    sh rust-installer/rustup.sh -y --default-toolchain 1.63
 fi


### PR DESCRIPTION
For the upcoming 0.12.0 release it would be good to add support for python 3.11. While this hasn't been released yet it's currently a release candidate with a frozen C API. We're likely to release rustworkx 0.12.0 prior to the Python 3.11 release. In order to avoid having to have rustworkx be a blocker for any downstream packages looking to adopt 3.11 this commit proactively enables support for testing and building with Python 3.11 off the latest rc in order to ensure we're building binaries compatible with 3.11 for the 0.12.0 release.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
