### PR TITLE
Fix Matplotlib warning when building docs

### DIFF
--- a/docs/source/tutorial/betweenness_centrality.rst
+++ b/docs/source/tutorial/betweenness_centrality.rst
@@ -98,7 +98,7 @@ Alternatively, you can use :func:`~rustworkx.visualization.graphviz_draw`:
         graph[node] = btw
 
     # Leverage matplotlib for color map
-    colormap = matplotlib.cm.get_cmap("magma")
+    colormap = matplotlib.colormaps["magma"]
     norm = matplotlib.colors.Normalize(
         vmin=min(centrality.values()),
         vmax=max(centrality.values())


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Fix the warning in the docs because of [`matplotlib.cm`](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.7.0.html#deprecation-of-top-level-cmap-registration-and-access-functions-in-mpl-cm) deprecations


