### PR TITLE
🐛 Fix deprecated `Loader.load_module()`

### DIFF
--- a/retworkx/namespace.py
+++ b/retworkx/namespace.py
@@ -43,6 +43,12 @@ class RetworkxLoader(Loader):
     def module_repr(self, module):
         return repr(module)
 
+    def create_module(self, spec):
+        return self.load_module(spec.name)
+
+    def exec_module(self, module):
+        pass
+
     def load_module(self, fullname):
         old_name = fullname
         fullname = _new_namespace(fullname, self.old_namespace, self.new_package)


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Any package that imports `retworkx` (such as `qiskit-terra`) under `Python>=3.10` currently raises
```console
ImportWarning: RetworkxLoader.exec_module() not found; falling back to load_module()
```
Any system that uses `pytest` and sets the `filterwarnings` feature to `error` will fail loudly as a consequence of this (see, e.g., https://github.com/cda-tum/qcec/actions/runs/3394728729/jobs/5643660360#step:4:453).

`Loader.load_module()` has been deprecated since Python 3.4 (https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.load_module) and starting with 3.10, Python has started to actually raise the above `ImportWarning`.

This PR works around this issue by providing (rather straight-forward) implementations of the required `Loader.create_module()` and `Loader.exec_module()` methods. The fix is inspired by https://github.com/benjaminp/six/pull/343.
With this PR, `rustworkx` and, in turn, `qiskit` can be used without errors under `Python>=3.10`.

