### PR TITLE
Add index_output option to layers() function

### DIFF
--- a/releasenotes/notes/add-index_output-dag-layers-d8329db4a1f76410.yaml
+++ b/releasenotes/notes/add-index_output-dag-layers-d8329db4a1f76410.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Added a new keyword arguments, ``index_output``, to the :func:`~.layers`
+    function. When set to ``True`` the output of the function is a list of
+    layers as node indices. The default output is still a list of layers of
+    node data payloads as before.

--- a/src/dag_algo/mod.rs
+++ b/src/dag_algo/mod.rs
@@ -215,14 +215,23 @@ pub fn is_directed_acyclic_graph(graph: &digraph::PyDiGraph) -> bool {
 /// :param PyDiGraph graph: The DAG to get the layers from
 /// :param list first_layer: A list of node ids for the first layer. This
 ///     will be the first layer in the output
+/// :param bool index_output: When set to to ``True`` the output layers will be
+///     a list of integer node indices.
 ///
-/// :returns: A list of layers, each layer is a list of node data
+/// :returns: A list of layers, each layer is a list of node data, or if
+/// ``index_output`` is ``True`` each layer is a list of node indices.
 /// :rtype: list
 ///
 /// :raises InvalidNode: If a node index in ``first_layer`` is not in the graph
-#[pyfunction]
-#[pyo3(text_signature = "(dag, first_layer, /)")]
-pub fn layers(py: Python, dag: &digraph::PyDiGraph, first_layer: Vec<usize>) -> PyResult<PyObject> {
+#[pyfunction(index_output = "false")]
+#[pyo3(text_signature = "(dag, first_layer, /, index_output=False)")]
+pub fn layers(
+    py: Python,
+    dag: &digraph::PyDiGraph,
+    first_layer: Vec<usize>,
+    index_output: bool,
+) -> PyResult<PyObject> {
+    let mut output_indices: Vec<Vec<usize>> = Vec::new();
     let mut output: Vec<Vec<&PyObject>> = Vec::new();
     // Convert usize to NodeIndex
     let mut first_layer_index: Vec<NodeIndex> = Vec::new();
@@ -235,19 +244,31 @@ pub fn layers(py: Python, dag: &digraph::PyDiGraph, first_layer: Vec<usize>) -> 
     let mut predecessor_count: HashMap<NodeIndex, usize> = HashMap::new();
 
     let mut layer_node_data: Vec<&PyObject> = Vec::new();
-    for layer_node in &cur_layer {
-        let node_data = match dag.graph.node_weight(*layer_node) {
-            Some(data) => data,
-            None => {
+    if !index_output {
+        for layer_node in &cur_layer {
+            let node_data = match dag.graph.node_weight(*layer_node) {
+                Some(data) => data,
+                None => {
+                    return Err(InvalidNode::new_err(format!(
+                        "An index input in 'first_layer' {} is not a valid node index in the graph",
+                        layer_node.index()
+                    )))
+                }
+            };
+            layer_node_data.push(node_data);
+        }
+        output.push(layer_node_data);
+    } else {
+        for layer_node in &cur_layer {
+            if !dag.graph.contains_node(*layer_node) {
                 return Err(InvalidNode::new_err(format!(
                     "An index input in 'first_layer' {} is not a valid node index in the graph",
                     layer_node.index()
-                )))
+                )));
             }
-        };
-        layer_node_data.push(node_data);
+        }
+        output_indices.push(cur_layer.iter().map(|x| x.index()).collect());
     }
-    output.push(layer_node_data);
 
     // Iterate until there are no more
     while !cur_layer.is_empty() {
@@ -281,17 +302,26 @@ pub fn layers(py: Python, dag: &digraph::PyDiGraph, first_layer: Vec<usize>) -> 
                 }
             }
         }
-        let mut layer_node_data: Vec<&PyObject> = Vec::new();
-        for layer_node in &next_layer {
-            layer_node_data.push(&dag.graph[*layer_node]);
-        }
-        if !layer_node_data.is_empty() {
-            output.push(layer_node_data);
+        if !index_output {
+            let mut layer_node_data: Vec<&PyObject> = Vec::new();
+
+            for layer_node in &next_layer {
+                layer_node_data.push(&dag.graph[*layer_node]);
+            }
+            if !layer_node_data.is_empty() {
+                output.push(layer_node_data);
+            }
+        } else if !next_layer.is_empty() {
+            output_indices.push(next_layer.iter().map(|x| x.index()).collect());
         }
         cur_layer = next_layer;
         next_layer = Vec::new();
     }
