### PR TITLE
Switch to new documentation links to avoid a redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Zenodo](https://img.shields.io/badge/Zenodo-10.5281%2Fzenodo.5879859-blue)](https://doi.org/10.5281/zenodo.5879859)
 
   - You can see the full rendered docs at:
-    <https://qiskit.org/documentation/rustworkx/dev>
+    <https://qiskit.org/ecosystem/rustworkx/dev>
 
 |:warning:| The retworkx project has been renamed to **rustworkx**. The use of the
 retworkx package will still work for the time being but starting in the 1.0.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -126,8 +126,8 @@ with open("sources.txt", "r") as fd:
         redirects[f"stubs/{source_str}"] = f"../apiref/{source_str}"
 
 if os.getenv("RETWORKX_LEGACY_DOCS", None) is not None:
-    redirects["*"] = "https://qiskit.org/documentation/rustworkx/$source.html"
-    html_baseurl = "https://qiskit.org/documentation/rustworkx/"
+    redirects["*"] = "https://qiskit.org/ecosystem/rustworkx/$source.html"
+    html_baseurl = "https://qiskit.org/ecosystem/rustworkx/"
 
 
 # Version extensions

--- a/rustworkx-core/src/lib.rs
+++ b/rustworkx-core/src/lib.rs
@@ -59,7 +59,7 @@
 //! The release notes for rustworkx-core are included as part of the rustworkx
 //! documentation which is hosted at:
 //!
-//! <https://qiskit.org/documentation/rustworkx/release_notes.html>
+//! <https://qiskit.org/ecosystem/rustworkx/release_notes.html>
 
 use std::convert::Infallible;
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     project_urls={
         "Bug Tracker": "https://github.com/Qiskit/rustworkx/issues",
         "Source Code": "https://github.com/Qiskit/rustworkx",
-        "Documentation": "https://qiskit.org/documentation/rustworkx",
+        "Documentation": "https://qiskit.org/ecosystem/rustworkx/",
     },
     rust_extensions=RUST_EXTENSIONS,
     include_package_data=True,


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

#873 reminded me of this. It is a minor change but it saves a redirect 