### PR TITLE
Fixup docs publish job

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -27,9 +27,9 @@ echo "show current dir: "
 pwd
 
 CURRENT_TAG=`git describe --abbrev=0`
-IFS='.'
-read -ra VERSION <<< "$CURRENT_TAG"
+IFS=. read -ra VERSION <<< "$CURRENT_TAG"
 STABLE_VERSION=${VERSION[0]}.${VERSION[1]}
+echo "Building for stable version $STABLE_VERSION"
 
 # Push to qiskit.org/ecosystem
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ changedir = {toxinidir}/docs
 commands =
   python -m ipykernel install --user
   jupyter kernelspec list
-  sphinx-build -W -b html source build/html {posargs}
+  sphinx-build -W -d {toxinidir}/docs/build/.doctrees -b html source build/html {posargs}
 
 [testenv:black]
 basepython = python3


### PR DESCRIPTION
This commit fixes two separate issues in the docs publishing job. The first is a failure that happens in the docs deployment on releases. The IFS (internal field separator) variable was getting set too broadly at the the level of the entire script instead of just the tag parsing. This was causing the passing of the secrets for decrypting the credential files to fail. This commit updates the IFS usage so it's not affecting the other commands after we split the tag version.

The second change is updating the default sphinx-build invocation to include the -d flag to change the default output directory for the .doctrees dir.
(see: https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-d for details on the flag). The .doctrees dir is a local cache of pickle files for parsed source files and doesn't need to be included in the build. By moving the default location for this outside our html build dir this will remove a lot of overhead from our uploaded docs as this cache can end up being quite large.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
