### PR TITLE
Add env variable to Python builds to force debug builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,11 @@ from setuptools import setup
 from setuptools_rust import Binding, RustExtension
 
 
+# If RUST_DEBUG is set, force compiling in debug mode. Else, use the default    behavior of whether
+# it's an editable installation.
+rust_debug = True if os.getenv("RUST_DEBUG") == "1" else None
+
+
 def readme():
     with open('README.md') as f:
         return f.read()
@@ -25,7 +30,7 @@ PKG_VERSION = "0.13.0"
 PKG_PACKAGES = ["rustworkx", "rustworkx.visualization"]
 PKG_INSTALL_REQUIRES = ['numpy>=1.16.0']
 RUST_EXTENSIONS = [RustExtension("rustworkx.rustworkx", "Cargo.toml",
-                                 binding=Binding.PyO3)]
+                                 binding=Binding.PyO3, debug=rust_debug)]
 
 retworkx_readme_compat = """# retworkx
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools_rust import Binding, RustExtension
 
 # If RUST_DEBUG is set, force compiling in debug mode. Else, use the default    behavior of whether
 # it's an editable installation.
-rust_debug = True if os.getenv("RUST_DEBUG") == "1" else None
+rustworkx_debug = True if os.getenv("RUSTWORKX_DEBUG") == "1" else None
 
 
 def readme():
@@ -30,7 +30,7 @@ PKG_VERSION = "0.13.0"
 PKG_PACKAGES = ["rustworkx", "rustworkx.visualization"]
 PKG_INSTALL_REQUIRES = ['numpy>=1.16.0']
 RUST_EXTENSIONS = [RustExtension("rustworkx.rustworkx", "Cargo.toml",
-                                 binding=Binding.PyO3, debug=rust_debug)]
+                                 binding=Binding.PyO3, debug=rustworkx_debug)]
 
 retworkx_readme_compat = """# retworkx
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ setenv =
   LANGUAGE=en_US
   LC_ALL=en_US.utf-8
   ARGS="-V"
+  RUST_DEBUG=1
 deps =
   setuptools-rust
   fixtures
@@ -22,6 +23,7 @@ extras =
 passenv =
   RETWORKX_TEST_PRESERVE_IMAGES
   RUSTWORKX_PKG_NAME
+  RUST_DEBUG
 changedir = {toxinidir}/tests
 commands =
   stestr run {posargs}
@@ -43,12 +45,14 @@ commands =
 basepython = python3
 setenv =
   {[testenv]setenv}
+  RUST_DEBUG=1
 deps =
   -r {toxinidir}/docs/source/requirements.txt
 passenv =
   {[testenv]passenv}
   RETWORKX_DEV_DOCS
   RETWORKX_LEGACY_DOCS
+  RUST_DEBUG
 changedir = {toxinidir}/docs
 commands =
   python -m ipykernel install --user

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ extras =
 passenv =
   RETWORKX_TEST_PRESERVE_IMAGES
   RUSTWORKX_PKG_NAME
-  RUST_DEBUG
+  RUSTWORKX_DEBUG
 changedir = {toxinidir}/tests
 commands =
   stestr run {posargs}
@@ -45,7 +45,7 @@ commands =
 basepython = python3
 setenv =
   {[testenv]setenv}
-  RUST_DEBUG=1
+  RUSTWORKX_DEBUG=1
 deps =
   -r {toxinidir}/docs/source/requirements.txt
 passenv =


### PR DESCRIPTION
This commit updates the setup.py for the python package to add a new env variable `RUST_DEBUG` to force the package to be built in debug mode. By default pip install will build the rust code in release mode, which is the sane default you want for publishing or installing a package. But for local development you typically want to build normally in debug mode. This increases the build speed and also adds additional runtime checking to validate the code is fully working. The tradeoff with this though is the runtime is very poor because the compiler doesn't do any optimization.

As part of this commit the tox configuration is updated to default to debug builds. For unit tests the execution time is unchanged, because while it compiles faster that is offset by the slower execution of the tests. However, in general I think it's better to run tests in debug mode by default because it will do runtime validation (e.g. bounds checks overflow detection, etc) which is good to catch in testing.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
