### PR TITLE
Has path

### DIFF
--- a/releasenotes/notes/has_path-1addf94c4d29d455.yaml
+++ b/releasenotes/notes/has_path-1addf94c4d29d455.yaml
@@ -1,0 +1,23 @@
+---
+features:
+  - |
+    Added functions :func:`~rustworkx.has_path` which accepts as arguments a :class:`~rustworkx.PyGraph` or :class:`~rustworkx.PyDiGraph`
+    in addition to a source and target node index. The fucntion returns True if a path is found using :func:`~rustworkx.dijkstra_shortest_paths`
+    and False if not. For example,
+
+    .. jupyter-execute::
+    
+        from rustworkx import PyDiGraph, has_path
+
+        graph = PyGraph()
+        a = graph.add_node("A")
+        b = graph.add_node("B")
+        c = graph.add_node("C")
+        edge_list = [(a, b, 1), (b, c, 1)]
+        graph.add_edges_from(edge_list)
+
+        path_exists = rustworkx.has_path(graph, a, c)
+        assert(path_exists == True)
+
+        path_exists = rustworkx.has_path(graph, c, a)
+        assert(path_exists == False)

--- a/releasenotes/notes/has_path-1addf94c4d29d455.yaml
+++ b/releasenotes/notes/has_path-1addf94c4d29d455.yaml
@@ -1,9 +1,7 @@
 ---
 features:
   - |
-    Added functions :func:`~rustworkx.has_path` which accepts as arguments a :class:`~rustworkx.PyGraph` or :class:`~rustworkx.PyDiGraph`
-    in addition to a source and target node index. The fucntion returns True if a path is found using :func:`~rustworkx.dijkstra_shortest_paths`
-    and False if not. For example,
+    Added :func:`~rustworkx.has_path` which accepts as arguments a :class:`~rustworkx.PyGraph` or :class:`~rustworkx.PyDiGraph` and checks if there is a path from source to destination
 
     .. jupyter-execute::
     

--- a/releasenotes/notes/has_path-1addf94c4d29d455.yaml
+++ b/releasenotes/notes/has_path-1addf94c4d29d455.yaml
@@ -9,15 +9,15 @@ features:
     
         from rustworkx import PyDiGraph, has_path
 
-        graph = PyGraph()
+        graph = PyDiGraph()
         a = graph.add_node("A")
         b = graph.add_node("B")
         c = graph.add_node("C")
         edge_list = [(a, b, 1), (b, c, 1)]
         graph.add_edges_from(edge_list)
 
-        path_exists = rustworkx.has_path(graph, a, c)
+        path_exists = has_path(graph, a, c)
         assert(path_exists == True)
 
-        path_exists = rustworkx.has_path(graph, c, a)
+        path_exists = has_path(graph, c, a)
         assert(path_exists == False)

--- a/rustworkx/__init__.py
+++ b/rustworkx/__init__.py
@@ -586,6 +586,45 @@ def _graph_dijkstra_shortest_path(graph, source, target=None, weight_fn=None, de
         default_weight=default_weight,
     )
 
+@functools.singledispatch
+def has_path(
+    graph,
+    source,
+    target,
+    as_undirected=False,
+):
+    """Checks if a path exists between a source and target node using Dijkstra's algorithm
+
+    :param graph: The input graph to use. Can either be a
+        :class:`~rustworkx.PyGraph` or :class:`~rustworkx.PyDiGraph`
+    :param int source: The node index to find paths from
+    :param int target: The index of the target node 
+    :param bool as_undirected: If set to true the graph will be treated as
+        undirected for finding existence of a path. This only works with a
+        :class:`~rustworkx.PyDiGraph` input for ``graph``
+
+    :return: True if a path exists, False if not
+    :rtype: bool
+    """
+    raise TypeError("Invalid Input Type %s for graph" % type(graph))
+    
+@has_path.register(PyDiGraph)
+def _digraph_has_path(graph, source, target, as_undirected=False):
+    return digraph_has_path(
+        graph,
+        source,
+        target=target,
+        as_undirected=as_undirected
+    )
+
+@has_path.register(PyGraph)
+def _graph_has_path(graph, source, target):
+    return graph_has_path(
+        graph,
+        source,
+        target=target,
+    )
+
 
 @functools.singledispatch
 def all_pairs_dijkstra_shortest_paths(graph, edge_cost_fn):

--- a/rustworkx/__init__.py
+++ b/rustworkx/__init__.py
@@ -594,7 +594,7 @@ def has_path(
     target,
     as_undirected=False,
 ):
-    """Checks if a path exists between a source and target node using Dijkstra's algorithm
+    """Checks if a path exists between a source and target node
 
     :param graph: The input graph to use. Can either be a
         :class:`~rustworkx.PyGraph` or :class:`~rustworkx.PyDiGraph`

