### PR TITLE
remove deploy documentation to /documentation

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -34,10 +34,6 @@ echo "Building for stable version $STABLE_VERSION"
 # Push to qiskit.org/ecosystem
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to qiskit.org/ecosystem"
-rclone sync --progress --exclude-from ./tools/other-builds.txt ./docs/build/html IBMCOS:qiskit-org-web-resources/documentation/retworkx
-rclone sync --progress --exclude-from ./tools/other-builds.txt ./docs/build/html IBMCOS:qiskit-org-web-resources/documentation/rustworkx
 rclone sync --progress --exclude-from ./tools/other-builds.txt ./docs/build/html IBMCOS:qiskit-org-web-resources/ecosystem/rustworkx
 echo "Pushing built docs to stable site"
-rclone sync --progress ./docs/build/html IBMCOS:qiskit-org-web-resources/documentation/retworkx/stable/"$STABLE_VERSION"
-rclone sync --progress ./docs/build/html IBMCOS:qiskit-org-web-resources/documentation/rustworkx/stable/"$STABLE_VERSION"
 rclone sync --progress ./docs/build/html IBMCOS:qiskit-org-web-resources/ecosystem/rustworkx/stable/"$STABLE_VERSION"

--- a/tools/deploy_documentation_dev.sh
+++ b/tools/deploy_documentation_dev.sh
@@ -29,6 +29,4 @@ pwd
 # Push to qiskit.org/ecosystem
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to website"
-rclone sync --progress ./docs/build/html IBMCOS:qiskit-org-web-resources/documentation/retworkx/dev
-rclone sync --progress ./docs/build/html IBMCOS:qiskit-org-web-resources/documentation/rustworkx/dev
 rclone sync --progress ./docs/build/html IBMCOS:qiskit-org-web-resources/ecosystem/rustworkx/dev


### PR DESCRIPTION
Follow up on https://github.com/Qiskit/rustworkx/pull/843

The documentation is correctly deployed in https://qiskit.org/ecosystem/rustworkx/ and the redirect is working. So, no need to upload to /documentation anymore.