### PR TITLE
Pin pillow<10 in CI

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,3 @@
 decorator==4.4.2
 importlib-metadata==4.13.0;python_version<'3.8'
+pillow<10.0.0


### PR DESCRIPTION
Since the recent release of Pillow 10.0.0 the docs CI job has started failing due to an error in Pillow when trying to run the jupyter-execute cell in the `.to_dot()` docstring. It looks like a bug that was introduced in the new release which is being tracked in python-pillow/Pillow#7259 where it's trying to return a jpeg representation of the object from the RGBA data loaded from a PNG. Until the issue is resolved upstream in pillow this commit just caps the version we run in CI via the constraints file. While pillow is an optional dependency and we could cap the version in the extras, this issue isn't severe enough to warrant that, and the typical pillow usage, especially via the rustworkx api (i.e. graphviz_draw() which returns a PIL.Image object) will continue to work as expected with pillow 10.0.0 there isn't a reason to cap more broadly. This is just needed as a workaround to unblock CI.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
