### PR TITLE
add .so files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ retworkx/*pyd
 *.svg
 !/docs/source/images/*.svg
 *.jpg
+**/*.so
 retworkx-core/Cargo.lock


### PR DESCRIPTION
When following the instructions in https://github.com/Qiskit/rustworkx#develop-mode after compilation I got a `.so` file not ignored by gitignore. 