### PR TITLE
Add SECURITY.md to document security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+Rustworkx supports one minor version release at a time both for bug and
+security fixes. For example, if the most recent release is 0.12.1 the 0.12.x
+release series is currently supported.
+
+## Reporting a Vulnerability
+
+To report vulnerabilities you can privately report a potential security issue
+via the Github security vulnerabilities feature. This can be done here:
+
+https://github.com/Qiskit/rustworkx/security/advisories
+
+Please do **not** open a public issue about a potential security vulnerability.
+
+You can find more details on the security vulnerability feature in the Github
+documentation here:
+
+https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability


### PR DESCRIPTION
This commit adds a SECURITY.md file to the repository to document the security policy. I recently enabled the private security advisories feature on the repository (which is a relatively new "beta" feature in github). Since we now have a place to privately raise potential security issues (besides email) it is good to have a documented policy on how security vulnerabilities should be reported and our support policy for version we will fix (which is just the latest release). As the project matures we can adjust this policy as needed (likely to support more than one version at a time).

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
