### PR TITLE
Fix clippy with Rust 1.66.0

### DIFF
--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -2724,14 +2724,14 @@ impl PyDiGraph {
     }
 
     fn __getitem__(&self, idx: usize) -> PyResult<&PyObject> {
-        match self.graph.node_weight(NodeIndex::new(idx as usize)) {
+        match self.graph.node_weight(NodeIndex::new(idx)) {
             Some(data) => Ok(data),
             None => Err(PyIndexError::new_err("No node found for index")),
         }
     }
 
     fn __setitem__(&mut self, idx: usize, value: PyObject) -> PyResult<()> {
-        let data = match self.graph.node_weight_mut(NodeIndex::new(idx as usize)) {
+        let data = match self.graph.node_weight_mut(NodeIndex::new(idx)) {
             Some(node_data) => node_data,
             None => return Err(PyIndexError::new_err("No node found for index")),
         };
@@ -2740,7 +2740,7 @@ impl PyDiGraph {
     }
 
     fn __delitem__(&mut self, idx: usize) -> PyResult<()> {
-        match self.graph.remove_node(NodeIndex::new(idx as usize)) {
+        match self.graph.remove_node(NodeIndex::new(idx)) {
             Some(_) => Ok(()),
             None => Err(PyIndexError::new_err("No node found for index")),
         }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1746,7 +1746,7 @@ impl PyGraph {
     }
 
     fn __delitem__(&mut self, idx: usize) -> PyResult<()> {
-        match self.graph.remove_node(NodeIndex::new(idx as usize)) {
+        match self.graph.remove_node(NodeIndex::new(idx)) {
             Some(_) => Ok(()),
             None => Err(PyIndexError::new_err("No node found for index")),
         }


### PR DESCRIPTION
The recent release of Rust 1.66.0 [1] added new on by default clippy rules which are causing failures when we run the clippy CI job with the new rust version. This commit updates the code to fix the issues that clippy has identified which will unblock CI.

[1] https://blog.rust-lang.org/2022/12/15/Rust-1.66.0.html

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
