### PR TITLE
Fix support of sequence protocol for returned lists

### DIFF
--- a/releasenotes/notes/fix-sequence-protocol-e95246e864cc850a.yaml
+++ b/releasenotes/notes/fix-sequence-protocol-e95246e864cc850a.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed an issue with the custom sequence return types,
+    :class:`~.BFSSuccessors`, :class:`~.NodeIndices`, :class:`~.EdgeList`,
+    :class:`~.WeightedEdgeList`, :class:`~.EdgeIndices`, and :class:`~.Chains`
+    where they previosuly were missing certain attributes that prevented them
+    being used as a sequence for certain built-in functions such as
+    ``reversed()``.
+    Fixed `#696 <https://github.com/Qiskit/rustworkx/issues/696>`__.

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -475,7 +475,7 @@ impl PyConvertToPyArray for Vec<(usize, usize, PyObject)> {
 macro_rules! custom_vec_iter_impl {
     ($name:ident, $data:ident, $T:ty, $doc:literal) => {
         #[doc = $doc]
-        #[pyclass(module = "rustworkx")]
+        #[pyclass(module = "rustworkx", sequence)]
         #[derive(Clone)]
         pub struct $name {
             pub $data: Vec<$T>,

--- a/tests/rustworkx_tests/test_custom_return_types.py
+++ b/tests/rustworkx_tests/test_custom_return_types.py
@@ -174,6 +174,12 @@ class TestNodeIndicesComparisons(unittest.TestCase):
         self.assertEqual([2, 3], slice_return)
         self.assertEqual([], indices[-1:-2])
 
+    def test_reversed(self):
+        indices = self.dag.node_indices()
+        reversed_slice = indices[::-1]
+        reversed_elems = list(reversed(indices))
+        self.assertEqual(reversed_slice, reversed_elems)
+
     def test_numpy_conversion(self):
         res = self.dag.node_indexes()
         np.testing.assert_array_equal(np.asarray(res, dtype=np.uintp), np.array([0, 1]))


### PR DESCRIPTION
Add the `sequence` option to PyO3's `pyclass`, so that the `sq_length` slot is implemented [1]. Implementing this method is required for sequence types, or Python C API functions like `PySequence_Size` will fail with an error.

The `reversed` built-in method relies on `PySequence_*` methods. A test reversing `NodeIndices` is added to guard against future violations of the sequence protocol.

Fixes #696.

[1]: https://github.com/PyO3/pyo3/pull/2567

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
