### PR TITLE
Update PyO3 to 0.17.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,13 +271,15 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.16.2"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "383ae168529a39fc97cbc1d9d4fa865377731a519bc27553ed96f50594de7c45"
+checksum = "a462c1af5ba1fddec1488c4646993a23ae7931f9e170ccba23e9c7c834277797"
 dependencies = [
+ "ahash",
  "libc",
  "ndarray",
- "num-complex 0.4.1",
+ "num-complex 0.2.4",
+ "num-integer",
  "num-traits",
  "pyo3",
 ]
@@ -350,17 +352,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.16.6"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0220c44442c9b239dd4357aa856ac468a4f5e1f0df19ddb89b2522952eb4c6ca"
+checksum = "201b6887e5576bf2f945fe65172c1fcbf3fcf285b23e4d71eb171d9736e38d32"
 dependencies = [
  "cfg-if",
  "hashbrown",
  "indexmap",
  "indoc",
  "libc",
+ "memoffset",
  "num-bigint",
- "num-complex 0.4.1",
+ "num-complex 0.2.4",
  "parking_lot",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -370,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.16.6"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c819d397859445928609d0ec5afc2da5204e0d0f73d6bf9e153b04e83c9cdc2"
+checksum = "bf0708c9ed01692635cbf056e286008e5a2927ab1a5e48cdd3aeb1ba5a6fef47"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -380,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.16.6"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca882703ab55f54702d7bfe1189b41b0af10272389f04cae38fe4cd56c65f75f"
+checksum = "90352dea4f486932b72ddf776264d293f85b79a1d214de1d023927b41461132d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -390,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.16.6"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568749402955ad7be7bad9a09b8593851cd36e549ac90bfd44079cea500f3f21"
+checksum = "7eb24b804a2d9e88bfcc480a5a6dd76f006c1e3edaf064e8250423336e2cd79d"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -402,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.16.6"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611f64e82d98f447787e82b8e7b0ebc681e1eb78fc1252668b2c605ffb4e1eb8"
+checksum = "f22bb49f6a7348c253d7ac67a6875f2dc65f36c2ae64a82c381d528972bea6d6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 ahash = { version = "0.7.6", default-features = false }
 petgraph = "0.6.2"
 fixedbitset = "0.4.2"
-numpy = "0.16.2"
+numpy = "0.17.2"
 rand = "0.8"
 rand_pcg = "0.3"
 rayon = "1.5"
@@ -35,7 +35,7 @@ serde_json = "1.0"
 rustworkx-core = { path = "rustworkx-core", version = "=0.12.0" }
 
 [dependencies.pyo3]
-version = "0.16.6"
+version = "0.17.2"
 features = ["extension-module", "hashbrown", "num-bigint", "num-complex", "indexmap"]
 
 [dependencies.hashbrown]

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -34,7 +34,7 @@ use pyo3::PyTraverseError;
 use pyo3::Python;
 
 use ndarray::prelude::*;
-use num_complex::Complex64;
+use numpy::Complex64;
 use num_traits::Zero;
 use numpy::PyReadonlyArray2;
 

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -10,7 +10,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-#![allow(clippy::borrow_deref_ref)]
+#![allow(clippy::borrow_as_ptr)]
 
 use std::cmp;
 use std::cmp::Ordering;
@@ -34,8 +34,8 @@ use pyo3::PyTraverseError;
 use pyo3::Python;
 
 use ndarray::prelude::*;
-use numpy::Complex64;
 use num_traits::Zero;
+use numpy::Complex64;
 use numpy::PyReadonlyArray2;
 
 use petgraph::algo;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -31,7 +31,7 @@ use pyo3::PyTraverseError;
 use pyo3::Python;
 
 use ndarray::prelude::*;
-use num_complex::Complex64;
+use numpy::Complex64;
 use num_traits::Zero;
 use numpy::PyReadonlyArray2;
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -10,7 +10,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-#![allow(clippy::borrow_deref_ref)]
+#![allow(clippy::borrow_as_ptr)]
 
 use std::cmp;
 use std::collections::BTreeMap;
@@ -31,8 +31,8 @@ use pyo3::PyTraverseError;
 use pyo3::Python;
 
 use ndarray::prelude::*;
-use numpy::Complex64;
 use num_traits::Zero;
+use numpy::Complex64;
 use numpy::PyReadonlyArray2;
 
 use super::dot_utils::build_dot;

--- a/src/graphml.rs
+++ b/src/graphml.rs
@@ -10,7 +10,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-#![allow(clippy::borrow_deref_ref)]
+#![allow(clippy::borrow_as_ptr)]
 
 use std::convert::From;
 use std::io::BufRead;

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -295,7 +295,7 @@ where
 
 impl<K, V> PyEq<PyAny> for DictMap<K, V>
 where
-    for<'p> K: PyEq<K> + Clone + pyo3::ToBorrowedObject,
+    for<'p> K: PyEq<K> + Clone + pyo3::ToPyObject,
     for<'p> V: PyEq<PyAny>,
 {
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ use union::*;
 
 use hashbrown::HashMap;
 use indexmap::map::Entry::{Occupied, Vacant};
-use num_complex::Complex64;
+use numpy::Complex64;
 
 use pyo3::create_exception;
 use pyo3::exceptions::PyException;

--- a/src/score.rs
+++ b/src/score.rs
@@ -9,7 +9,6 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations
 // under the License.
-#![allow(clippy::derive_partial_eq_without_eq)]
 
 use std::cmp::Ordering;
 use std::ops::{Add, AddAssign};

--- a/src/score.rs
+++ b/src/score.rs
@@ -9,6 +9,7 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations
 // under the License.
+#![allow(clippy::derive_partial_eq_without_eq)]
 
 use std::cmp::Ordering;
 use std::ops::{Add, AddAssign};


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Bumps PyO3 and NumPy to 0.17.2

It has been a while since dependabot has sent us updates notifications for PyO3 and we missed a couple. But I think bumping to 0.17.2 should work fine given the Rust MSRV is still the same and we have released 0.12
