### PR TITLE
Relax constraints in rustworkx-core for hashbrown and indexmap

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,11 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.platform.rust-target }}
+      - name: 'Set msrv min versions'
+        run: |
+          cargo update -p hashbrown:0.12.3 --precise 0.12.3 --workspace
+          cargo update -p indexmap:0.9.3 --precise 1.9.3 --workspace
+        if: ${{ matrix.msrv == 'MSRV' }}
       - name: 'Install dependencies'
         run: python -m pip install --upgrade tox
       - name: 'Install binary dependencies'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
       - name: 'Set msrv min versions'
         run: |
           cargo update -p hashbrown:0.12.3 --precise 0.12.3 --workspace
-          cargo update -p indexmap:0.9.3 --precise 1.9.3 --workspace
+          cargo update -p indexmap:1.9.3 --precise 1.9.3 --workspace
         if: ${{ matrix.msrv == 'MSRV' }}
       - name: 'Install dependencies'
         run: python -m pip install --upgrade tox

--- a/rustworkx-core/Cargo.toml
+++ b/rustworkx-core/Cargo.toml
@@ -19,7 +19,7 @@ rand_pcg = "0.3.1"
 rayon = "1.6"
 num-traits = "0.2"
 priority-queue = "1.2"
-rayon-cond = "0.3"
+rayon-cond = "0.2"
 
 [dependencies.hashbrown]
 version = ">=0.12, <0.15"

--- a/rustworkx-core/Cargo.toml
+++ b/rustworkx-core/Cargo.toml
@@ -19,15 +19,12 @@ rand_pcg = "0.3.1"
 rayon = "1.6"
 num-traits = "0.2"
 priority-queue = "1.2"
-rayon-cond = "0.2"
+rayon-cond = "0.3"
 
 [dependencies.hashbrown]
-version = "0.12"
+version = ">=0.12, <0.15"
 features = ["rayon"]
 
 [dependencies.indexmap]
-version = "1.9"
+version = ">=1.9, < 3"
 features = ["rayon"]
-
-[dev-dependencies]
-rand = "0.8"


### PR DESCRIPTION
This commit updates the version constraints on the hashbrown and indexmap dependencies in rustworkx-core's dependency list. These 2 dependencies are used for I/O to rustworkx-core and we previously had our versions set to the highest version compatible with the msrv. However, for users of rustworkx-core with newer MSRVs this limited version support caused issues if they wanted to use a newer version of these library (which was compatible with their MSRV) as an input or output to rustworkx-core. For example, as described in #911 qiskit-terra was using hashbrown 0.13.x and had errors because the released version of rustworkx-core only was listed as compatible with hashbrown 0.12. This version mismatch meant that the hashbrown objects created in qiskit-terra were not recognized by rustworkx-core because of the version mismatch. This commit attempts to fix this issue by increasing the allowable range of versions to be greater than or equal to our previous fixed version and capped at the last known working version. This should enable users to set a fixed library version that they want even if it's newer and requires a higher MSRV.

This commit is for the stable/0.13 branch as the minimum version is lower on the stable branch as the MSRV for the 0.13.0 is much older than what we're using on the main branch now. A separate PR will be pushed up for main to update it there. This was done in reverse in the interest of ensuring we include this in 0.13.1 and the inevitable backport conflict if we started with main first.

Fixes #911

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
