### PR TITLE
Fix clippy error with new Rust 1.65 release

### DIFF
--- a/src/shortest_path/num_shortest_path.rs
+++ b/src/shortest_path/num_shortest_path.rs
@@ -35,7 +35,7 @@ pub fn num_shortest_paths_unweighted<Ty: EdgeType>(
             source
         )));
     }
-    let mut bfs = Bfs::new(&graph, node_index);
+    let mut bfs = Bfs::new(graph, node_index);
     let mut distance: Vec<Option<usize>> = vec![None; graph.node_bound()];
     distance[node_index.index()] = Some(0);
     out_map[source] = 1.to_biguint().unwrap();


### PR DESCRIPTION
Rust 1.65 was recently released which added some new clippy rules. This commit fixes the failure reported when running clippy with 1.65. This would have caused a CI failure as we start using the new rust version in CI.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
