### PR TITLE
Switch from Python 3.11rc to official release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         rust: [stable]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11.0-rc.2"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
         platform: [
           { os: "macOS-latest", python-architecture: "x64", rust-target: "x86_64-apple-darwin" },
           { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" },

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,6 +13,9 @@ queue_rules:
       - check-success=python3.10-x64 windows-latest
       - check-success=python3.10-x64 ubuntu-latest
       - check-success=python3.10-x64 macOS-latest
+      - check-success=python3.11-x64 windows-latest
+      - check-success=python3.11-x64 ubuntu-latest
+      - check-success=python3.11-x64 macOS-latest
       - check-success=Build, rustfmt, and python lint
       - check-success=Coverage
       - check-success=Build Docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py36, py37, py38, py39, py310, lint
+envlist = py37, py38, py39, py310, py311, lint
 isolated_build = true
 
 [testenv]
@@ -20,11 +20,6 @@ passenv = RETWORKX_TEST_PRESERVE_IMAGES RUSTWORKX_PKG_NAME
 changedir = {toxinidir}/tests
 commands =
   stestr run {posargs}
-
-[testenv:py36]
-extras =
-  mpl
-  graphviz
 
 [testenv:py37]
 extras =


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Switches from the 3.11 Python release candidate to the official release.

Also, I profited to remove some references to Pytho 3.6 as we have already specified in the release notes that we will not support anymore.