### PR TITLE
[WIP] Migrate steiner_tree() and metric_closure() to rustworkx-core

### DIFF
--- a/rustworkx-core/src/lib.rs
+++ b/rustworkx-core/src/lib.rs
@@ -89,6 +89,8 @@ mod min_scored;
 pub mod token_swapper;
 pub mod utils;
 
+pub mod steiner_tree;
+
 // re-export petgraph so there is a consistent version available to users and
 // then only need to require rustworkx-core in their dependencies
 pub use petgraph;

--- a/rustworkx-core/src/steiner_tree.rs
+++ b/rustworkx-core/src/steiner_tree.rs
@@ -3,6 +3,7 @@ use petgraph::stable_graph::{NodeIndex, StableGraph};
 use petgraph::visit::NodeIndexable;
 use petgraph::visit::{EdgeRef, GraphBase, IntoEdgeReferences};
 use petgraph::Directed;
+use rayon::prelude::ParallelSliceMut;
 use std::cmp::Ordering;
 
 use crate::petgraph::unionfind::UnionFind;

--- a/rustworkx-core/src/steiner_tree.rs
+++ b/rustworkx-core/src/steiner_tree.rs
@@ -1,0 +1,55 @@
+use hashbrown::HashMap;
+use petgraph::stable_graph::{NodeIndex, StableGraph};
+use petgraph::visit::{EdgeRef, GraphBase, IntoEdgeReferences};
+use petgraph::Directed;
+use std::cmp::Ordering;
+
+fn deduplicate_edges<F, E, W>(
+    out_graph: &mut StableGraph<(), W, Directed>,
+    weight_fn: &mut F,
+) -> Result<(), E>
+where
+    W: Clone,
+    F: FnMut(&W) -> Result<f64, E>,
+{
+    //if out_graph.multigraph {
+    if true {
+        // Find all edges between nodes
+        let mut duplicate_map: HashMap<
+            [NodeIndex; 2],
+            Vec<(<StableGraph<(), W, Directed> as GraphBase>::EdgeId, W)>,
+        > = HashMap::new();
+        for edge in out_graph.edge_references() {
+            if duplicate_map.contains_key(&[edge.source(), edge.target()]) {
+                duplicate_map
+                    .get_mut(&[edge.source(), edge.target()])
+                    .unwrap()
+                    .push((edge.id(), edge.weight().clone()));
+            } else if duplicate_map.contains_key(&[edge.target(), edge.source()]) {
+                duplicate_map
+                    .get_mut(&[edge.target(), edge.source()])
+                    .unwrap()
+                    .push((edge.id(), edge.weight().clone()));
+            } else {
+                duplicate_map.insert(
+                    [edge.source(), edge.target()],
+                    vec![(edge.id(), edge.weight().clone())],
+                );
+            }
+        }
+        // For a node pair with > 1 edge find minimum edge and remove others
+        for edges_raw in duplicate_map.values().filter(|x| x.len() > 1) {
+            let mut edges: Vec<(<StableGraph<(), W, Directed> as GraphBase>::EdgeId, f64)> =
+                Vec::with_capacity(edges_raw.len());
+            for edge in edges_raw {
+                let w = weight_fn(&edge.1)?;
+                edges.push((edge.0, w));
+            }
+            edges.sort_unstable_by(|a, b| (a.1).partial_cmp(&b.1).unwrap_or(Ordering::Less));
+            edges[1..].iter().for_each(|x| {
+                out_graph.remove_edge(x.0);
+            });
+        }
+    }
+    Ok(())
+}

--- a/rustworkx-core/src/steiner_tree.rs
+++ b/rustworkx-core/src/steiner_tree.rs
@@ -4,6 +4,14 @@ use petgraph::visit::{EdgeRef, GraphBase, IntoEdgeReferences};
 use petgraph::Directed;
 use std::cmp::Ordering;
 
