### PR TITLE
Bump `quick-xml` to 0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.24.1"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37dddbbe9df96afafcb8027fcf263971b726530e12f0787f620a7ba5b4846081"
+checksum = "e5c1a97b1bc42b1d550bfb48d4262153fe400a12bab1511821736f7eac76d7e2"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.22.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
+checksum = "11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.23.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea"
+checksum = "37dddbbe9df96afafcb8027fcf263971b726530e12f0787f620a7ba5b4846081"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rayon = "1.6"
 num-traits = "0.2"
 num-bigint = "0.4"
 num-complex = "0.4"
-quick-xml = "0.22.0"
+quick-xml = "0.23.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rustworkx-core = { path = "rustworkx-core", version = "=0.13.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rayon = "1.6"
 num-traits = "0.2"
 num-bigint = "0.4"
 num-complex = "0.4"
-quick-xml = "0.23.0"
+quick-xml = "0.24.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rustworkx-core = { path = "rustworkx-core", version = "=0.13.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rayon = "1.6"
 num-traits = "0.2"
 num-bigint = "0.4"
 num-complex = "0.4"
-quick-xml = "0.24.0"
+quick-xml = "0.28"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rustworkx-core = { path = "rustworkx-core", version = "=0.13.0" }

--- a/src/graphml.rs
+++ b/src/graphml.rs
@@ -13,7 +13,6 @@
 #![allow(clippy::borrow_as_ptr)]
 
 use std::convert::From;
-use std::io::BufRead;
 use std::iter::FromIterator;
 use std::num::{ParseFloatError, ParseIntError};
 use std::path::Path;
@@ -209,11 +208,7 @@ impl Graph {
         }
     }
 
