### PR TITLE
Prepare 0.13.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,9 +414,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cffef52f74ec3b1a1baf295d9b8fcc3070327aefc39a6d00656b13c1d0b8885c"
+checksum = "ffb88ae05f306b4bfcde40ac4a51dc0b05936a9207a4b75b798c7729c4258a59"
 dependencies = [
  "cfg-if",
  "hashbrown",
@@ -435,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713eccf888fb05f1a96eb78c0dbc51907fee42b3377272dc902eb38985f418d5"
+checksum = "554db24f0b3c180a9c0b1268f91287ab3f17c162e15b54caaae5a6b3773396b0"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b2ecbdcfb01cbbf56e179ce969a048fd7305a66d4cdf3303e0da09d69afe4c3"
+checksum = "922ede8759e8600ad4da3195ae41259654b9c55da4f7eec84a0ccc7d067a70a4"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -455,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78fdc0899f2ea781c463679b20cb08af9247febc8d052de941951024cd8aea0"
+checksum = "8a5caec6a1dd355964a841fcbeeb1b89fe4146c87295573f94228911af3cc5a2"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60da7b84f1227c3e2fe7593505de274dcf4c8928b4e0a1c23d551a14e4e80a0f"
+checksum = "e0b78ccbb160db1556cdb6fd96c50334c5d4ec44dc5e0a968d0a1208fa0efa8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -589,7 +589,7 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustworkx"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "ahash 0.8.0",
  "fixedbitset",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "rustworkx-core"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "ahash 0.8.0",
  "fixedbitset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustworkx"
 description = "A python graph library implemented in Rust"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Matthew Treinish <mtreinish@kortar.org>"]
 license = "Apache-2.0"
 readme = "README.md"
@@ -33,10 +33,10 @@ ndarray-stats = "0.5.1"
 quick-xml = "0.28"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rustworkx-core = { path = "rustworkx-core", version = "=0.13.0" }
+rustworkx-core = { path = "rustworkx-core", version = "=0.13.1" }
 
 [dependencies.pyo3]
-version = "0.19.0"
+version = "0.19.1"
 features = ["extension-module", "hashbrown", "num-bigint", "num-complex", "indexmap"]
 
 [dependencies.hashbrown]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,9 +24,9 @@ copyright = '2021, rustworkx Contributors'
 docs_url_prefix = "ecosystem/rustworkx"
 
 # The short X.Y version.
-version = '0.13.0'
+version = '0.13.1'
 # The full version, including alpha/beta/rc tags.
-release = '0.13.0'
+release = '0.13.1'
 
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.autosummary',

--- a/releasenotes/notes/prepare-0.13.1-45317a1fda68b4ca.yaml
+++ b/releasenotes/notes/prepare-0.13.1-45317a1fda68b4ca.yaml
@@ -2,11 +2,23 @@
 prelude: >
     rustworkx 0.13.1 is a bugfix release, addressing some issues identified
     since the 0.13.0 release.
+fixes:
+  - |
+    Fixed a potential soure of non-determinism in the output of the
+    ``token_swapper()`` function in rustworkx-core along with it's matching
+    function in the Python rustworkx package: :func:`~.graph_token_swapper`.
+  - |
+    Fixed the rustworkx-core dependencies to loosen the constraints on the
+    version of ``hashbrown`` and ``indexmap`` used. Previously, they were fixed
+    to the latest version which was compatible with rustworkx's MSRV. This has
+    been updated so a range of versions can be used, which will enable users
+    that don't have as restrictive of an MSRV to use newer versions of these
+    libraries with rustworkx-core.
 issues:
   - |
     The type hint stub files included in this release (and 0.13.0) are not
     compatible with Python 3.7's type hinting syntax. If you are now using
-    `mypy` to partially validate the typing in your usage of rustworkx, you
+    ``mypy`` to partially validate the typing in your usage of rustworkx, you
     should not run this with Python 3.7 as it will not function correctly.
     The actual rustworkx code will continue to function as expected with
     Python 3.7 for the 0.13.x release series, it was just the typing syntax

--- a/releasenotes/notes/prepare-0.13.1-45317a1fda68b4ca.yaml
+++ b/releasenotes/notes/prepare-0.13.1-45317a1fda68b4ca.yaml
@@ -4,8 +4,8 @@ prelude: >
     since the 0.13.0 release.
 fixes:
   - |
-    Fixed a potential soure of non-determinism in the output of the
-    ``token_swapper()`` function in rustworkx-core along with it's matching
+    Fixed a potential source of non-determinism in the output of the
+    ``token_swapper()`` function in rustworkx-core along with its matching
     function in the Python rustworkx package: :func:`~.graph_token_swapper`.
   - |
     Fixed the rustworkx-core dependencies to loosen the constraints on the

--- a/releasenotes/notes/prepare-0.13.1-45317a1fda68b4ca.yaml
+++ b/releasenotes/notes/prepare-0.13.1-45317a1fda68b4ca.yaml
@@ -1,0 +1,13 @@
+---
+prelude: >
+    rustworkx 0.13.1 is a bugfix release, addressing some issues identified
+    since the 0.13.0 release.
+issues:
+  - |
+    The type hint stub files included in this release (and 0.13.0) are not
+    compatible with Python 3.7's type hinting syntax. If you are now using
+    `mypy` to partially validate the typing in your usage of rustworkx, you
+    should not run this with Python 3.7 as it will not function correctly.
+    The actual rustworkx code will continue to function as expected with
+    Python 3.7 for the 0.13.x release series, it was just the typing syntax
+    used in the stubs files which are incompatible with Python 3.7.

--- a/rustworkx-core/Cargo.toml
+++ b/rustworkx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustworkx-core"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 authors = ["Matthew Treinish <mtreinish@kortar.org>"]
 description = "Rust APIs used for rustworkx algorithms"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ mpl_extras = ['matplotlib>=3.0']
 graphviz_extras = ['pillow>=5.4']
 
 PKG_NAME = os.getenv('RUSTWORKX_PKG_NAME', "rustworkx")
-PKG_VERSION = "0.13.0"
+PKG_VERSION = "0.13.1"
 PKG_PACKAGES = ["rustworkx", "rustworkx.visualization"]
 PKG_INSTALL_REQUIRES = ['numpy>=1.16.0']
 RUST_EXTENSIONS = [RustExtension("rustworkx.rustworkx", "Cargo.toml",


### PR DESCRIPTION
This commit prepares the 0.13.1 release, this consists of bumping the version number to 0.13.1 in all the appropriate files. It also adds a prelude release note to provide a brief introduction to the release. When this commit merges it should be tagged as the 0.13.1 release.

Closes #893

TODO:

- [x] Wait for last backport PRs to merge (#941 and #940)
- [x] Review backported release notes and make edits

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
