### PR TITLE
Add cargo publish job for rustworkx-core

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,6 +5,21 @@ on:
     tags:
       - '*'
 jobs:
+  rustworkx-core:
+    name: Publish rustworkx-core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run cargo publish
+        run: |
+          cd rustworkx-core
+          cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   sdist:
     name: Build sdist
     runs-on: ubuntu-latest


### PR DESCRIPTION
This commit adds a CI job to automatically publish rustworkx-core to crates.io on releases. In the past I have just manually run cargo publish locally but this is error prone and depends on me doing the correct thing. Having it run automatically in CI limits the chances of something going wrong.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
