### PR TITLE
Apply wheel job fixes from 0.13.0 release

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -67,7 +67,7 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
           CIBW_SKIP: cp36-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
-          CIBW_TEST_REQUIRES: networkx scipy testtools fixtures
+          CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
       - uses: actions/upload-artifact@v3
         with:
@@ -92,7 +92,7 @@ jobs:
           python-version: '3.7'
       - uses: dtolnay/rust-toolchain@stable
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: all
       - name: Install cibuildwheel
@@ -135,7 +135,7 @@ jobs:
           python-version: '3.7'
       - uses: dtolnay/rust-toolchain@stable
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: all
       - name: Install cibuildwheel
@@ -150,7 +150,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
-          CIBW_SKIP: cp36-* cp39-* cp310-* pp* *win32 *musl*
+          CIBW_SKIP: cp36-* cp39-* cp310-* cp311-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
@@ -178,7 +178,7 @@ jobs:
           python-version: '3.7'
       - uses: dtolnay/rust-toolchain@stable
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: all
       - name: Install cibuildwheel
@@ -221,7 +221,7 @@ jobs:
           python-version: '3.7'
       - uses: dtolnay/rust-toolchain@stable
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: all
       - name: Install cibuildwheel
@@ -236,11 +236,12 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
-          CIBW_SKIP: cp36-* cp39-* cp310-* pp* *win32 *musl*
+          CIBW_SKIP: cp36-* cp39-* cp310-* cp311-* pp* *win32 *musl*
           CIBW_BEFORE_BUILD: pip install -U setuptools-rust
           CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
           CIBW_ARCHS_LINUX: s390x
+          CIBW_TEST_SKIP: "*-*linux_s390x"
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
@@ -264,7 +265,7 @@ jobs:
           python-version: '3.7'
       - uses: dtolnay/rust-toolchain@stable
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: all
       - name: Install cibuildwheel
@@ -284,6 +285,7 @@ jobs:
           CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
           CIBW_ARCHS_LINUX: s390x
+          CIBW_TEST_SKIP: "*-*linux_s390x"
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
@@ -294,7 +296,7 @@ jobs:
           TWINE_USERNAME: retworkx-ci
   build-mac-arm-wheels:
     name: Build wheels on macos for arm and universal2
-    runs-on: macos-10.15
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - name: Build wheels
@@ -365,7 +367,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install deps
-        run: pip install -U twine setuptools-rust
+        run: pip install -U twine setuptools-rust wheel build
       - name: Build sdist
         run: python setup.py bdist_wheel
         env:

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -71,23 +71,23 @@ source.
    * - Linux
      - x86_64
      - :ref:`tier-1`
-     - Distributions compatible with the `manylinux 2014 <https://peps.python.org/pep-0599/>`__ packaging specification
+     - Distributions compatible with the `manylinux 2014`_ packaging specification
    * - Linux
      - i686 
      - :ref:`tier-2` (Python < 3.10), :ref:`tier-3` (Python >= 3.10)
-     - Distributions compatible with the `manylinux 2014 <https://peps.python.org/pep-0599/>`__ packaging specification
+     - Distributions compatible with the `manylinux 2014`_ packaging specification
    * - Linux
      - aarch64
      - :ref:`tier-2`
-     - Distributions compatible with the `manylinux 2014 <https://peps.python.org/pep-0599/`__ packaging specification
+     - Distributions compatible with the `manylinux 2014`_ packaging specification
    * - Linux
      - pp64le
      - :ref:`tier-3`
-     - Distributions compatible with the `manylinux 2014 <https://peps.python.org/pep-0599/>`__ packaging specification
+     - Distributions compatible with the `manylinux 2014`_ packaging specification
    * - Linux
      - s390x
      - :ref:`tier-4`
-     - Distributions compatible with the `manylinux 2014 <https://peps.python.org/pep-0599/>`__ packaging specification
+     - Distributions compatible with the `manylinux 2014`_ packaging specification
    * - macOS (10.9 or newer)
      - x86_64
      - :ref:`tier-1`
@@ -104,6 +104,9 @@ source.
      - i686 or x86_64
      - :ref:`tier-2` (Python < 3.10), :ref:`tier-3` (Python >= 3.10)
      -
+
+
+.. _manylinux 2014: https://peps.python.org/pep-0599/>
 
 .. _tier-1:
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -10,8 +10,8 @@ Installing Rustworkx
 ====================
 
 rustworkx is published on pypi so on x86_64, i686, ppc64le, s390x, and aarch64
-Linux systems, x86_64 on Mac OSX, and 32 and 64 bit Windows installing is as
-simple as running::
+Linux systems, x86_64 and arm64 on macOS, and 32 and 64 bit Windows
+installing is as simple as running::
 
     pip install rustworkx
 
@@ -71,28 +71,28 @@ source.
    * - Linux
      - x86_64
      - :ref:`tier-1`
