### PR TITLE
Bump version numbers after 0.12.0 release

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -356,27 +356,27 @@ jobs:
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
           TWINE_USERNAME: retworkx-ci
-    retworkx-compat-build:
-      name: Build retworkx
-      runs-on: ubuntu-latest
-      needs: ["build_wheels", "build-win32-wheels"]
-      steps:
-        - uses: actions/checkout@v2
-        - uses: actions/setup-python@v2
-          name: Install Python
-          with:
-            python-version: '3.7'
-        - name: Install deps
-          run: pip install -U twine setuptools-rust
-        - name: Build sdist
-          run: python setup.py sdist bdist_wheel
-          env:
-            RUSTWORKX_PKG_NAME: retworkx
-        - uses: actions/upload-artifact@v2
-          with:
-            path: ./dist/*
-        - name: Upload to PyPI
-          run: twine upload ./dist/*
-          env:
-            TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-            TWINE_USERNAME: retworkx-ci
+  retworkx-compat-build:
+    name: Build retworkx
+    runs-on: ubuntu-latest
+    needs: ["build_wheels", "build-win32-wheels"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+      - name: Install deps
+        run: pip install -U twine setuptools-rust
+      - name: Build sdist
+        run: python setup.py sdist bdist_wheel
+        env:
+          RUSTWORKX_PKG_NAME: retworkx
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./dist/*
+      - name: Upload to PyPI
+        run: twine upload ./dist/*
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -33,4 +33,4 @@ pull_request_rules:
     actions:
       backport:
         branches:
-          - stable/0.11
+          - stable/0.12

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "rustworkx"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "fixedbitset",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "rustworkx-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "fixedbitset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustworkx"
 description = "A python graph library implemented in Rust"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Matthew Treinish <mtreinish@kortar.org>"]
 license = "Apache-2.0"
 readme = "README.md"
@@ -32,7 +32,7 @@ num-complex = "0.4"
 quick-xml = "0.22.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rustworkx-core = { path = "rustworkx-core", version = "=0.12.0" }
+rustworkx-core = { path = "rustworkx-core", version = "=0.13.0" }
 
 [dependencies.pyo3]
 version = "0.16.6"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,9 +24,9 @@ copyright = u'2021, rustworkx Contributors'
 
 
 # The short X.Y version.
-version = '0.12.0'
+version = '0.13.0'
 # The full version, including alpha/beta/rc tags.
-release = '0.12.0'
+release = '0.13.0'
 
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.autosummary',

--- a/rustworkx-core/Cargo.toml
+++ b/rustworkx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustworkx-core"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2018"
 authors = ["Matthew Treinish <mtreinish@kortar.org>"]
 description = "Rust APIs used for rustworkx algorithms"

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ README = readme()
 if PKG_NAME == "retworkx":
     README = retworkx_readme_compat + README
     PKG_PACKAGES = ["retworkx"]
-    PKG_INSTALL_REQUIRES.append(f"rustworkx>={PKG_VERSION}")
+    PKG_INSTALL_REQUIRES.append(f"rustworkx=={PKG_VERSION}")
     RUST_EXTENSIONS = []
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ mpl_extras = ['matplotlib>=3.0']
 graphviz_extras = ['pillow>=5.4']
 
 PKG_NAME = os.getenv('RUSTWORKX_PKG_NAME', "rustworkx")
-PKG_VERSION = "0.12.0"
+PKG_VERSION = "0.13.0"
 PKG_PACKAGES = ["rustworkx", "rustworkx.visualization"]
 PKG_INSTALL_REQUIRES = ['numpy>=1.16.0']
 RUST_EXTENSIONS = [RustExtension("rustworkx.rustworkx", "Cargo.toml",
@@ -41,7 +41,7 @@ README = readme()
 if PKG_NAME == "retworkx":
     README = retworkx_readme_compat + README
     PKG_PACKAGES = ["retworkx"]
-    PKG_INSTALL_REQUIRES.append(f"rustworkx=={PKG_VERSION}")
+    PKG_INSTALL_REQUIRES.append(f"rustworkx>={PKG_VERSION}")
     RUST_EXTENSIONS = []
 
 setup(


### PR DESCRIPTION
Now that the 0.12.0 release is out the door this commit bumps the version numbers to indicate that the main branch is now ahead of the 0.12.0 release. At the same time this commit fixes an indentation issue in the CI wheel publish jobs that we hit during the 0.12.0 release.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
