### PR TITLE
Rename old `RETWORKX` environment variables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,12 +172,12 @@ not include any way to view the images from the visualization tests.
 
 If you want to inspect the output from the visualization tests (which is common
 if you're working on visualizations) you can set the
-`RETWORKX_TEST_PRESERVE_IMAGES` environment variable to any value and this will
+`RUSTWORKX_TEST_PRESERVE_IMAGES` environment variable to any value and this will
 skip the cleanup. This will enable you to look at the output image and ensure the
 visualization is correct. For example, running:
 
 ```
-RETWORKX_TEST_PRESERVE_IMAGES=1 tox -epy
+RUSTWORKX_TEST_PRESERVE_IMAGES=1 tox -epy
 ```
 
 will run the visualization tests and preserve the generated image files after

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -71,7 +71,7 @@ intersphinx_mapping = {
 
 # Prepend warning for development docs:
 
-if not os.getenv('RETWORKX_DEV_DOCS', None):
+if not os.getenv('RUSTWORKX_DEV_DOCS', None):
     rst_prolog = """
 .. raw:: html
 
@@ -152,7 +152,7 @@ def _get_versions(app, config):
 
 
 def _get_version_label(current_version):
-    if not os.getenv('RETWORKX_DEV_DOCS', None):
+    if not os.getenv('RUSTWORKX_DEV_DOCS', None):
         current_version_info = current_version.split('.')
         return ".".join(current_version_info[:-1])
     else:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -124,7 +124,7 @@ with open("sources.txt", "r") as fd:
     for source_str in fd:
         redirects[f"stubs/{source_str}"] = f"../apiref/{source_str}"
 
-if os.getenv("RETWORKX_LEGACY_DOCS", None) is not None:
+if os.getenv("RUSTWORKX_LEGACY_DOCS", None) is not None:
     redirects["*"] = "https://qiskit.org/ecosystem/rustworkx/$source.html"
     html_baseurl = "https://qiskit.org/ecosystem/rustworkx/"
 

--- a/tests/retworkx_backwards_compat/visualization/test_graphviz.py
+++ b/tests/retworkx_backwards_compat/visualization/test_graphviz.py
@@ -31,7 +31,7 @@ try:
 except Exception:
     HAS_PILLOW = False
 
-SAVE_IMAGES = os.getenv("RETWORKX_TEST_PRESERVE_IMAGES", None)
+SAVE_IMAGES = os.getenv("RUSTWORKX_TEST_PRESERVE_IMAGES", None)
 
 
 def _save_image(image, path):

--- a/tests/retworkx_backwards_compat/visualization/test_mpl.py
+++ b/tests/retworkx_backwards_compat/visualization/test_mpl.py
@@ -29,7 +29,7 @@ try:
 except ImportError:
     HAS_MPL = False
 
-SAVE_IMAGES = os.getenv("RETWORKX_TEST_PRESERVE_IMAGES", None)
+SAVE_IMAGES = os.getenv("RUSTWORKX_TEST_PRESERVE_IMAGES", None)
 
 
 def _save_images(fig, path):

--- a/tests/rustworkx_tests/visualization/test_graphviz.py
+++ b/tests/rustworkx_tests/visualization/test_graphviz.py
@@ -31,7 +31,7 @@ try:
 except Exception:
     HAS_PILLOW = False
 
-SAVE_IMAGES = os.getenv("RETWORKX_TEST_PRESERVE_IMAGES", None)
+SAVE_IMAGES = os.getenv("RUSTWORKX_TEST_PRESERVE_IMAGES", None)
 
 
 def _save_image(image, path):

--- a/tests/rustworkx_tests/visualization/test_mpl.py
+++ b/tests/rustworkx_tests/visualization/test_mpl.py
@@ -29,7 +29,7 @@ try:
 except ImportError:
     HAS_MPL = False
 
-SAVE_IMAGES = os.getenv("RETWORKX_TEST_PRESERVE_IMAGES", None)
+SAVE_IMAGES = os.getenv("RUSTWORKX_TEST_PRESERVE_IMAGES", None)
 
 
 def _save_images(fig, path):

--- a/tools/deploy_documentation_dev.sh
+++ b/tools/deploy_documentation_dev.sh
@@ -21,7 +21,7 @@ sudo apt-get install -y ./rclone.deb
 RCLONE_CONFIG_PATH=$(rclone config file | tail -1)
 
 # Build the documentation.
-RETWORKX_DEV_DOCS=1 tox -edocs
+RUSTWORKX_DEV_DOCS=1 tox -edocs
 
 echo "show current dir: "
 pwd

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ deps =
 passenv =
   {[testenv]passenv}
   RUSTWORKX_DEV_DOCS
-  RETWORKX_LEGACY_DOCS
+  RUSTWORKX_LEGACY_DOCS
   RUST_DEBUG
 changedir = {toxinidir}/docs
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ extras =
   mpl
   graphviz
 passenv =
-  RETWORKX_TEST_PRESERVE_IMAGES
+  RUSTWORKX_TEST_PRESERVE_IMAGES
   RUSTWORKX_PKG_NAME
   RUSTWORKX_DEBUG
 changedir = {toxinidir}/tests
@@ -51,7 +51,7 @@ deps =
   -r {toxinidir}/docs/source/requirements.txt
 passenv =
   {[testenv]passenv}
-  RETWORKX_DEV_DOCS
+  RUSTWORKX_DEV_DOCS
   RETWORKX_LEGACY_DOCS
   RUST_DEBUG
 changedir = {toxinidir}/docs


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Renaming some flags I found while working in #861