-     - Distributions compatible with the [manylinux 2014](https://peps.python.org/pep-0599/) packaging specification
+     - Distributions compatible with the `manylinux 2014 <https://peps.python.org/pep-0599/>`__ packaging specification
    * - Linux
      - i686 
      - :ref:`tier-2` (Python < 3.10), :ref:`tier-3` (Python >= 3.10)
-     - Distributions compatible with the [manylinux 2014](https://peps.python.org/pep-0599/) packaging specification
+     - Distributions compatible with the `manylinux 2014 <https://peps.python.org/pep-0599/>`__ packaging specification
    * - Linux
      - aarch64
      - :ref:`tier-2`
-     - Distributions compatible with the [manylinux 2014](https://peps.python.org/pep-0599/) packaging specification
+     - Distributions compatible with the `manylinux 2014 <https://peps.python.org/pep-0599/`__ packaging specification
    * - Linux
      - pp64le
      - :ref:`tier-3`
-     - Distributions compatible with the [manylinux 2014](https://peps.python.org/pep-0599/) packaging specification
+     - Distributions compatible with the `manylinux 2014 <https://peps.python.org/pep-0599/>`__ packaging specification
    * - Linux
      - s390x
-     - :ref:`tier-3`
-     - Distributions compatible with the [manylinux 2014](https://peps.python.org/pep-0599/) packaging specification
+     - :ref:`tier-4`
+     - Distributions compatible with the `manylinux 2014 <https://peps.python.org/pep-0599/>`__ packaging specification
    * - macOS (10.9 or newer)
      - x86_64
      - :ref:`tier-1`
      -
-   * - macOS (10.15 or newer)
+   * - macOS (11 or newer)
      - arm64
      - :ref:`tier-4`
      -

--- a/releasenotes/notes/s390x-tier-4-1701a0f044759cd1.yaml
+++ b/releasenotes/notes/s390x-tier-4-1701a0f044759cd1.yaml
@@ -5,7 +5,7 @@ upgrade:
     documented in :ref:`platform-suppport`). This is a result of no longer being
     able to run tests during the pre-compiled wheel publishing jobs due to
     constraints in the available CI infrastructure. There hopefully shouldn't 
-    be any meaningful impact resulting from this change, but as we're no longer tests being
+    be any meaningful impact resulting from this change, but as there are no longer tests being
     run to validate the binaries prior to publishing them there are no longer
     guarantees that the wheels for s390x are fully functional (although the
     likelihood they are is still high as it works on other platforms). If any

--- a/releasenotes/notes/s390x-tier-4-1701a0f044759cd1.yaml
+++ b/releasenotes/notes/s390x-tier-4-1701a0f044759cd1.yaml
@@ -1,0 +1,12 @@
+---
+upgrade:
+  - |
+    Support for the Linux s390x platform has changed from tier 3 to tier 4 (as
+    documented in :ref:`platform-suppport`). This is a result of no longer being
+    able to run tests during the pre-compiled wheel publishing jobs due to
+    constraints in the available CI infrastructure. There hopefully shouldn't 
+    be a change resulting from this change, but as we're no longer tests being
+    run to validate the binaries prior to publishing them there are no longer
+    guarantees that the wheels for s390x are fully functional (although the
+    likelihood they are is still high as it works on other platforms). If any
+    issues are encountered with s390x Linux please open an issue.

--- a/releasenotes/notes/s390x-tier-4-1701a0f044759cd1.yaml
+++ b/releasenotes/notes/s390x-tier-4-1701a0f044759cd1.yaml
@@ -5,7 +5,7 @@ upgrade:
     documented in :ref:`platform-suppport`). This is a result of no longer being
     able to run tests during the pre-compiled wheel publishing jobs due to
     constraints in the available CI infrastructure. There hopefully shouldn't 
-    be a change resulting from this change, but as we're no longer tests being
+    be any meaningful impact resulting from this change, but as we're no longer tests being
     run to validate the binaries prior to publishing them there are no longer
     guarantees that the wheels for s390x are fully functional (although the
     likelihood they are is still high as it works on other platforms). If any


### PR DESCRIPTION
This commit applies the various fixes needed to the wheel publishing job definitions for the 0.13.0 release. There were several jon errors during the release which were caused by various changes made to rustworkx, upstream dependencies, and CI environment since the 0.12.0 which caused issues during the release process. #753 should still be finished to simplify the job definitions, but that should be rebased to take this more targeted fix. The intent is for this to be a minimal diff for backporting to stable/0.13 for a future 0.13.1 release.

Of particular importance here though is the change in support tier for s390x from 3 to 4. This was caused by repeated issues with timeouts caused by running tests during the s390x linux wheel builds. To ensure we can reliably build the wheels this drops the testing from the s390x so that they can reliably complete in 12 job hours.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
