### PR TITLE
Pin ipykernel and jupyter-client packages

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,4 @@
 decorator==4.4.2
 importlib-metadata==4.13.0;python_version<'3.8'
+ipykernel==6.21.3
+jupyter-client==8.0.3


### PR DESCRIPTION
With the recent release of ipykernel 6.22.0 and jupyter-client 8.1.0 our docs builds are failing to run, it fails on processing the first jupyter-execute directive as it's unable to launch a jupyter kernel. This commit pins these packages in the constraints file (as we don't directly depend on them) to the last known working version to unblock CI.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