+struct MetricClosureEdge {
+    source: usize,
+    target: usize,
+    distance: f64,
+    path: Vec<usize>,
+}
+
+
 fn deduplicate_edges<F, E, W>(
     out_graph: &mut StableGraph<(), W, Directed>,
     weight_fn: &mut F,

--- a/rustworkx-core/src/steiner_tree.rs
+++ b/rustworkx-core/src/steiner_tree.rs
@@ -11,6 +11,19 @@ struct MetricClosureEdge {
     path: Vec<usize>,
 }
 
+fn _metric_closure_edges<F, E, W>(
+    graph: &StableGraph<(), W, Directed>,
+    weight_fn: &mut F,
+) -> Result<Vec<MetricClosureEdge>, E> {
+    let node_count = graph.node_count();
+    if node_count == 0 {
+        return Ok(Vec::new());
+    }
+    // TODO implemented
+    panic!("not implemented");
+}
+
+
 
 fn deduplicate_edges<F, E, W>(
     out_graph: &mut StableGraph<(), W, Directed>,

--- a/rustworkx-core/src/steiner_tree.rs
+++ b/rustworkx-core/src/steiner_tree.rs
@@ -1,8 +1,11 @@
 use hashbrown::HashMap;
 use petgraph::stable_graph::{NodeIndex, StableGraph};
+use petgraph::visit::NodeIndexable;
 use petgraph::visit::{EdgeRef, GraphBase, IntoEdgeReferences};
 use petgraph::Directed;
 use std::cmp::Ordering;
+
+use crate::petgraph::unionfind::UnionFind;
 
 struct MetricClosureEdge {
     source: usize,
@@ -10,6 +13,7 @@ struct MetricClosureEdge {
     distance: f64,
     path: Vec<usize>,
 }
+
 /// Return the metric closure of a graph
 ///
 /// The metric closure of a graph is the complete graph in which each edge is
@@ -56,6 +60,25 @@ fn _metric_closure_edges<F, E, W>(
     panic!("not implemented");
 }
 
+/// Computes the shortest path between all pairs `(s, t)` of the given `terminal_nodes`
+/// *provided* that:
+///   - there is an edge `(u, v)` in the graph and path pass through this edge.
+///   - node `s` is the closest node to  `u` among all `terminal_nodes`
+///   - node `t` is the closest node to `v` among all `terminal_nodes`
+/// and wraps the result inside a `MetricClosureEdge`
+///
+/// For example, if all vertices are terminals, it returns the original edges of the graph.
+fn fast_metric_edges<F, E, W>(
+    graph: &mut StableGraph<(), W, Directed>,
+    terminal_nodes: Vec<usize>,
+    weight_fn: &mut F,
+) -> Result<Vec<MetricClosureEdge>, E>
+where
+    W: Clone,
+    F: FnMut(&W) -> Result<f64, E>,
+{
+    Ok(Vec::new())
+}
 
 
 fn deduplicate_edges<F, E, W>(

--- a/rustworkx-core/src/steiner_tree.rs
+++ b/rustworkx-core/src/steiner_tree.rs
@@ -10,6 +10,39 @@ struct MetricClosureEdge {
     distance: f64,
     path: Vec<usize>,
 }
+/// Return the metric closure of a graph
+///
+/// The metric closure of a graph is the complete graph in which each edge is
+/// weighted by the shortest path distance between the nodes in the graph.
+///
+/// :param PyGraph graph: The input graph to find the metric closure for
+/// :param weight_fn: A callable object that will be passed an edge's
+///     weight/data payload and expected to return a ``float``. For example,
+///     you can use ``weight_fn=float`` to cast every weight as a float
+///
+/// :return: A metric closure graph from the input graph
+/// :rtype: PyGraph
+/// :raises ValueError: when an edge weight with NaN or negative value
+///     is provided.
+pub fn metric_closure<F, E, W>(
+    graph: &StableGraph<(), W, Directed>,
+    weight_fn: &mut F,
+) -> Result<StableGraph<(), W, Directed>, E>
+where
+    W: Clone,
+{
+    let mut out_graph: StableGraph<(), W, Directed> = graph.clone();
+    out_graph.clear_edges();
+    // let edges = _metric_closure_edges(graph, weight_fn)?;
+    //for edge in edges {
+    //   out_graph.add_edge(
+    //      NodeIndex::new(edge.source),
+    //     NodeIndex::new(edge.target),
+    //    edge.distance,
+    //);
+    //}
+    Ok(out_graph)
+}
 
 fn _metric_closure_edges<F, E, W>(
     graph: &StableGraph<(), W, Directed>,

--- a/rustworkx-core/src/steiner_tree.rs
+++ b/rustworkx-core/src/steiner_tree.rs
@@ -8,10 +8,10 @@ use std::cmp::Ordering;
 
 use crate::petgraph::unionfind::UnionFind;
 
-struct MetricClosureEdge {
+struct MetricClosureEdge<W> {
     source: usize,
     target: usize,
-    distance: f64,
+    distance: W,
     path: Vec<usize>,
 }
 
@@ -38,21 +38,21 @@ where
 {
     let mut out_graph: StableGraph<(), W, Directed> = graph.clone();
     out_graph.clear_edges();
-    // let edges = _metric_closure_edges(graph, weight_fn)?;
-    //for edge in edges {
-    //   out_graph.add_edge(
-    //      NodeIndex::new(edge.source),
-    //     NodeIndex::new(edge.target),
-    //    edge.distance,
-    //);
-    //}
+    let edges = _metric_closure_edges(graph, weight_fn)?;
+    for edge in edges {
+        out_graph.add_edge(
+            NodeIndex::new(edge.source),
+            NodeIndex::new(edge.target),
+            edge.distance,
+        );
+    }
     Ok(out_graph)
 }
 
 fn _metric_closure_edges<F, E, W>(
     graph: &StableGraph<(), W, Directed>,
     weight_fn: &mut F,
-) -> Result<Vec<MetricClosureEdge>, E> {
+) -> Result<Vec<MetricClosureEdge<W>>, E> {
     let node_count = graph.node_count();
     if node_count == 0 {
         return Ok(Vec::new());
@@ -73,7 +73,7 @@ fn fast_metric_edges<F, E, W>(
     graph: &mut StableGraph<(), W, Directed>,
     terminal_nodes: Vec<usize>,
     weight_fn: &mut F,
-) -> Result<Vec<MetricClosureEdge>, E>
+) -> Result<Vec<MetricClosureEdge<W>>, E>
 where
     W: Clone,
     F: FnMut(&W) -> Result<f64, E>,
@@ -137,7 +137,7 @@ where
         let weight_b = (b.distance, b.source, b.target);
         weight_a.partial_cmp(&weight_b).unwrap_or(Ordering::Less)
     });
-    Ok(())
+    Ok(out)
 }
 
 fn deduplicate_edges<F, E, W>(

--- a/rustworkx-core/src/steiner_tree.rs
+++ b/rustworkx-core/src/steiner_tree.rs
@@ -130,7 +130,7 @@ where
     W: Clone,
     F: FnMut(&W) -> Result<f64, E>,
 {
-    let mut edge_list = fast_metric_edges(graph, terminal_nodes, &mut weight_fn)?;
+    let mut edge_list = fast_metric_edges(graph, terminal_nodes, weight_fn)?;
     let mut subgraphs = UnionFind::<usize>::new(graph.node_bound());
     edge_list.par_sort_unstable_by(|a, b| {
         let weight_a = (a.distance, a.source, a.target);


### PR DESCRIPTION
I am implementing #769.
 
Addional dependency.
- all_pairs_dijkstra_shortest_paths @ [src/shortest_path/all_pairs_dijkstra.rs](https://github.com/Qiskit/rustworkx/blob/main/src/shortest_path/all_pairs_dijkstra.rs)
- 
- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
