### PR TITLE
Remove stray debug prints from tests

### DIFF
--- a/tests/retworkx_backwards_compat/digraph/test_dijkstra.py
+++ b/tests/retworkx_backwards_compat/digraph/test_dijkstra.py
@@ -194,7 +194,6 @@ class TestDijkstraDiGraph(unittest.TestCase):
 
     def test_dijkstra_all_pair_paths(self):
         paths = retworkx.digraph_all_pairs_dijkstra_shortest_paths(self.graph, float)
-        print(paths)
         expected = {
             0: {1: [0, 1], 2: [0, 3, 2], 3: [0, 3], 4: [0, 3, 4], 5: [0, 1, 5]},
             1: {

--- a/tests/retworkx_backwards_compat/graph/test_all_simple_paths.py
+++ b/tests/retworkx_backwards_compat/graph/test_all_simple_paths.py
@@ -227,7 +227,6 @@ class TestGraphAllSimplePathsAllPairs(unittest.TestCase):
 
     def test_all_simple_paths_with_min_depth_and_cutoff(self):
         paths = retworkx.all_pairs_all_simple_paths(self.graph, min_depth=3, cutoff=3)
-        print(paths)
         expected = {
             0: {2: [[0, 1, 2], [0, 3, 2]]},
             1: {3: [[1, 2, 3], [1, 0, 3]]},

--- a/tests/rustworkx_tests/digraph/test_dijkstra.py
+++ b/tests/rustworkx_tests/digraph/test_dijkstra.py
@@ -194,7 +194,6 @@ class TestDijkstraDiGraph(unittest.TestCase):
 
     def test_dijkstra_all_pair_paths(self):
         paths = rustworkx.digraph_all_pairs_dijkstra_shortest_paths(self.graph, float)
-        print(paths)
         expected = {
             0: {1: [0, 1], 2: [0, 3, 2], 3: [0, 3], 4: [0, 3, 4], 5: [0, 1, 5]},
             1: {

--- a/tests/rustworkx_tests/generators/test_heavy_square.py
+++ b/tests/rustworkx_tests/generators/test_heavy_square.py
@@ -373,7 +373,6 @@ class TestHeavyHexGraph(unittest.TestCase):
             (44, 60),
             (44, 64),
         ]
-        print("\n\nEDGE LIST  ", graph.edge_list())
         self.assertEqual(list(graph.edge_list()), expected_edges)
 
     def test_directed_heavy_square_graph_3(self):

--- a/tests/rustworkx_tests/graph/test_all_simple_paths.py
+++ b/tests/rustworkx_tests/graph/test_all_simple_paths.py
@@ -227,7 +227,6 @@ class TestGraphAllSimplePathsAllPairs(unittest.TestCase):
 
     def test_all_simple_paths_with_min_depth_and_cutoff(self):
         paths = rustworkx.all_pairs_all_simple_paths(self.graph, min_depth=3, cutoff=3)
-        print(paths)
         expected = {
             0: {2: [[0, 1, 2], [0, 3, 2]]},
             1: {3: [[1, 2, 3], [1, 0, 3]]},


### PR DESCRIPTION
This commit removes some stray debug print messages that were in some test files. This was causing spurious output that wasn't actionable during test runs both locally and in CI.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
