### PR TITLE
Add a section to Python docs about page for rustworkx-core

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,10 +38,10 @@ to install rustworkx.
 rustworkx-core
 --------------
 
-In addition to the Python library as part of rustworkx a standalone Rust library
+In addition to the Python library, as part of rustworkx a standalone Rust library
 is also included. This library provides a generic interface for Rust users
 that wish to use the same graph algorithm implementations exposed in the Python
-library. This library, rustworkx-core, is used to build rustworkx the Python
+library. This library, rustworkx-core, is used to build the Python rustworkx
 library but can be used for any Rust application that needs the same graph
 functionality that rustworkx provides.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,7 +4,7 @@ rustworkx Documentation
 
 .. note::
 
-    The project has been renamed to **rustworkx**. You can still use the legavcy
+    The project has been renamed to **rustworkx**. You can still use the legacy
     retworkx name for now but starting in the 1.0.0 release the retworkx name
     will no longer be supported.
 
@@ -34,6 +34,25 @@ pre-compiled binaries for Linux on x86, x86_64, aarch64, s390x, and ppc64le,
 MacOS on x86_64, and arm64, and Windows 32bit and 64bit systems. However, if
 you are not running on one of these platforms, you will need a rust compiler
 to install rustworkx.
+
+rustworkx-core
+--------------
+
+In addition to the Python library as part of rustworkx a standalone Rust library
+is also included. This library provides a generic interface for Rust users
+that wish to use the same graph algorithm implementations exposed in the Python
+library. This library, rustworkx-core, is used to build rustworkx the Python
+library but can be used for any Rust application that needs the same graph
+functionality that rustworkx provides.
+
+You can find more details on rustworkx-core here:
+
+https://crates.io/crates/rustworkx-core
+
+and the documentation for the library is hosted here:
+
+https://docs.rs/rustworkx-core/0.13.0/rustworkx_core/
+
 
 Project history
 ---------------

--- a/rustworkx-core/README.md
+++ b/rustworkx-core/README.md
@@ -7,7 +7,12 @@
 > If you're using retworkx-core 0.11.0 you will need to change your requirement
 > and use statements to use the new crate name
 
-This crate contains the rust library rustworkx-core. This library is part of the
+rustworkx-core is a graph algorithm library that is built on top of
+[petgraph](https://github.com/petgraph/petgraph). It offers additional
+algorithms and functionality on top of the core data structures offered in
+the petgraph library.
+
+This crate contains the Rust library rustworkx-core. This library is part of the
 rustworkx project. However while the larger rustworkx project is a Python library
 that offers a general purpose high performance graph library written in Rust,
 rustworkx-core is a pure rust library that offers a stable rust API for any
@@ -18,7 +23,7 @@ At it's core rustworkx is built on top of the
 Python layer. However, many of the algorithms (and to a lesser extent data
 structures) needed for rustworkx are not available in petgraph. For places
 where these algorithms are implemented in a generic way the rustworkx-core
-crate exposes it for rust users.
+crate exposes it for Rust users.
 
 ## Usage
 


### PR DESCRIPTION
The main page explaining the rustworkx library in the Python docs previously didn't make any mention of rustworkx-core. While in general the Python side is built on top of rustworkx-core and the vast majority of the users of the Python library don't need to know about the pure Rust library inside, it is still good to highlight its existence in case anyone finds the Python library but is really interested in consuming it from Rust. This commit just adds a small subsection to the about page explaining the existence of rustworkx-core, its purpose, and where you can find mroe information about it.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
