### PR TITLE
Pin Python version in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,13 +82,13 @@ jobs:
         with:
           python-version: 3.7
           architecture: ${{ matrix.platform.python-architecture }}
-        if: runner.os == 'Windows' && ${{ matrix.python-version }} == "3.7.16"
+        if: ${{ runner.os == 'Windows' && matrix.python-version == '3.7.16' }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.platform.python-architecture }}
-        if: runner.os == 'Windows' && ${{ matrix.python-version }} != '3.7.16'
+        if: ${{ runner.os == 'Windows' && matrix.python-version != '3.7.16' }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         rust: [stable]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: ['3.7.16', 3.8, 3.9, "3.10", "3.11"]
         platform: [
           { os: "macOS-latest", python-architecture: "x64", rust-target: "x86_64-apple-darwin" },
           { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" },

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,19 +76,19 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.platform.python-architecture }}
-        if: runner.os != 'windows'
+        if: runner.os != 'Windows'
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: 3.7
           architecture: ${{ matrix.platform.python-architecture }}
-        if: runner.os == 'windows' && ${{ matrix.python-version }} == "3.7.16"
+        if: runner.os == 'Windows' && ${{ matrix.python-version }} == "3.7.16"
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.platform.python-architecture }}
-        if: runner.os == 'windows' && ${{ matrix.python-version }} != '3.7.16'
+        if: runner.os == 'Windows' && ${{ matrix.python-version }} != '3.7.16'
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,20 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.platform.python-architecture }}
+        if: runner.os != 'windows'
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+          architecture: ${{ matrix.platform.python-architecture }}
+        if: runner.os == 'windows' && ${{ matrix.python-version }} == "3.7.16"
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.platform.python-architecture }}
+        if: runner.os == 'windows' && ${{ matrix.python-version }} != '3.7.16'
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:


### PR DESCRIPTION
Recently github updated the cached version of python installed for 3.7 in the CI environment to 3.7.17. This new binary was not built with bz2 support which is causing failures in our CI jobs that run with 3.7. While we'll be dropping 3.7 support from the main branch (for 0.14.0) in the near future we still support 3.7 on the stable 0.13.x series. This commit pins the python version to the previous patch release which was known to work.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
