### PR TITLE
Add commas between args to passenv in tox.ini

### DIFF
--- a/.github/workflows/docs_dev.yml
+++ b/.github/workflows/docs_dev.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel 'tox<4'
+        pip install -U virtualenv setuptools wheel tox
         sudo apt-get install graphviz pandoc
     - name: Build and publish
       env:

--- a/.github/workflows/docs_release.yml
+++ b/.github/workflows/docs_release.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel 'tox<4'
+        pip install -U virtualenv setuptools wheel tox
         sudo apt-get install graphviz pandoc
     - name: Build and publish
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
           profile: minimal
           default: true
       - name: 'Install dependencies'
-        run: python -m pip install --upgrade 'tox<4'
+        run: python -m pip install --upgrade tox
       - name: 'Install binary dependencies'
         run: sudo apt-get install -y graphviz
         if: runner.os == 'Linux'
@@ -118,7 +118,7 @@ jobs:
           profile: minimal
           default: true
       - name: 'Install dependencies'
-        run: python -m pip install --upgrade 'tox<4'
+        run: python -m pip install --upgrade tox
       - name: 'Install binary dependencies'
         run: sudo apt-get install -y graphviz
         if: runner.os == 'Linux'
@@ -195,7 +195,7 @@ jobs:
       - name: Install binary deps
         run: sudo apt-get install -y graphviz
       - name: Install deps
-        run: pip install -U 'tox<4'
+        run: pip install -U tox
       - name: Build Docs
         run: tox -edocs
       - uses: actions/upload-artifact@v2

--- a/tests/rustworkx_tests/visualization/test_graphviz.py
+++ b/tests/rustworkx_tests/visualization/test_graphviz.py
@@ -117,11 +117,11 @@ class TestGraphvizDraw(unittest.TestCase):
         self.assertIsInstance(image, PIL.Image.Image)
         _save_image(image, "test_graphviz_draw_graph_attr.png")
 
-    def test_image_type(self):
-        graph = rustworkx.directed_gnp_random_graph(50, 0.8)
-        image = graphviz_draw(graph, image_type="jpg")
-        self.assertIsInstance(image, PIL.Image.Image)
-        _save_image(image, "test_graphviz_draw_image_type.jpg")
+    # def test_image_type(self):
+    #     graph = rustworkx.directed_gnp_random_graph(50, 0.8)
+    #     image = graphviz_draw(graph, image_type="jpg")
+    #     self.assertIsInstance(image, PIL.Image.Image)
+    #     _save_image(image, "test_graphviz_draw_image_type.jpg")
 
     def test_image_type_invalid_type(self):
         graph = rustworkx.directed_gnp_random_graph(50, 0.8)

--- a/tests/rustworkx_tests/visualization/test_graphviz.py
+++ b/tests/rustworkx_tests/visualization/test_graphviz.py
@@ -117,11 +117,11 @@ class TestGraphvizDraw(unittest.TestCase):
         self.assertIsInstance(image, PIL.Image.Image)
         _save_image(image, "test_graphviz_draw_graph_attr.png")
 
-    # def test_image_type(self):
-    #     graph = rustworkx.directed_gnp_random_graph(50, 0.8)
-    #     image = graphviz_draw(graph, image_type="jpg")
-    #     self.assertIsInstance(image, PIL.Image.Image)
-    #     _save_image(image, "test_graphviz_draw_image_type.jpg")
+    def test_image_type(self):
+        graph = rustworkx.directed_gnp_random_graph(50, 0.8)
+        image = graphviz_draw(graph, image_type="jpg")
+        self.assertIsInstance(image, PIL.Image.Image)
+        _save_image(image, "test_graphviz_draw_image_type.jpg")
 
     def test_image_type_invalid_type(self):
         graph = rustworkx.directed_gnp_random_graph(50, 0.8)

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,9 @@ deps =
 extras =
   mpl
   graphviz
-passenv = RETWORKX_TEST_PRESERVE_IMAGES, RUSTWORKX_PKG_NAME
+passenv =
+  RETWORKX_TEST_PRESERVE_IMAGES
+  RUSTWORKX_PKG_NAME
 changedir = {toxinidir}/tests
 commands =
   stestr run {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,10 @@ setenv =
   {[testenv]setenv}
 deps =
   -r {toxinidir}/docs/source/requirements.txt
-passenv = {[testenv]passenv}, RETWORKX_DEV_DOCS, RETWORKX_LEGACY_DOCS
+passenv =
+  {[testenv]passenv}
+  RETWORKX_DEV_DOCS
+  RETWORKX_LEGACY_DOCS
 changedir = {toxinidir}/docs
 commands =
   sphinx-build -W -b html source build/html {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
 extras =
   mpl
   graphviz
-passenv = RETWORKX_TEST_PRESERVE_IMAGES RUSTWORKX_PKG_NAME
+passenv = RETWORKX_TEST_PRESERVE_IMAGES, RUSTWORKX_PKG_NAME
 changedir = {toxinidir}/tests
 commands =
   stestr run {posargs}
@@ -44,7 +44,7 @@ setenv =
   {[testenv]setenv}
 deps =
   -r {toxinidir}/docs/source/requirements.txt
-passenv = {[testenv]passenv} RETWORKX_DEV_DOCS RETWORKX_LEGACY_DOCS
+passenv = {[testenv]passenv}, RETWORKX_DEV_DOCS, RETWORKX_LEGACY_DOCS
 changedir = {toxinidir}/docs
 commands =
   sphinx-build -W -b html source build/html {posargs}


### PR DESCRIPTION
The presence of commas is enforced in tox 4.0.6

Closes #812

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X ] I ran rustfmt locally
- [ X] I have added the tests to cover my changes.
- [ X] I have updated the documentation accordingly.
- [X ] I have read the CONTRIBUTING document.
-->
