### PR TITLE
Fix build errors with Rust 1.73.0

### DIFF
--- a/rustworkx-core/src/centrality.rs
+++ b/rustworkx-core/src/centrality.rs
@@ -738,7 +738,7 @@ where
 {
     let alpha: f64 = alpha.unwrap_or(0.1);
 
-    let mut beta: HashMap<usize, f64> = beta_map.unwrap_or_else(HashMap::new);
+    let mut beta: HashMap<usize, f64> = beta_map.unwrap_or_default();
 
     if beta.is_empty() {
         // beta_map was none

--- a/src/dag_algo/mod.rs
+++ b/src/dag_algo/mod.rs
@@ -628,7 +628,6 @@ pub fn collect_bicolor_runs(
                 }
             } else {
                 for color in colors {
-                    let color = color;
                     ensure_vector_has_index!(pending_list, block_id, color);
                     if let Some(color_block_id) = block_id[color] {
                         block_list[color_block_id].append(&mut pending_list[color]);

--- a/src/matching/mod.rs
+++ b/src/matching/mod.rs
@@ -92,7 +92,7 @@ fn _inner_is_matching(graph: &graph::PyGraph, matching: &HashSet<(usize, usize)>
             .contains_edge(NodeIndex::new(e.0), NodeIndex::new(e.1))
     };
 
-    if !matching.iter().all(|e| has_edge(e)) {
+    if !matching.iter().all(has_edge) {
         return false;
     }
     let mut found: HashSet<usize> = HashSet::with_capacity(2 * matching.len());

--- a/src/score.rs
+++ b/src/score.rs
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 #![allow(clippy::derive_partial_eq_without_eq)]
+#![allow(clippy::incorrect_partial_ord_impl_on_ord_type)]
 
 use std::cmp::Ordering;
 use std::ops::{Add, AddAssign};


### PR DESCRIPTION
The recent Rust 1.73.0 release introduced some changes to clippy's behavior that are causing failures in CI (and correctly calling out issues in our code). This commit updates the rustworkx source to correct these failures.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
