### PR TITLE
Prepare 0.12.1 release

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -371,27 +371,27 @@ jobs:
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
           TWINE_USERNAME: retworkx-ci
-    retworkx-compat-build:
-      name: Build retworkx
-      runs-on: ubuntu-latest
-      needs: ["build_wheels", "build-win32-wheels"]
-      steps:
-        - uses: actions/checkout@v2
-        - uses: actions/setup-python@v2
-          name: Install Python
-          with:
-            python-version: '3.7'
-        - name: Install deps
-          run: pip install -U twine setuptools-rust
-        - name: Build sdist
-          run: python setup.py sdist bdist_wheel
-          env:
-            RUSTWORKX_PKG_NAME: retworkx
-        - uses: actions/upload-artifact@v2
-          with:
-            path: ./dist/*
-        - name: Upload to PyPI
-          run: twine upload ./dist/*
-          env:
-            TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-            TWINE_USERNAME: retworkx-ci
+  retworkx-compat-build:
+    name: Build retworkx
+    runs-on: ubuntu-latest
+    needs: ["build_wheels", "build-win32-wheels"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+      - name: Install deps
+        run: pip install -U twine setuptools-rust
+      - name: Build sdist
+        run: python setup.py sdist bdist_wheel
+        env:
+          RUSTWORKX_PKG_NAME: retworkx
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./dist/*
+      - name: Upload to PyPI
+        run: twine upload ./dist/*
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "rustworkx"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "ahash",
  "fixedbitset",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "rustworkx-core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "ahash",
  "fixedbitset",
@@ -583,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustworkx"
 description = "A python graph library implemented in Rust"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Matthew Treinish <mtreinish@kortar.org>"]
 license = "Apache-2.0"
 readme = "README.md"
@@ -32,7 +32,7 @@ num-complex = "0.4"
 quick-xml = "0.22.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rustworkx-core = { path = "rustworkx-core", version = "=0.12.0" }
+rustworkx-core = { path = "rustworkx-core", version = "=0.12.1" }
 
 [dependencies.pyo3]
 version = "0.17.3"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,9 +24,9 @@ copyright = u'2021, rustworkx Contributors'
 
 
 # The short X.Y version.
-version = '0.12.0'
+version = '0.12.1'
 # The full version, including alpha/beta/rc tags.
-release = '0.12.0'
+release = '0.12.1'
 
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.autosummary',

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,7 +4,7 @@ rustworkx Documentation
 
 .. note::
 
-    The project has been renamed to **rustworkx**. You can still use the legavcy
+    The project has been renamed to **rustworkx**. You can still use the legacy
     retworkx name for now but starting in the 1.0.0 release the retworkx name
     will no longer be supported.
 

--- a/releasenotes/notes/prepare-0.12.1-e59878f49351baf1.yaml
+++ b/releasenotes/notes/prepare-0.12.1-e59878f49351baf1.yaml
@@ -1,0 +1,4 @@
+---
+prelude: |
+    This release is a bugfix release that fixes bugs identified since the
+    0.12.0 release.

--- a/rustworkx-core/Cargo.toml
+++ b/rustworkx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustworkx-core"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2018"
 authors = ["Matthew Treinish <mtreinish@kortar.org>"]
 description = "Rust APIs used for rustworkx algorithms"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ mpl_extras = ['matplotlib>=3.0']
 graphviz_extras = ['pillow>=5.4']
 
 PKG_NAME = os.getenv('RUSTWORKX_PKG_NAME', "rustworkx")
-PKG_VERSION = "0.12.0"
+PKG_VERSION = "0.12.1"
 PKG_PACKAGES = ["rustworkx", "rustworkx.visualization"]
 PKG_INSTALL_REQUIRES = ['numpy>=1.16.0']
 RUST_EXTENSIONS = [RustExtension("rustworkx.rustworkx", "Cargo.toml",


### PR DESCRIPTION
This commit prepares for the 0.12.1 bugfix release. It bumps all the version numbers and adds a prelude release note to document the release. Once this merges we should tag the 0.12.1 release from that merged commit.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
