### PR TITLE
add find_predecessor_node_by_edge.

### DIFF
--- a/releasenotes/notes/add_find_predecessor_node_by_edge-fcd525aff055c5fb.yaml
+++ b/releasenotes/notes/add_find_predecessor_node_by_edge-fcd525aff055c5fb.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add a method
+    :meth:`~rustworkx.DiGraph.find_predecessor_node_by_edge` to get
+    the immediate predecessor of a node which is connected by the
+    specified edge.

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -1737,7 +1737,7 @@ impl PyDiGraph {
     /// :returns: The node object that has an edge from it to the provided
     ///     node index which matches the provided condition
     #[pyo3(text_signature = "(self, node, predicate, /)")]
-    pub fn find_adjacent_predecessor_node_by_edge(
+    pub fn find_predecessor_node_by_edge(
         &self,
         py: Python,
         node: usize,

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -1726,8 +1726,8 @@ impl PyDiGraph {
 
     /// Find a source node with a specific edge
     ///
-    /// This method is used to find an adjacent predecessor
-    /// to a given node given an edge condition.
+    /// This method is used to find a predecessor of
+    /// a given node given an edge condition.
     ///
     /// :param int node: The node to use as the source of the search
     /// :param callable predicate: A python callable that will take a single

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -1726,7 +1726,7 @@ impl PyDiGraph {
 
     /// Find a source node with a specific edge
     ///
-    /// This method is used to find a target node that is an adjacent predecessor
+    /// This method is used to find an adjacent predecessor
     /// to a given node given an edge condition.
     ///
     /// :param int node: The node to use as the source of the search

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -1724,7 +1724,7 @@ impl PyDiGraph {
         Err(NoSuitableNeighbors::new_err("No suitable neighbor"))
     }
 
-    /// Find a target node with a specific edge
+    /// Find a source node with a specific edge
     ///
     /// This method is used to find a target node that is an adjacent predecessor
     /// to a given node given an edge condition.

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -1724,6 +1724,42 @@ impl PyDiGraph {
         Err(NoSuitableNeighbors::new_err("No suitable neighbor"))
     }
 
+    /// Find a target node with a specific edge
+    ///
+    /// This method is used to find a target node that is an adjacent predecessor
+    /// to a given node given an edge condition.
+    ///
+    /// :param int node: The node to use as the source of the search
+    /// :param callable predicate: A python callable that will take a single
+    ///     parameter, the edge object, and will return a boolean if the
+    ///     edge matches or not
+    ///
+    /// :returns: The node object that has an edge from it to the provided
+    ///     node index which matches the provided condition
+    #[pyo3(text_signature = "(self, node, predicate, /)")]
+    pub fn find_adjacent_predecessor_node_by_edge(
+        &self,
+        py: Python,
+        node: usize,
+        predicate: PyObject,
+    ) -> PyResult<&PyObject> {
+        let predicate_callable = |a: &PyObject| -> PyResult<PyObject> {
+            let res = predicate.call1(py, (a,))?;
+            Ok(res.to_object(py))
+        };
+        let index = NodeIndex::new(node);
+        let dir = petgraph::Direction::Incoming;
+        let edges = self.graph.edges_directed(index, dir);
+        for edge in edges {
+            let edge_predicate_raw = predicate_callable(edge.weight())?;
+            let edge_predicate: bool = edge_predicate_raw.extract(py)?;
+            if edge_predicate {
+                return Ok(self.graph.node_weight(edge.source()).unwrap());
+            }
+        }
+        Err(NoSuitableNeighbors::new_err("No suitable neighbor"))
+    }
+
     /// Generate a dot file from the graph
     ///
     /// :param node_attr: A callable that will take in a node data object

--- a/tests/rustworkx_tests/digraph/test_edges.py
+++ b/tests/rustworkx_tests/digraph/test_edges.py
@@ -254,7 +254,7 @@ class TestEdges(unittest.TestCase):
         res = dag.find_predecessor_node_by_edge(node_b, compare_edges)
         self.assertEqual("a", res)
 
-    def test_find_adjacent_predecessor_node_by_edge_no_match(self):
+    def test_find_predecessor_node_by_edge_no_match(self):
         dag = rustworkx.PyDAG()
         node_a = dag.add_node("a")
         node_b = dag.add_child(node_a, "b", "a to b")

--- a/tests/rustworkx_tests/digraph/test_edges.py
+++ b/tests/rustworkx_tests/digraph/test_edges.py
@@ -241,7 +241,7 @@ class TestEdges(unittest.TestCase):
         with self.assertRaises(rustworkx.NoSuitableNeighbors):
             dag.find_adjacent_node_by_edge(node_a, compare_edges)
 
-    def test_find_adjacent_predecessor_node_by_edge(self):
+    def test_find_predecessor_node_by_edge(self):
         dag = rustworkx.PyDAG()
         node_a = dag.add_node("a")
         node_b = dag.add_child(node_a, "b", "a to b")

--- a/tests/rustworkx_tests/digraph/test_edges.py
+++ b/tests/rustworkx_tests/digraph/test_edges.py
@@ -242,13 +242,14 @@ class TestEdges(unittest.TestCase):
             dag.find_adjacent_node_by_edge(node_a, compare_edges)
 
     def test_find_adjacent_predecessor_node_by_edge(self):
-        from rustworkx.visualization import mpl_draw        
+        from rustworkx.visualization import mpl_draw
+
         dag = rustworkx.PyDAG()
         node_a = dag.add_node("a")
         node_b = dag.add_child(node_a, "b", "a to b")
         node_c = dag.add_child(node_b, "c", "b to c")
         node_d = dag.add_child(node_c, "d", "c to d")
-        mpl_draw(dag, with_labels=True, labels=str, edge_labels=str).savefig('test.png')
+        mpl_draw(dag, with_labels=True, labels=str, edge_labels=str).savefig("test.png")
 
         def compare_edges(edge):
             return "a to b" == edge

--- a/tests/rustworkx_tests/digraph/test_edges.py
+++ b/tests/rustworkx_tests/digraph/test_edges.py
@@ -254,6 +254,19 @@ class TestEdges(unittest.TestCase):
         res = dag.find_adjacent_predecessor_node_by_edge(node_b, compare_edges)
         self.assertEqual("a", res)
 
+    def test_find_adjacent_predecessor_node_by_edge_no_match(self):
+        dag = rustworkx.PyDAG()
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", "a to b")
+        node_c = dag.add_child(node_b, "c", "b to c")
+        dag.add_child(node_c, "d", "c to d")
+
+        def compare_edges(edge):
+            return "b to c" == edge
+
+        with self.assertRaises(rustworkx.NoSuitableNeighbors):
+            dag.find_adjacent_predecessor_node_by_edge(node_b, compare_edges)
+
     def test_add_edge_from(self):
         dag = rustworkx.PyDAG()
         nodes = list(range(4))

--- a/tests/rustworkx_tests/digraph/test_edges.py
+++ b/tests/rustworkx_tests/digraph/test_edges.py
@@ -232,7 +232,7 @@ class TestEdges(unittest.TestCase):
     def test_find_adjacent_node_by_edge_no_match(self):
         dag = rustworkx.PyDAG()
         node_a = dag.add_node("a")
-        node_b = dag.add_child(node_a, "b", {"weights": [1, 2]})
+        dag.add_child(node_a, "b", {"weights": [1, 2]})
         dag.add_child(node_a, "c", {"weights": [3, 4]})
 
         def compare_edges(edge):
@@ -242,13 +242,11 @@ class TestEdges(unittest.TestCase):
             dag.find_adjacent_node_by_edge(node_a, compare_edges)
 
     def test_find_adjacent_predecessor_node_by_edge(self):
-        from rustworkx.visualization import mpl_draw
-
         dag = rustworkx.PyDAG()
         node_a = dag.add_node("a")
         node_b = dag.add_child(node_a, "b", "a to b")
         node_c = dag.add_child(node_b, "c", "b to c")
-        node_d = dag.add_child(node_c, "d", "c to d")
+        dag.add_child(node_c, "d", "c to d")
 
         def compare_edges(edge):
             return "a to b" == edge

--- a/tests/rustworkx_tests/digraph/test_edges.py
+++ b/tests/rustworkx_tests/digraph/test_edges.py
@@ -232,7 +232,7 @@ class TestEdges(unittest.TestCase):
     def test_find_adjacent_node_by_edge_no_match(self):
         dag = rustworkx.PyDAG()
         node_a = dag.add_node("a")
-        dag.add_child(node_a, "b", {"weights": [1, 2]})
+        node_b = dag.add_child(node_a, "b", {"weights": [1, 2]})
         dag.add_child(node_a, "c", {"weights": [3, 4]})
 
         def compare_edges(edge):
@@ -240,6 +240,21 @@ class TestEdges(unittest.TestCase):
 
         with self.assertRaises(rustworkx.NoSuitableNeighbors):
             dag.find_adjacent_node_by_edge(node_a, compare_edges)
+
+    def test_find_adjacent_predecessor_node_by_edge(self):
+        from rustworkx.visualization import mpl_draw        
+        dag = rustworkx.PyDAG()
+        node_a = dag.add_node("a")
+        node_b = dag.add_child(node_a, "b", "a to b")
+        node_c = dag.add_child(node_b, "c", "b to c")
+        node_d = dag.add_child(node_c, "d", "c to d")
+        mpl_draw(dag, with_labels=True, labels=str, edge_labels=str).savefig('test.png')
+
+        def compare_edges(edge):
+            return "a to b" == edge
+
+        res = dag.find_adjacent_predecessor_node_by_edge(node_c, compare_edges)
+        self.assertEqual("b", res)
 
     def test_add_edge_from(self):
         dag = rustworkx.PyDAG()

--- a/tests/rustworkx_tests/digraph/test_edges.py
+++ b/tests/rustworkx_tests/digraph/test_edges.py
@@ -265,7 +265,7 @@ class TestEdges(unittest.TestCase):
             return "b to c" == edge
 
         with self.assertRaises(rustworkx.NoSuitableNeighbors):
-            dag.find_adjacent_predecessor_node_by_edge(node_b, compare_edges)
+            dag.find_predecessor_node_by_edge(node_b, compare_edges)
 
     def test_add_edge_from(self):
         dag = rustworkx.PyDAG()

--- a/tests/rustworkx_tests/digraph/test_edges.py
+++ b/tests/rustworkx_tests/digraph/test_edges.py
@@ -249,13 +249,12 @@ class TestEdges(unittest.TestCase):
         node_b = dag.add_child(node_a, "b", "a to b")
         node_c = dag.add_child(node_b, "c", "b to c")
         node_d = dag.add_child(node_c, "d", "c to d")
-        mpl_draw(dag, with_labels=True, labels=str, edge_labels=str).savefig("test.png")
 
         def compare_edges(edge):
             return "a to b" == edge
 
-        res = dag.find_adjacent_predecessor_node_by_edge(node_c, compare_edges)
-        self.assertEqual("b", res)
+        res = dag.find_adjacent_predecessor_node_by_edge(node_b, compare_edges)
+        self.assertEqual("a", res)
 
     def test_add_edge_from(self):
         dag = rustworkx.PyDAG()

--- a/tests/rustworkx_tests/digraph/test_edges.py
+++ b/tests/rustworkx_tests/digraph/test_edges.py
@@ -251,7 +251,7 @@ class TestEdges(unittest.TestCase):
         def compare_edges(edge):
             return "a to b" == edge
 
-        res = dag.find_adjacent_predecessor_node_by_edge(node_b, compare_edges)
+        res = dag.find_predecessor_node_by_edge(node_b, compare_edges)
         self.assertEqual("a", res)
 
     def test_find_adjacent_predecessor_node_by_edge_no_match(self):


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
add function to get immediate predecessor of node by edge.