### PR TITLE
Update tox configuration to use tox >= 4.4.0

### DIFF
--- a/.github/workflows/docs_dev.yml
+++ b/.github/workflows/docs_dev.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel 'tox<4'
+        pip install -U virtualenv setuptools wheel tox
         sudo apt-get install graphviz pandoc
     - name: Build and publish
       env:

--- a/.github/workflows/docs_release.yml
+++ b/.github/workflows/docs_release.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel 'tox<4'
+        pip install -U virtualenv setuptools wheel tox
         sudo apt-get install graphviz pandoc
     - name: Build and publish
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,18 +131,21 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.platform.rust-target }}
-      - name: 'Install dependencies'
-        run: python -m pip install --upgrade tox
       - name: 'Install binary dependencies'
         run: sudo apt-get install -y graphviz
         if: runner.os == 'Linux'
-      - name: 'Build rustworkx'
+      - name: 'Build rustworkx and test dependencies'
         run: |
-          tox -epy --notest
-      - name: 'Run retworkx tests'
+          pip install -c constraints.txt -U '.[mpl,graphviz]' fixtures testtools>=2.5.0 networkx>=2.5 stestr
+      - name: 'Build retworkx'
         env:
           RUSTWORKX_PKG_NAME: "retworkx"
-        run: tox -epy -- -t ./retworkx_backwards_compat
+        run: |
+          pip install -c constraints.txt -U .
+      - name: 'Run retworkx tests'
+        run: |
+          cd tests
+          stestr run -t ./retworkx_backwards_compat
   coverage:
     needs: [tests]
     name: Coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.platform.rust-target }}
       - name: 'Install dependencies'
-        run: python -m pip install --upgrade 'tox<4'
+        run: python -m pip install --upgrade tox
       - name: 'Install binary dependencies'
         run: sudo apt-get install -y graphviz
         if: runner.os == 'Linux'
@@ -103,7 +103,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: 'Install dependencies'
-        run: python -m pip install --upgrade 'tox<4'
+        run: python -m pip install --upgrade tox
       - name: 'Run rustworkx stub tests'
         run: tox -estubs
   tests_retworkx_compat:
@@ -132,7 +132,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.platform.rust-target }}
       - name: 'Install dependencies'
-        run: python -m pip install --upgrade 'tox<4'
+        run: python -m pip install --upgrade tox
       - name: 'Install binary dependencies'
         run: sudo apt-get install -y graphviz
         if: runner.os == 'Linux'
@@ -202,7 +202,7 @@ jobs:
       - name: Install binary deps
         run: sudo apt-get install -y graphviz
       - name: Install deps
-        run: pip install -U 'tox<4'
+        run: pip install -U tox
       - name: Build Docs
         run: tox -edocs
       - uses: actions/upload-artifact@v3

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-minversion = 2.1
+minversion = 4.4.0
 envlist = py37, py38, py39, py310, py311, lint
 isolated_build = true
 
 [testenv]
-install_command = pip install -c{toxinidir}/constraints.txt -U {opts} {packages}
+install_command = python -I -m pip install -c{toxinidir}/constraints.txt -U {opts} {packages}
 setenv =
   VIRTUAL_ENV={envdir}
   LANGUAGE=en_US
@@ -19,14 +19,15 @@ deps =
 extras =
   mpl
   graphviz
-passenv = RETWORKX_TEST_PRESERVE_IMAGES RUSTWORKX_PKG_NAME
+passenv =
+  RETWORKX_TEST_PRESERVE_IMAGES
+  RUSTWORKX_PKG_NAME
 changedir = {toxinidir}/tests
 commands =
   stestr run {posargs}
 
 [testenv:lint]
 basepython = python3
-envdir = .tox/lint
 deps =
   black~=22.0
   flake8
@@ -44,7 +45,10 @@ setenv =
   {[testenv]setenv}
 deps =
   -r {toxinidir}/docs/source/requirements.txt
-passenv = {[testenv]passenv} RETWORKX_DEV_DOCS RETWORKX_LEGACY_DOCS
+passenv =
+  {[testenv]passenv}
+  RETWORKX_DEV_DOCS
+  RETWORKX_LEGACY_DOCS
 changedir = {toxinidir}/docs
 commands =
   python -m ipykernel install --user
@@ -53,14 +57,12 @@ commands =
 
 [testenv:black]
 basepython = python3
-envdir = .tox/lint
 deps =
   black~=22.0
 commands = black {posargs} '../rustworkx' '../tests' '../retworkx'
 
 [testenv:stubs]
 basepython = python3
-envdir = .tox/stubs
 deps =
   mypy==1.0.1
 commands = python -m mypy.stubtest --concise --ignore-missing-stub rustworkx.rustworkx


### PR DESCRIPTION
Tox 4.0.0 was released in December 2022 [1] and was a major rewrite of the internals of the package that included numerous backwards incompatible changes [2]. Along with that major rewrite was a long period of instability in the package with a flurry of 47 releases [3] since 4.0.0 (which has only been 3-4 months). At the time of the 4.0.0 release we pinned the tox version in CI with #761 to avoid this instability as our tox configuration was not compatible with tox 4.x.y and tox was actually not compatible with how we had things configured more generally. The hope was that tox would stabilize more, fix the issues that plagued the tox 4 release series and we'd be able to relax that pin without requiring bumping our minimum tox version to ensure users could use either the old version or the new version locally. However, since #761 that hope hasn't been realized the divergence between tox 3 and tox 4 has only widened and at least personally I'm not convinced of an improvement in stability to the tox 4 release series. That being said however, this is becoming a developer pain as by default when setting up a new build environment pip will install the latest version of tox and we don't have an effective mechanism to pin the tox version for users as you need to install tox manually as it's the primary python development entrypoint we use. The only only avenue to address this would be documentation updates in the CONTRIBUTING.md file, which we didn't update at the time in #761 because it was meant to be a version temporary pin that has turned out to not be so temporary.

Since it's been >3 months since we first pinned the tox version and that pin was meant to be temporary this commit removes that pin and bumps our minimum supported tox version to be 4.4.0, which despite not being compatible with tox < 4 as we originally hoped, at least seems to work fine with install rustworkx after updating the configuration file. This should hopefully ease the onboarding experience for developers when working with rustworkx and trying to bootstrap a local development environment. Longer term I expect we'll look at moving off of tox, as it no longer seems like a project we can rely on (especially as a key component for our development and CI infrastructure) for rustworkx and instead look at something like `nox` which I've heard good things about and know that PyO3 had moved to it a year or two ago.

Fixes #812

[1] https://pypi.org/project/tox/4.0.0/
[2] https://tox.wiki/en/latest/upgrading.html
[3] https://pypi.org/project/tox/#history

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
