### PR TITLE
Add todo_nodes sort to maintain deterministic output in token_swapper

### DIFF
--- a/rustworkx-core/src/token_swapper.rs
+++ b/rustworkx-core/src/token_swapper.rs
@@ -23,6 +23,7 @@ use petgraph::visit::{
 };
 use petgraph::Directed;
 use petgraph::Direction::{Incoming, Outgoing};
+use rayon::prelude::*;
 use rayon_cond::CondIterator;
 
 use crate::connectivity::find_cycle;
@@ -127,10 +128,11 @@ where
             .collect();
 
         // todo_nodes are all the mapping entries where left != right
-        let todo_nodes: Vec<NodeIndex> = tokens
+        let mut todo_nodes: Vec<NodeIndex> = tokens
             .iter()
             .filter_map(|(node, dest)| if node != dest { Some(*node) } else { None })
             .collect();
+        todo_nodes.par_sort();
 
         // Add initial edges to the digraph/sub_digraph
         for node in self.graph.node_identifiers() {


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
This PR adds a sort to the `todo_nodes` Vec in `token_swapper` in order to maintain deterministic output when using a seed. This problem appeared when implementing https://github.com/Qiskit/qiskit-terra/pull/10001 and some of the tests produced correct, but random output.