### PR TITLE
Turn off CI for forks

### DIFF
--- a/.github/workflows/docs_dev.yml
+++ b/.github/workflows/docs_dev.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   deploy:
+    if: github.repository_owner == 'Qiskit'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build_lint:
+    if: github.repository_owner == 'Qiskit'
     name: Build, rustfmt, and python lint
     runs-on: ubuntu-latest
     steps:
@@ -49,6 +50,7 @@ jobs:
           name: rustworkx_core_docs
           path: target/doc/rustworkx_core
   tests:
+    if: github.repository_owner == 'Qiskit'
     needs: [build_lint]
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }} ${{ matrix.msrv }}
     runs-on: ${{ matrix.platform.os }}
@@ -87,6 +89,7 @@ jobs:
       - name: 'Run tests'
         run: tox -epy
   tests_stubs:
+    if: github.repository_owner == 'Qiskit'
     needs: [tests]
     name: python-stubs-${{ matrix.python-version }}
     runs-on: ubuntu-latest
@@ -107,6 +110,7 @@ jobs:
       - name: 'Run rustworkx stub tests'
         run: tox -estubs
   tests_retworkx_compat:
+    if: github.repository_owner == 'Qiskit'
     needs: [build_lint]
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }} ${{ matrix.msrv }}
     runs-on: ${{ matrix.platform.os }}
@@ -147,6 +151,7 @@ jobs:
           cd tests
           stestr run -t ./retworkx_backwards_compat
   coverage:
+    if: github.repository_owner == 'Qiskit'
     needs: [tests]
     name: Coverage
     runs-on: ubuntu-latest
@@ -189,6 +194,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: coveralls.info
   docs:
+    if: github.repository_owner == 'Qiskit'
     needs: [tests]
     name: Build Docs
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary

Most people agree that GitHub made a mistake by having forks run CI both on the fork and in the upstream repository. It wastes computing resources (which has a real environmental cost!).

If people really want to run CI in their fork, they can always modify their fork's config to revert this change.