--- a/rustworkx/__init__.py
+++ b/rustworkx/__init__.py
@@ -586,6 +586,7 @@ def _graph_dijkstra_shortest_path(graph, source, target=None, weight_fn=None, de
         default_weight=default_weight,
     )
 
+
 @functools.singledispatch
 def has_path(
     graph,
@@ -598,7 +599,7 @@ def has_path(
     :param graph: The input graph to use. Can either be a
         :class:`~rustworkx.PyGraph` or :class:`~rustworkx.PyDiGraph`
     :param int source: The node index to find paths from
-    :param int target: The index of the target node 
+    :param int target: The index of the target node
     :param bool as_undirected: If set to true the graph will be treated as
         undirected for finding existence of a path. This only works with a
         :class:`~rustworkx.PyDiGraph` input for ``graph``
@@ -607,23 +608,16 @@ def has_path(
     :rtype: bool
     """
     raise TypeError("Invalid Input Type %s for graph" % type(graph))
-    
+
+
 @has_path.register(PyDiGraph)
 def _digraph_has_path(graph, source, target, as_undirected=False):
-    return digraph_has_path(
-        graph,
-        source,
-        target=target,
-        as_undirected=as_undirected
-    )
+    return digraph_has_path(graph, source, target=target, as_undirected=as_undirected)
+
 
 @has_path.register(PyGraph)
 def _graph_has_path(graph, source, target):
-    return graph_has_path(
-        graph,
-        source,
-        target=target,
-    )
+    return graph_has_path(graph, source, target=target)
 
 
 @functools.singledispatch

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,6 +400,8 @@ fn rustworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(digraph_all_simple_paths))?;
     m.add_wrapped(wrap_pyfunction!(graph_dijkstra_shortest_paths))?;
     m.add_wrapped(wrap_pyfunction!(digraph_dijkstra_shortest_paths))?;
+    m.add_wrapped(wrap_pyfunction!(graph_has_path))?;
+    m.add_wrapped(wrap_pyfunction!(digraph_has_path))?;
     m.add_wrapped(wrap_pyfunction!(graph_dijkstra_shortest_path_lengths))?;
     m.add_wrapped(wrap_pyfunction!(digraph_dijkstra_shortest_path_lengths))?;
     m.add_wrapped(wrap_pyfunction!(graph_bellman_ford_shortest_paths))?;

--- a/src/shortest_path/mod.rs
+++ b/src/shortest_path/mod.rs
@@ -223,7 +223,7 @@ pub fn digraph_dijkstra_shortest_paths(
 /// :param int source: The node index to find paths from
 /// :param int target: The index of the target node
 /// :param bool as_undirected: If set to true the graph will be treated as
-///     undirected for finding the shortest path.
+///     undirected for finding a path
 ///
 /// :return: True if a path exists, False if not.
 /// :rtype: bool

--- a/src/shortest_path/mod.rs
+++ b/src/shortest_path/mod.rs
@@ -130,14 +130,7 @@ pub fn graph_has_path(
     source: usize,
     target: usize,
 ) -> PyResult<bool> {
-    let paths = graph_dijkstra_shortest_paths(
-        py, 
-        graph, 
-        source, 
-        Some(target), 
-        None, 
-        1.0,
-    )?;
+    let paths = graph_dijkstra_shortest_paths(py, graph, source, Some(target), None, 1.0)?;
 
     Ok(paths.paths.len() > 0)
 }
@@ -241,16 +234,9 @@ pub fn digraph_has_path(
     target: usize,
     as_undirected: bool,
 ) -> PyResult<bool> {
-    let paths = digraph_dijkstra_shortest_paths(
-        py, 
-        graph, 
-        source, 
-        Some(target), 
-        None,
-        1.0,
-        as_undirected,
-    )?;
-    
+    let paths =
+        digraph_dijkstra_shortest_paths(py, graph, source, Some(target), None, 1.0, as_undirected)?;
+
     Ok(paths.paths.len() > 0)
 }
 

--- a/src/shortest_path/mod.rs
+++ b/src/shortest_path/mod.rs
@@ -109,7 +109,7 @@ pub fn graph_dijkstra_shortest_paths(
     })
 }
 
-/// Check if a graph has a path between source and target nodes using Dijkstra's algorithm
+/// Check if a graph has a path between source and target nodes 
 ///
 /// :param PyGraph graph:
 /// :param int source: The node index to find paths from
@@ -210,7 +210,7 @@ pub fn digraph_dijkstra_shortest_paths(
     })
 }
 
-/// Check if a digraph has a path between source and target nodes using Dijkstra's algorithm
+/// Check if a digraph has a path between source and target nodes
 ///
 /// :param PyDiGraph graph:
 /// :param int source: The node index to find paths from

--- a/src/shortest_path/mod.rs
+++ b/src/shortest_path/mod.rs
@@ -109,7 +109,7 @@ pub fn graph_dijkstra_shortest_paths(
     })
 }
 
-/// Check if a graph has a path between source and target nodes 
+/// Check if a graph has a path between source and target nodes
 ///
 /// :param PyGraph graph:
 /// :param int source: The node index to find paths from

--- a/src/shortest_path/mod.rs
+++ b/src/shortest_path/mod.rs
@@ -109,6 +109,39 @@ pub fn graph_dijkstra_shortest_paths(
     })
 }
 
+/// Check if a graph has a path between source and target nodes using Dijkstra's algorithm
+///
+/// :param PyGraph graph:
+/// :param int source: The node index to find paths from
+/// :param int target: The index of the target node
+///
+/// :return: True if a path exists, False if not.
+/// :rtype: bool
+/// :raises ValueError: when an edge weight with NaN or negative value
+///     is provided.
+#[pyfunction]
+#[pyo3(
+    signature=(graph, source, target),
+    text_signature = "(graph, source, target)"
+)]
+pub fn graph_has_path(
+    py: Python,
+    graph: &graph::PyGraph,
+    source: usize,
+    target: usize,
+) -> PyResult<bool> {
+    let paths = graph_dijkstra_shortest_paths(
+        py, 
+        graph, 
+        source, 
+        Some(target), 
+        None, 
+        1.0,
+    )?;
+
+    Ok(paths.paths.len() > 0)
+}
+
 /// Find the shortest path from a node
 ///
 /// This function will generate the shortest path from a source node using
@@ -182,6 +215,43 @@ pub fn digraph_dijkstra_shortest_paths(
             })
             .collect(),
     })
+}
+
+/// Check if a digraph has a path between source and target nodes using Dijkstra's algorithm
+///
+/// :param PyDiGraph graph:
+/// :param int source: The node index to find paths from
+/// :param int target: The index of the target node
+/// :param bool as_undirected: If set to true the graph will be treated as
+///     undirected for finding the shortest path.
+///
+/// :return: True if a path exists, False if not.
+/// :rtype: bool
+/// :raises ValueError: when an edge weight with NaN or negative value
+///     is provided.
+#[pyfunction]
+#[pyo3(
+    signature=(graph, source, target, as_undirected=false),
+    text_signature = "(graph, source, target, /, as_undirected=false)"
+)]
+pub fn digraph_has_path(
+    py: Python,
+    graph: &digraph::PyDiGraph,
+    source: usize,
+    target: usize,
+    as_undirected: bool,
+) -> PyResult<bool> {
+    let paths = digraph_dijkstra_shortest_paths(
+        py, 
+        graph, 
+        source, 
+        Some(target), 
+        None,
+        1.0,
+        as_undirected,
+    )?;
+    
+    Ok(paths.paths.len() > 0)
 }
 
 /// Compute the lengths of the shortest paths for a PyGraph object using

--- a/src/shortest_path/mod.rs
+++ b/src/shortest_path/mod.rs
@@ -130,9 +130,9 @@ pub fn graph_has_path(
     source: usize,
     target: usize,
 ) -> PyResult<bool> {
-    let paths = graph_dijkstra_shortest_paths(py, graph, source, Some(target), None, 1.0)?;
+    let path_mapping = graph_dijkstra_shortest_paths(py, graph, source, Some(target), None, 1.0)?;
 
-    Ok(paths.paths.len() > 0)
+    Ok(!path_mapping.paths.is_empty())
 }
 
 /// Find the shortest path from a node
@@ -234,10 +234,10 @@ pub fn digraph_has_path(
     target: usize,
     as_undirected: bool,
 ) -> PyResult<bool> {
-    let paths =
+    let path_mapping =
         digraph_dijkstra_shortest_paths(py, graph, source, Some(target), None, 1.0, as_undirected)?;
 
-    Ok(paths.paths.len() > 0)
+    Ok(!path_mapping.paths.is_empty())
 }
 
 /// Compute the lengths of the shortest paths for a PyGraph object using

--- a/tests/rustworkx_tests/digraph/test_dijkstra.py
+++ b/tests/rustworkx_tests/digraph/test_dijkstra.py
@@ -83,10 +83,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
         ]
         g.add_edges_from(edge_list)
 
-        path_exists = rustworkx.digraph_has_path(g, a, c)
-        expected = False
-
-        self.assertEqual(path_exists, expected)
+        self.assertFalse(rustworkx.digraph_has_path(g, a, c))
 
     def test_dijkstra_path_with_weight_fn(self):
         paths = rustworkx.digraph_dijkstra_shortest_paths(self.graph, self.a, weight_fn=lambda x: x)

--- a/tests/rustworkx_tests/digraph/test_dijkstra.py
+++ b/tests/rustworkx_tests/digraph/test_dijkstra.py
@@ -75,19 +75,18 @@ class TestDijkstraDiGraph(unittest.TestCase):
         a = g.add_node("A")
         b = g.add_node("B")
         c = g.add_node("C")
-        
+
         edge_list = [
             (a, b, 7),
             (c, b, 9),
             (c, b, 10),
         ]
         g.add_edges_from(edge_list)
-        
+
         path_exists = rustworkx.digraph_has_path(g, a, c)
         expected = False
-        
-        self.assertEqual(path_exists, expected)
 
+        self.assertEqual(path_exists, expected)
 
     def test_dijkstra_path_with_weight_fn(self):
         paths = rustworkx.digraph_dijkstra_shortest_paths(self.graph, self.a, weight_fn=lambda x: x)

--- a/tests/rustworkx_tests/digraph/test_dijkstra.py
+++ b/tests/rustworkx_tests/digraph/test_dijkstra.py
@@ -70,6 +70,25 @@ class TestDijkstraDiGraph(unittest.TestCase):
         }
         self.assertEqual(expected, paths)
 
+    def test_dijkstra_has_path(self):
+        g = rustworkx.PyDiGraph()
+        a = g.add_node("A")
+        b = g.add_node("B")
+        c = g.add_node("C")
+        
+        edge_list = [
+            (a, b, 7),
+            (c, b, 9),
+            (c, b, 10),
+        ]
+        g.add_edges_from(edge_list)
+        
+        path_exists = rustworkx.digraph_has_path(g, a, c)
+        expected = False
+        
+        self.assertEqual(path_exists, expected)
+
+
     def test_dijkstra_path_with_weight_fn(self):
         paths = rustworkx.digraph_dijkstra_shortest_paths(self.graph, self.a, weight_fn=lambda x: x)
         expected = {

--- a/tests/rustworkx_tests/graph/test_dijkstra.py
+++ b/tests/rustworkx_tests/graph/test_dijkstra.py
@@ -63,10 +63,7 @@ class TestDijkstraGraph(unittest.TestCase):
         ]
         g.add_edges_from(edge_list)
 
-        path_exists = rustworkx.graph_has_path(g, a, c)
-        expected = True
-
-        self.assertEqual(path_exists, expected)
+        self.assertTrue(rustworkx.graph_has_path(g, a, c))
 
     def test_dijkstra_with_no_goal_set(self):
         path = rustworkx.graph_dijkstra_shortest_path_lengths(self.graph, self.a, lambda x: 1)

--- a/tests/rustworkx_tests/graph/test_dijkstra.py
+++ b/tests/rustworkx_tests/graph/test_dijkstra.py
@@ -49,23 +49,23 @@ class TestDijkstraGraph(unittest.TestCase):
         # a -> c -> d -> e = 20
         expected = {4: [self.a, self.c, self.d, self.e]}
         self.assertEqual(expected, path)
-    
+
     def test_dijkstra_has_path(self):
         g = rustworkx.PyGraph()
         a = g.add_node("A")
         b = g.add_node("B")
         c = g.add_node("C")
-        
+
         edge_list = [
             (a, b, 7),
             (c, b, 9),
             (c, b, 10),
         ]
         g.add_edges_from(edge_list)
-        
-        path_exists = rustworkx.digraph_has_path(g, a, c)
+
+        path_exists = rustworkx.graph_has_path(g, a, c)
         expected = True
-        
+
         self.assertEqual(path_exists, expected)
 
     def test_dijkstra_with_no_goal_set(self):

--- a/tests/rustworkx_tests/graph/test_dijkstra.py
+++ b/tests/rustworkx_tests/graph/test_dijkstra.py
@@ -49,6 +49,24 @@ class TestDijkstraGraph(unittest.TestCase):
         # a -> c -> d -> e = 20
         expected = {4: [self.a, self.c, self.d, self.e]}
         self.assertEqual(expected, path)
+    
+    def test_dijkstra_has_path(self):
+        g = rustworkx.PyGraph()
+        a = g.add_node("A")
+        b = g.add_node("B")
+        c = g.add_node("C")
+        
+        edge_list = [
+            (a, b, 7),
+            (c, b, 9),
+            (c, b, 10),
+        ]
+        g.add_edges_from(edge_list)
+        
+        path_exists = rustworkx.digraph_has_path(g, a, c)
+        expected = True
+        
+        self.assertEqual(path_exists, expected)
 
     def test_dijkstra_with_no_goal_set(self):
         path = rustworkx.graph_dijkstra_shortest_path_lengths(self.graph, self.a, lambda x: 1)


### PR DESCRIPTION
Addresses #934. 

Added a function `has_path()` which uses `graph_dijkstra_shortest_paths()` or `digraph_dijkstra_shortest_paths()` to check if a path between a source and target node exists for a `PyGraph` or `PyDiGraph`, respectively.
