### PR TITLE
Fix install and use of Jupyter Kernel for docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -176,4 +176,4 @@ def avoid_duplicate_in_dispatch(app, obj, bound_method):
 def setup(app):
     app.connect('config-inited', _get_versions)
     app.connect('autodoc-before-process-signature', avoid_duplicate_in_dispatch)
-    app.add_config_value("jupyter_execute_default_kernel", "python", "env")
+    app.add_config_value("jupyter_execute_default_kernel", "python3", "env")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -115,6 +115,9 @@ latex_documents = [
    u'rustworkx Contributors', 'manual'),
 ]
 
+# Jupyter Sphinx options
+jupyter_execute_default_kernel = "python3"
+
 # Texinfo options
 
 texinfo_documents = [
@@ -176,4 +179,3 @@ def avoid_duplicate_in_dispatch(app, obj, bound_method):
 def setup(app):
     app.connect('config-inited', _get_versions)
     app.connect('autodoc-before-process-signature', avoid_duplicate_in_dispatch)
-    app.add_config_value("jupyter_execute_default_kernel", "python3", "env")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -176,3 +176,4 @@ def avoid_duplicate_in_dispatch(app, obj, bound_method):
 def setup(app):
     app.connect('config-inited', _get_versions)
     app.connect('autodoc-before-process-signature', avoid_duplicate_in_dispatch)
+    app.add_config_value("jupyter_execute_default_kernel", "python", "env")

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -9,3 +9,4 @@ qiskit-sphinx-theme>=1.7
 matplotlib>=3.4
 sphinx-reredirects
 sphinxemoji
+ipykernel

--- a/tools/deploy_documentation_dev.sh
+++ b/tools/deploy_documentation_dev.sh
@@ -20,6 +20,9 @@ sudo apt-get install -y ./rclone.deb
 
 RCLONE_CONFIG_PATH=$(rclone config file | tail -1)
 
+# Show available Jupyter kernels
+jupyter kernelspec list
+
 # Build the documentation.
 RETWORKX_DEV_DOCS=1 tox -edocs
 

--- a/tools/deploy_documentation_dev.sh
+++ b/tools/deploy_documentation_dev.sh
@@ -20,9 +20,6 @@ sudo apt-get install -y ./rclone.deb
 
 RCLONE_CONFIG_PATH=$(rclone config file | tail -1)
 
-# Show available Jupyter kernels
-jupyter kernelspec list
-
 # Build the documentation.
 RETWORKX_DEV_DOCS=1 tox -edocs
 

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ deps =
 passenv = {[testenv]passenv} RETWORKX_DEV_DOCS RETWORKX_LEGACY_DOCS
 changedir = {toxinidir}/docs
 commands =
+  jupyter kernelspec list
   sphinx-build -W -b html source build/html {posargs}
 
 [testenv:black]

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ deps =
 passenv = {[testenv]passenv} RETWORKX_DEV_DOCS RETWORKX_LEGACY_DOCS
 changedir = {toxinidir}/docs
 commands =
+  python -m ipykernel install --user
   jupyter kernelspec list
   sphinx-build -W -b html source build/html {posargs}
 


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Tries to fix the same problem as #844 but without pinning

For some reason the `python3` kernel stopped being installed togethe with Jupyter, hence:
* we install the kernel on the tox environment
* we explicity use the kernel in the Sphinx configuration