### PR TITLE
Pin importlib-metadata in CI

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,2 @@
 decorator==4.4.2
+importlib-metadata==4.13.0;python_version<'3.8'


### PR DESCRIPTION
The recent release of importlib-metadata broke compatibility with stevedore on Python 3.7. Stevedore is a dependency of a dependency of stestr which we use for running tests in CI so this is blocking CI from working and tests from running locally with Python 3.7. This commit pins the importlib-metadata version in CI to unblock things.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