-    Ok(PyList::new(py, output).into())
+    if !index_output {
+        Ok(PyList::new(py, output).into())
+    } else {
+        Ok(PyList::new(py, output_indices).into())
+    }
 }
 
 /// Get the lexicographical topological sorted nodes from the provided DAG

--- a/src/dag_algo/mod.rs
+++ b/src/dag_algo/mod.rs
@@ -219,7 +219,7 @@ pub fn is_directed_acyclic_graph(graph: &digraph::PyDiGraph) -> bool {
 ///     a list of integer node indices.
 ///
 /// :returns: A list of layers, each layer is a list of node data, or if
-/// ``index_output`` is ``True`` each layer is a list of node indices.
+///     ``index_output`` is ``True`` each layer is a list of node indices.
 /// :rtype: list
 ///
 /// :raises InvalidNode: If a node index in ``first_layer`` is not in the graph

--- a/tests/rustworkx_tests/digraph/test_layers.py
+++ b/tests/rustworkx_tests/digraph/test_layers.py
@@ -63,3 +63,51 @@ class TestLayers(unittest.TestCase):
         dag = rustworkx.PyDAG()
         with self.assertRaises(rustworkx.InvalidNode):
             rustworkx.layers(dag, [42])
+
+    def test_dagcircuit_basic_index_output(self):
+        dag = rustworkx.PyDAG()
+        qr_0_in = dag.add_node("qr[0]")
+        qr_0_out = dag.add_node("qr[0]")
+        qr_1_in = dag.add_node("qr[1]")
+        qr_1_out = dag.add_node("qr[1]")
+        cr_0_in = dag.add_node("cr[0]")
+        cr_0_out = dag.add_node("cr[0]")
+        cr_1_in = dag.add_node("cr[1]")
+        cr_1_out = dag.add_node("cr[1]")
+        input_nodes = [qr_0_in, qr_1_in, cr_0_in, cr_1_in]
+
+        h_gate = dag.add_child(qr_0_in, "h", "qr[0]")
+        cx_gate = dag.add_child(h_gate, "cx", "qr[0]")
+        dag.add_edge(qr_1_in, cx_gate, "qr[1]")
+        measure_qr_1 = dag.add_child(cx_gate, "measure", "qr[1]")
+        dag.add_edge(cr_1_in, measure_qr_1, "cr[1]")
+        x_gate = dag.add_child(measure_qr_1, "x", "qr[1]")
+        dag.add_edge(measure_qr_1, x_gate, "cr[1]")
+        dag.add_edge(cr_0_in, x_gate, "cr[0]")
+
+        measure_qr_0 = dag.add_child(cx_gate, "measure", "qr[0]")
+        dag.add_edge(measure_qr_0, qr_0_out, "qr[0]")
+        dag.add_edge(measure_qr_0, cr_0_out, "cr[0]")
+        dag.add_edge(x_gate, measure_qr_0, "cr[0]")
+
+        measure_qr_1_out = dag.add_child(x_gate, "measure", "cr[1]")
+        dag.add_edge(x_gate, measure_qr_1_out, "qr[1]")
+        dag.add_edge(measure_qr_1_out, qr_1_out, "qr[1]")
+        dag.add_edge(measure_qr_1_out, cr_1_out, "cr[1]")
+
+        res = rustworkx.layers(dag, input_nodes, index_output=True)
+        expected = [
+            [qr_0_in, qr_1_in, cr_0_in, cr_1_in],
+            [h_gate],
+            [cx_gate],
+            [measure_qr_1],
+            [x_gate],
+            [measure_qr_1_out, measure_qr_0],
+            [cr_1_out, qr_1_out, cr_0_out, qr_0_out],
+        ]
+        self.assertEqual(expected, res)
+
+    def test_first_layer_invalid_node_index_output(self):
+        dag = rustworkx.PyDAG()
+        with self.assertRaises(rustworkx.InvalidNode):
+            rustworkx.layers(dag, [42], index_output=True)


### PR DESCRIPTION
This commit adds a new keyword argument, index_output, to the layers() function which is used to return a list of list of node indices representing the layers in the DAG instead of a list of list of node data payloads. The default output does not change, but for users that prefer to work with indices (which is probably a more natural return format for the function) this option allows them to work with indices.

Closes #646

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
