### PR TITLE
Pin tox version used in CI to < 4.0.0

### DIFF
--- a/.github/workflows/docs_dev.yml
+++ b/.github/workflows/docs_dev.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel tox
+        pip install -U virtualenv setuptools wheel 'tox<4'
         sudo apt-get install graphviz pandoc
     - name: Build and publish
       env:

--- a/.github/workflows/docs_release.yml
+++ b/.github/workflows/docs_release.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel tox
+        pip install -U virtualenv setuptools wheel 'tox<4'
         sudo apt-get install graphviz pandoc
     - name: Build and publish
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
           profile: minimal
           default: true
       - name: 'Install dependencies'
-        run: python -m pip install --upgrade tox
+        run: python -m pip install --upgrade 'tox<4'
       - name: 'Install binary dependencies'
         run: sudo apt-get install -y graphviz
         if: runner.os == 'Linux'
@@ -118,7 +118,7 @@ jobs:
           profile: minimal
           default: true
       - name: 'Install dependencies'
-        run: python -m pip install --upgrade tox
+        run: python -m pip install --upgrade 'tox<4'
       - name: 'Install binary dependencies'
         run: sudo apt-get install -y graphviz
         if: runner.os == 'Linux'
@@ -195,7 +195,7 @@ jobs:
       - name: Install binary deps
         run: sudo apt-get install -y graphviz
       - name: Install deps
-        run: pip install -U tox
+        run: pip install -U 'tox<4'
       - name: Build Docs
         run: tox -edocs
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
The most recent tox release, 4.0.0, is a major rewrite of the internals of tox and several things behave quite differently. This new release is causing CI jobs to fail as something in incompatible with our tox configuration. This commit pins the tox version we're using in CI to unblock things until we can update the tox configuration to be compatible with both the new and old versions of tox.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
