### PR TITLE
mapping is not possible when a node has no neighbors

### DIFF
--- a/rustworkx-core/src/token_swapper.rs
+++ b/rustworkx-core/src/token_swapper.rs
@@ -205,6 +205,16 @@ where
         }
         let id_node = self.rev_node_map[&node];
         let id_token = self.rev_node_map[&tokens[&node]];
+
+        if self
+            .graph
+            .neighbors(id_node)
+            .collect::<Vec<G::NodeId>>()
+            .is_empty()
+        {
+            return Err(MapNotPossible {});
+        }
+
         for id_neighbor in self.graph.neighbors(id_node) {
             let neighbor = self.node_map[&id_neighbor];
             let dist_neighbor: DictMap<G::NodeId, usize> = dijkstra(
@@ -700,6 +710,21 @@ mod test_token_swapper {
             (NodeIndex::new(0), NodeIndex::new(2)),
             (NodeIndex::new(3), NodeIndex::new(3)),
         ]);
+        match token_swapper(&g, mapping, Some(10), Some(4), Some(50)) {
+            Ok(_) => panic!("This should error"),
+            Err(_) => (),
+        };
+    }
+
+    #[test]
+    fn test_edgeless_graph_fails() {
+        let mut g = petgraph::graph::UnGraph::<(), ()>::new_undirected();
+        let a = g.add_node(());
+        let b = g.add_node(());
+        let c = g.add_node(());
+        let d = g.add_node(());
+        g.add_edge(c, d, ());
+        let mapping = HashMap::from([(a, b), (b, a)]);
         match token_swapper(&g, mapping, Some(10), Some(4), Some(50)) {
             Ok(_) => panic!("This should error"),
             Err(_) => (),

--- a/rustworkx-core/src/token_swapper.rs
+++ b/rustworkx-core/src/token_swapper.rs
@@ -206,12 +206,7 @@ where
         let id_node = self.rev_node_map[&node];
         let id_token = self.rev_node_map[&tokens[&node]];
 
-        if self
-            .graph
-            .neighbors(id_node)
-            .collect::<Vec<G::NodeId>>()
-            .is_empty()
-        {
+        if self.graph.neighbors(id_node).next().is_none() {
             return Err(MapNotPossible {});
         }
 


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Fixes #994.

I believe that the function ``add_token_edges(node)`` should return ``Err(MapNotPossible {})`` when no mapping exists. This was already handled in the case that ``node`` had at least one neighbor.  Now I am also returning the error in the case a node has no neighbors. 