-    fn add_node<'a, I>(
-        &mut self,
-        element: &'a BytesStart<'a>,
-        default_data: I,
-    ) -> Result<(), Error>
+    fn add_node<'a, I>(&mut self, element: &'a BytesStart<'a>, default_data: I) -> Result<(), Error>
     where
         I: Iterator<Item = &'a Key>,
     {
@@ -227,11 +222,7 @@ impl Graph {
         Ok(())
     }
 
-    fn add_edge<'a, I>(
-        &mut self,
-        element: &'a BytesStart<'a>,
-        default_data: I,
-    ) -> Result<(), Error>
+    fn add_edge<'a, I>(&mut self, element: &'a BytesStart<'a>, default_data: I) -> Result<(), Error>
     where
         I: Iterator<Item = &'a Key>,
     {
@@ -379,10 +370,7 @@ impl Default for GraphML {
 }
 
 impl GraphML {
-    fn create_graph<'a>(
-        &mut self,
-        element: &'a BytesStart<'a>,
-    ) -> Result<(), Error> {
+    fn create_graph<'a>(&mut self, element: &'a BytesStart<'a>) -> Result<(), Error> {
         let dir = match xml_attribute(element, b"edgedefault")?.as_bytes() {
             b"directed" => Direction::Directed,
             b"undirected" => Direction::UnDirected,
@@ -401,11 +389,7 @@ impl GraphML {
         Ok(())
     }
 
-    fn add_node<'a, B: BufRead>(
-        &mut self,
-        _reader: &Reader<B>,
-        element: &'a BytesStart<'a>,
-    ) -> Result<(), Error> {
+    fn add_node<'a>(&mut self, element: &'a BytesStart<'a>) -> Result<(), Error> {
         if let Some(graph) = self.graphs.last_mut() {
             graph.add_node(
                 element,
@@ -416,11 +400,7 @@ impl GraphML {
         Ok(())
     }
 
-    fn add_edge<'a, B: BufRead>(
-        &mut self,
-        _reader: &Reader<B>,
-        element: &'a BytesStart<'a>,
-    ) -> Result<(), Error> {
+    fn add_edge<'a>(&mut self, element: &'a BytesStart<'a>) -> Result<(), Error> {
         if let Some(graph) = self.graphs.last_mut() {
             graph.add_edge(
                 element,
@@ -431,10 +411,7 @@ impl GraphML {
         Ok(())
     }
 
-    fn add_graphml_key<'a>(
-        &mut self,
-        element: &'a BytesStart<'a>,
-    ) -> Result<Domain, Error> {
+    fn add_graphml_key<'a>(&mut self, element: &'a BytesStart<'a>) -> Result<Domain, Error> {
         let id = xml_attribute(element, b"id")?;
         let ty = match xml_attribute(element, b"attr.type")?.as_bytes() {
             b"boolean" => Type::Boolean,
@@ -578,12 +555,12 @@ impl GraphML {
                     }
                     QName(b"node") => {
                         matches!(state, State::Graph);
-                        graphml.add_node(&reader, e)?;
+                        graphml.add_node(e)?;
                         state = State::Node;
                     }
                     QName(b"edge") => {
                         matches!(state, State::Graph);
-                        graphml.add_edge(&reader, e)?;
+                        graphml.add_edge(e)?;
                         state = State::Edge;
                     }
                     QName(b"data") => {
@@ -616,11 +593,11 @@ impl GraphML {
                     }
                     QName(b"node") => {
                         matches!(state, State::Graph);
-                        graphml.add_node(&reader, e)?;
+                        graphml.add_node(e)?;
                     }
                     QName(b"edge") => {
                         matches!(state, State::Graph);
-                        graphml.add_edge(&reader, e)?;
+                        graphml.add_edge(e)?;
                     }
                     QName(b"port") => {
                         return Err(Error::UnSupported(String::from("Ports are not supported.")));

--- a/src/graphml.rs
+++ b/src/graphml.rs
@@ -95,7 +95,10 @@ fn xml_attribute<'a, B: BufRead>(
         .find_map(|a| {
             if let Ok(a) = a {
                 if a.key == QName(key) {
-                    let decoded = a.unescape_value().map_err(Error::from).map(|cow_str| cow_str.into_owned());
+                    let decoded = a
+                        .unescape_value()
+                        .map_err(Error::from)
+                        .map(|cow_str| cow_str.into_owned());
                     return Some(decoded);
                 }
             }

--- a/src/graphml.rs
+++ b/src/graphml.rs
@@ -209,9 +209,8 @@ impl Graph {
         }
     }
 
-    fn add_node<'a, B: BufRead, I>(
+    fn add_node<'a, I>(
         &mut self,
-        _reader: &Reader<B>,
         element: &'a BytesStart<'a>,
         default_data: I,
     ) -> Result<(), Error>
@@ -228,9 +227,8 @@ impl Graph {
         Ok(())
     }
 
-    fn add_edge<'a, B: BufRead, I>(
+    fn add_edge<'a, I>(
         &mut self,
-        _reader: &Reader<B>,
         element: &'a BytesStart<'a>,
         default_data: I,
     ) -> Result<(), Error>
@@ -381,9 +379,8 @@ impl Default for GraphML {
 }
 
 impl GraphML {
-    fn create_graph<'a, B: BufRead>(
+    fn create_graph<'a>(
         &mut self,
-        _reader: &Reader<B>,
         element: &'a BytesStart<'a>,
     ) -> Result<(), Error> {
         let dir = match xml_attribute(element, b"edgedefault")?.as_bytes() {
@@ -406,12 +403,11 @@ impl GraphML {
 
     fn add_node<'a, B: BufRead>(
         &mut self,
-        reader: &Reader<B>,
+        _reader: &Reader<B>,
         element: &'a BytesStart<'a>,
     ) -> Result<(), Error> {
         if let Some(graph) = self.graphs.last_mut() {
             graph.add_node(
-                reader,
                 element,
                 self.key_for_nodes.values().chain(self.key_for_all.values()),
             )?;
@@ -422,12 +418,11 @@ impl GraphML {
 
     fn add_edge<'a, B: BufRead>(
         &mut self,
-        reader: &Reader<B>,
+        _reader: &Reader<B>,
         element: &'a BytesStart<'a>,
     ) -> Result<(), Error> {
         if let Some(graph) = self.graphs.last_mut() {
             graph.add_edge(
-                reader,
                 element,
                 self.key_for_edges.values().chain(self.key_for_all.values()),
             )?;
@@ -436,9 +431,8 @@ impl GraphML {
         Ok(())
     }
 
-    fn add_graphml_key<'a, B: BufRead>(
+    fn add_graphml_key<'a>(
         &mut self,
-        _reader: &Reader<B>,
         element: &'a BytesStart<'a>,
     ) -> Result<Domain, Error> {
         let id = xml_attribute(element, b"id")?;
@@ -570,7 +564,7 @@ impl GraphML {
                 Event::Start(ref e) => match e.name() {
                     QName(b"key") => {
                         matches!(state, State::Start);
-                        domain_of_last_key = graphml.add_graphml_key(&reader, e)?;
+                        domain_of_last_key = graphml.add_graphml_key(e)?;
                         state = State::Key;
                     }
                     QName(b"default") => {
@@ -579,7 +573,7 @@ impl GraphML {
                     }
                     QName(b"graph") => {
                         matches!(state, State::Start);
-                        graphml.create_graph(&reader, e)?;
+                        graphml.create_graph(e)?;
                         state = State::Graph;
                     }
                     QName(b"node") => {
@@ -618,7 +612,7 @@ impl GraphML {
                 Event::Empty(ref e) => match e.name() {
                     QName(b"key") => {
                         matches!(state, State::Start);
-                        graphml.add_graphml_key(&reader, e)?;
+                        graphml.add_graphml_key(e)?;
                     }
                     QName(b"node") => {
                         matches!(state, State::Graph);


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Closes #835 

Bumps `quick-xml` to 0.28 before the old version 0.22 stops being compiled by future Rust versions (as said in the warnings)