### PR TITLE
Only publish wheel for retworkx compat package

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -380,11 +380,11 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.10'
       - name: Install deps
         run: pip install -U twine setuptools-rust
       - name: Build sdist
-        run: python setup.py sdist bdist_wheel
+        run: python setup.py bdist_wheel
         env:
           RUSTWORKX_PKG_NAME: retworkx
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
This commit fixes the retworkx compat package publish job. The first issue is that the sdist for the retworkx package is not valid, we trigger the creation of the compat package by an env variable when calling setup.py/setuptools/builder/etc which triggers change the package name and other attributes. However if we create an sdist while setting the env variable this just bundles the setup.py and other source files in a tarball and when the sdist is installed rustworkx would be installed. So for the compat package we should only publish a pure python wheel that will have the actual compat shim. The other small change is switch the package to use python 3.10 instead of 3.7, which goes EoL in the near future.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
