### PR TITLE
Implement `check_cycle` in `__getstate__` and `__setstate__`. Expand python copy tests.

### DIFF
--- a/releasenotes/notes/fix-check-cycle-on-copy-d060a1781976f728.yaml
+++ b/releasenotes/notes/fix-check-cycle-on-copy-d060a1781976f728.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed the :attr:`~.PyDiGraph.check_cycle` attribute not being preserved
+    when copying :class:`~.PyDiGraph` with `copy.copy()` and `copy.deepcopy()`

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -305,6 +305,7 @@ impl PyDiGraph {
         out_dict.set_item("nodes_removed", self.node_removed)?;
         out_dict.set_item("multigraph", self.multigraph)?;
         out_dict.set_item("attrs", self.attrs.clone_ref(py))?;
+        out_dict.set_item("check_cycle", self.check_cycle)?;
         let dir = petgraph::Direction::Incoming;
         for node_index in self.graph.node_indices() {
             let node_data = self.graph.node_weight(node_index).unwrap();
@@ -341,6 +342,11 @@ impl PyDiGraph {
             None => py.None(),
         };
         self.attrs = attrs;
+        let check_cycle_raw = dict_state
+            .get_item("check_cycle")
+            .unwrap()
+            .downcast::<PyBool>()?;
+        self.check_cycle = check_cycle_raw.extract()?;
         let mut node_indices: Vec<usize> = Vec::new();
         for raw_index in nodes_dict.keys() {
             let tmp_index = raw_index.downcast::<PyLong>()?;

--- a/tests/rustworkx_tests/digraph/test_copy.py
+++ b/tests/rustworkx_tests/digraph/test_copy.py
@@ -73,10 +73,6 @@ class TestCopy(unittest.TestCase):
         self.assertEqual(graph_a[node_a], graph_b[node_a])
         self.assertIs(graph_a[node_a], graph_b[node_a])
         self.assertEqual(
-                graph_a.get_edge_data(node_a, node_b),
-                graph_b.get_edge_data(node_a, node_b)
-            )
-        self.assertIs(
-                graph_a.get_edge_data(node_a, node_b),
-                graph_b.get_edge_data(node_a, node_b)
-            )
+            graph_a.get_edge_data(node_a, node_b), graph_b.get_edge_data(node_a, node_b)
+        )
+        self.assertIs(graph_a.get_edge_data(node_a, node_b), graph_b.get_edge_data(node_a, node_b))

--- a/tests/rustworkx_tests/digraph/test_copy.py
+++ b/tests/rustworkx_tests/digraph/test_copy.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import unittest
+import copy
 
 import rustworkx
 
@@ -53,3 +54,29 @@ class TestCopy(unittest.TestCase):
         graph_b.get_edge_data(0, 1)["edge"] = 162
         self.assertEqual(graph_b[0]["a"], 42)
         self.assertEqual(graph_a.get_edge_data(0, 1), {"edge": 162})
+
+    def test_python_copy_check_cycle(self):
+        graph_a = rustworkx.PyDiGraph(check_cycle=True)
+        graph_b = copy.copy(graph_a)
+        graph_c = rustworkx.PyDiGraph(check_cycle=False)
+        graph_d = copy.copy(graph_c)
+        self.assertTrue(graph_b.check_cycle)
+        self.assertFalse(graph_d.check_cycle)
+
+    def test_python_copy_same_objects(self):
+        graph_a = rustworkx.PyDiGraph(attrs=[1])
+        node_a = graph_a.add_node([2])
+        node_b = graph_a.add_child(node_a, [3], [4])
+        graph_b = copy.copy(graph_a)
+        self.assertEqual(graph_a.attrs, graph_b.attrs)
+        self.assertIs(graph_a.attrs, graph_b.attrs)
+        self.assertEqual(graph_a[node_a], graph_b[node_a])
+        self.assertIs(graph_a[node_a], graph_b[node_a])
+        self.assertEqual(
+                graph_a.get_edge_data(node_a, node_b),
+                graph_b.get_edge_data(node_a, node_b)
+            )
+        self.assertIs(
+                graph_a.get_edge_data(node_a, node_b),
+                graph_b.get_edge_data(node_a, node_b)
+            )

--- a/tests/rustworkx_tests/digraph/test_deepcopy.py
+++ b/tests/rustworkx_tests/digraph/test_deepcopy.py
@@ -65,10 +65,8 @@ class TestDeepcopy(unittest.TestCase):
         self.assertEqual(graph_a[node_a], graph_b[node_a])
         self.assertIsNot(graph_a[node_a], graph_b[node_a])
         self.assertEqual(
-                graph_a.get_edge_data(node_a, node_b),
-                graph_b.get_edge_data(node_a, node_b)
-            )
+            graph_a.get_edge_data(node_a, node_b), graph_b.get_edge_data(node_a, node_b)
+        )
         self.assertIsNot(
-                graph_a.get_edge_data(node_a, node_b),
-                graph_b.get_edge_data(node_a, node_b)
-            )
+            graph_a.get_edge_data(node_a, node_b), graph_b.get_edge_data(node_a, node_b)
+        )

--- a/tests/rustworkx_tests/digraph/test_deepcopy.py
+++ b/tests/rustworkx_tests/digraph/test_deepcopy.py
@@ -46,3 +46,29 @@ class TestDeepcopy(unittest.TestCase):
         graph = rustworkx.PyDiGraph(attrs="abc")
         graph_copy = copy.deepcopy(graph)
         self.assertEqual(graph.attrs, graph_copy.attrs)
+
+    def test_deepcopy_check_cycle(self):
+        graph_a = rustworkx.PyDiGraph(check_cycle=True)
+        graph_b = copy.deepcopy(graph_a)
+        graph_c = rustworkx.PyDiGraph(check_cycle=False)
+        graph_d = copy.deepcopy(graph_c)
+        self.assertTrue(graph_b.check_cycle)
+        self.assertFalse(graph_d.check_cycle)
+
+    def test_deepcopy_different_objects(self):
+        graph_a = rustworkx.PyDiGraph(attrs=[1])
+        node_a = graph_a.add_node([2])
+        node_b = graph_a.add_child(node_a, [3], [4])
+        graph_b = copy.deepcopy(graph_a)
+        self.assertEqual(graph_a.attrs, graph_b.attrs)
+        self.assertIsNot(graph_a.attrs, graph_b.attrs)
+        self.assertEqual(graph_a[node_a], graph_b[node_a])
+        self.assertIsNot(graph_a[node_a], graph_b[node_a])
+        self.assertEqual(
+                graph_a.get_edge_data(node_a, node_b),
+                graph_b.get_edge_data(node_a, node_b)
+            )
+        self.assertIsNot(
+                graph_a.get_edge_data(node_a, node_b),
+                graph_b.get_edge_data(node_a, node_b)
+            )


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ x ] I ran rustfmt locally
- [ x ] I have added the tests to cover my changes.
- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the CONTRIBUTING document.
-->
Adds `check_cycle` to `__getstate__` and `__setstate__` so that python copy and deepcopy should be exact duplicates of the original objects.
Expands the digraph copy and deepcopy tests to include `check_cycle` tests and python object instance tests.

Should resolve #836.