### PR TITLE
Pin qiskit_sphinx_theme version

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -5,7 +5,7 @@ jupyter-sphinx
 pydot
 pillow>=4.2.1
 reno>=3.4.0
-qiskit-sphinx-theme>=1.7
+qiskit-sphinx-theme==1.10.3
 matplotlib>=3.4
 sphinx-reredirects
 sphinxemoji


### PR DESCRIPTION
The recently released 1.11.x release series of the sphinx theme is incompatible with the customization we made to the templates for the theme to remove the top bar. The recommendation from the theme package maintainers was to just pin the theme version to the old version if the modifications are required. This should unblock the CI docs failure we've seen for the past couple of weeks which was caused by an incompatibility with our template files.

Longer term, I think we might want to migrate to a different theme package for the rustworkx docs. The direciton of the qiskit docs theme is to be more tightly coupled with the evolving Qiskit ecosystem which makes a lot of sense for the other consumers of the theme package. But for rustworkx we typically have tried to keep it independent as it's a base dependency for Qiskit, so selecting a different theme is probably the best path forward to avoid tension like this in the future.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
