### PR TITLE
Fix compatibility with priority-queue 1.3.0

### DIFF
--- a/releasenotes/notes/fix-priority-queue-compat-48c22f64a9208812.yaml
+++ b/releasenotes/notes/fix-priority-queue-compat-48c22f64a9208812.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a compatibility issue when building ``rustworkx-core`` with
+    priority-queue 1.3.0.
+    Fixed `#744 <https://github.com/Qiskit/rustworkx/issues/744>`__

--- a/rustworkx-core/src/connectivity/min_cut.rs
+++ b/rustworkx-core/src/connectivity/min_cut.rs
@@ -55,7 +55,7 @@ where
         for edge in graph.edges(nx) {
             pq.change_priority_by(&edge.target(), |x| {
                 *x += edge_cost(edge);
-            })
+            });
         }
     }
 


### PR DESCRIPTION
In priority-queue 1.3.0 compilation of rustworkx-core's min_cut module will fail because of the lack of a semicolon on the change_priority_by() call. This wasn't an issue with priority-queue 1.2.0 and for rustworkx development we are using priority-queue 1.2.0 because the priority queue 1.3.0 requires a rust version newer than our msrv. However, adding a semicolon to fix this compilation issue is also still compatibile with priority-queue 1.2.0. This commit does that to fix compatibility with newer versions of rustworkx-core that want to leverage the latest version of priority queue where they don't have the same MSRV constraints as rustworkx.

Fixes #744

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
