### PR TITLE
Add support for Python 3.12 and musllinux to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         rust: [stable]
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
         platform: [
           { os: "macOS-latest", python-architecture: "x64", rust-target: "x86_64-apple-darwin" },
           { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" },
@@ -76,19 +76,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.platform.python-architecture }}
-        if: runner.os != 'Windows'
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.7
-          architecture: ${{ matrix.platform.python-architecture }}
-        if: ${{ runner.os == 'Windows' && matrix.python-version == '3.7.16' }}
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: ${{ matrix.platform.python-architecture }}
-        if: ${{ runner.os == 'Windows' && matrix.python-version != '3.7.16' }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -55,20 +55,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.10.1 twine
+          python -m pip install cibuildwheel==2.16.2 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_BEFORE_ALL_LINUX: "yum install -y wget && {package}/tools/install_rust.sh"
-          CIBW_ENVIRONMENT_LINUX: 'PATH="$PATH:$HOME/.cargo/bin"'
-          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
-          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
-          CIBW_SKIP: cp36-* cp37-* pp* *win32 *musl*
-          CIBW_BEFORE_BUILD: pip install -U setuptools-rust
-          CIBW_TEST_REQUIRES: networkx testtools fixtures
-          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
@@ -97,20 +87,11 @@ jobs:
           platforms: all
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.10.1 twine
+          python -m pip install cibuildwheel==2.16.2 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BEFORE_ALL_LINUX: "yum install -y wget && {package}/tools/install_rust.sh"
-          CIBW_ENVIRONMENT_LINUX: 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true"'
-          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
-          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
-          CIBW_SKIP: cp36-* cp37-* pp* *win32 *musl*
-          CIBW_BEFORE_BUILD: pip install -U setuptools-rust
-          CIBW_TEST_REQUIRES: networkx scipy testtools fixtures
-          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
           CIBW_ARCHS_LINUX: aarch64
       - uses: actions/upload-artifact@v3
         with:
@@ -140,20 +121,12 @@ jobs:
           platforms: all
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.10.1 twine
+          python -m pip install cibuildwheel==2.16.2 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BEFORE_ALL_LINUX: "yum install -y wget && {package}/tools/install_rust.sh"
-          CIBW_ENVIRONMENT_LINUX: 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true"'
-          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
-          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
-          CIBW_SKIP: cp36-* cp37-* cp39-* cp310-* cp311-* pp* *win32 *musl*
-          CIBW_BEFORE_BUILD: pip install -U setuptools-rust
-          CIBW_TEST_REQUIRES: networkx testtools fixtures
-          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
+          CIBW_SKIP: cp36-* cp37-* cp39-* cp310-* cp311-* pp* *win32
           CIBW_ARCHS_LINUX: ppc64le
       - uses: actions/upload-artifact@v3
         with:
@@ -183,20 +156,12 @@ jobs:
           platforms: all
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.10.1 twine
+          python -m pip install cibuildwheel==2.16.2 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BEFORE_ALL_LINUX: "yum install -y wget && {package}/tools/install_rust.sh"
-          CIBW_ENVIRONMENT_LINUX: 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true"'
-          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
-          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
-          CIBW_SKIP: cp36-* cp37-* cp38-* pp* *win32 *musl*
-          CIBW_BEFORE_BUILD: pip install -U setuptools-rust
-          CIBW_TEST_REQUIRES: networkx testtools fixtures
-          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
+          CIBW_SKIP: cp36-* cp37-* cp38-* cp312-* pp* *win32 *musl*
           CIBW_ARCHS_LINUX: ppc64le
       - uses: actions/upload-artifact@v3
         with:
@@ -226,20 +191,12 @@ jobs:
           platforms: all
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.10.1 twine
+          python -m pip install cibuildwheel==2.16.2 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BEFORE_ALL_LINUX: "yum install -y wget && {package}/tools/install_rust.sh"
-          CIBW_ENVIRONMENT_LINUX: 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true"'
-          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
-          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
           CIBW_SKIP: cp36-* cp37-* cp39-* cp310-* cp311-* pp* *win32 *musl*
-          CIBW_BEFORE_BUILD: pip install -U setuptools-rust
-          CIBW_TEST_REQUIRES: networkx testtools fixtures
-          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
           CIBW_ARCHS_LINUX: s390x
           CIBW_TEST_SKIP: "*-*linux_s390x"
       - uses: actions/upload-artifact@v3
@@ -270,20 +227,12 @@ jobs:
           platforms: all
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.10.1 twine
+          python -m pip install cibuildwheel==2.16.2 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BEFORE_ALL_LINUX: "yum install -y wget && {package}/tools/install_rust.sh"
-          CIBW_ENVIRONMENT_LINUX: 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true"'
-          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
-          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
-          CIBW_SKIP: cp36-* cp37-* cp38-* pp* *win32 *musl*
-          CIBW_BEFORE_BUILD: pip install -U setuptools-rust
-          CIBW_TEST_REQUIRES: networkx testtools fixtures
-          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
+          CIBW_SKIP: cp36-* cp37-* cp38-* cp312-* pp* *win32 *musl*
           CIBW_ARCHS_LINUX: s390x
           CIBW_TEST_SKIP: "*-*linux_s390x"
       - uses: actions/upload-artifact@v3
@@ -300,7 +249,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build wheels
-        uses: joerick/cibuildwheel@v2.10.1
+        uses: joerick/cibuildwheel@v2.16.2
         env:
           CIBW_BEFORE_ALL: rustup target add aarch64-apple-darwin
           CIBW_ARCHS_MACOS: arm64 universal2
@@ -338,16 +287,12 @@ jobs:
         run: rustup default stable-i686-pc-windows-msvc
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.10.1 twine
+          python -m pip install cibuildwheel==2.16.2 twine
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9
           CIBW_SKIP: cp36-* cp37-* pp* *amd64 *musl*
-          CIBW_BEFORE_BUILD: pip install -U setuptools-rust
-          CIBW_TEST_REQUIRES: networkx testtools fixtures
-          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -53,7 +53,37 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_LINUX: aarch64
-          CIBW_SKIP: cp36-* cp37-* pp* *musl*
+          CIBW_SKIP: cp36-* cp37-* cp311-* cp312-* pp* *musl*
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+  build_wheels_aarch64_part_2:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: '3.8'
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel==2.16.2 twine
+      - name: Build wheels
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_ARCHS_LINUX: aarch64
+          CIBW_SKIP: cp36-* cp37-* cp38-* cp39-* cp310-* pp* *musl*
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -144,7 +144,6 @@ jobs:
         env:
           CIBW_SKIP: cp36-* cp37-* cp39-* cp310-* cp311-* pp* *win32 *musl*
           CIBW_ARCHS_LINUX: s390x
-          CIBW_TEST_SKIP: "*-*linux_s390x"
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
@@ -175,7 +174,6 @@ jobs:
         env:
           CIBW_SKIP: cp36-* cp37-* cp38-* cp312-* pp* *win32 *musl*
           CIBW_ARCHS_LINUX: s390x
-          CIBW_TEST_SKIP: "*-*linux_s390x"
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -53,6 +53,7 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_LINUX: aarch64
+          CIBW_SKIP: cp36-* cp37-* pp* *musl*
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,9 +1,44 @@
 ---
 name: Wheel Builds
 on:
-  pull_request:
-    branches: [ main, 'stable/*' ]
+  push:
+    tags:
+      - '*'
 jobs:
+  rustworkx-core:
+    name: Publish rustworkx-core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run cargo publish
+        run: |
+          cd rustworkx-core
+          cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    needs: ["build_wheels", "build-win32-wheels"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: '3.8'
+      - name: Install deps
+        run: pip install -U twine setuptools-rust
+      - name: Build sdist
+        run: python setup.py sdist
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./dist/*
+      - name: Upload to PyPI
+        run: twine upload ./dist/*
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -27,6 +62,11 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build_wheels_aarch64:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -87,6 +127,11 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build_wheels_ppc64le:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -117,6 +162,11 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build_wheels_ppc64le_part2:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -147,6 +197,11 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build_wheels_s390x:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -177,6 +232,11 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build_wheels_s390x_part2:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -207,6 +267,11 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build-mac-arm-wheels:
     name: Build wheels on macos for arm and universal2
     runs-on: macos-latest
@@ -229,6 +294,11 @@ jobs:
       - name: Install twine
         run: |
           python -m pip install twine
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   build-win32-wheels:
     name: Build wheels on win32
     runs-on: windows-latest
@@ -255,6 +325,11 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci
   retworkx-compat-build:
     name: Build retworkx
     runs-on: ubuntu-latest
@@ -274,3 +349,8 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./dist/*
+      - name: Upload to PyPI
+        run: twine upload ./dist/*
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: retworkx-ci

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,44 +1,9 @@
 ---
 name: Wheel Builds
 on:
-  push:
-    tags:
-      - '*'
+  pull_request:
+    branches: [ main, 'stable/*' ]
 jobs:
-  rustworkx-core:
-    name: Publish rustworkx-core
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Run cargo publish
-        run: |
-          cd rustworkx-core
-          cargo publish
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-  sdist:
-    name: Build sdist
-    runs-on: ubuntu-latest
-    needs: ["build_wheels", "build-win32-wheels"]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        name: Install Python
-        with:
-          python-version: '3.8'
-      - name: Install deps
-        run: pip install -U twine setuptools-rust
-      - name: Build sdist
-        run: python setup.py sdist
-      - uses: actions/upload-artifact@v3
-        with:
-          path: ./dist/*
-      - name: Upload to PyPI
-        run: twine upload ./dist/*
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -62,11 +27,6 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   build_wheels_aarch64:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -96,11 +56,6 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   build_wheels_ppc64le:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -131,11 +86,6 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   build_wheels_ppc64le_part2:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -166,11 +116,6 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   build_wheels_s390x:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -202,11 +147,6 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   build_wheels_s390x_part2:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -238,11 +178,6 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   build-mac-arm-wheels:
     name: Build wheels on macos for arm and universal2
     runs-on: macos-latest
@@ -265,11 +200,6 @@ jobs:
       - name: Install twine
         run: |
           python -m pip install twine
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   build-win32-wheels:
     name: Build wheels on win32
     runs-on: windows-latest
@@ -296,11 +226,6 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci
   retworkx-compat-build:
     name: Build retworkx
     runs-on: ubuntu-latest
@@ -320,8 +245,3 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./dist/*
-      - name: Upload to PyPI
-        run: twine upload ./dist/*
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: retworkx-ci

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -89,6 +89,14 @@ source.
      - s390x
      - :ref:`tier-4`
      - Distributions compatible with the `manylinux 2014`_ packaging specification
+   * - Linux (musl)
+     - x86_64
+     - :ref:`tier-3`
+     -
+   * - Linux (musl)
+     - aarch64
+     - :ref:`tier-3`
+     -
    * - macOS (10.9 or newer)
      - x86_64
      - :ref:`tier-1`

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -93,7 +93,7 @@ source.
      - x86_64
      - :ref:`tier-3`
      -
-   * - macOS (10.9 or newer)
+   * - macOS (10.12 or newer)
      - x86_64
      - :ref:`tier-1`
      -

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -93,10 +93,6 @@ source.
      - x86_64
      - :ref:`tier-3`
      -
-   * - Linux (musl)
-     - aarch64
-     - :ref:`tier-3`
-     -
    * - macOS (10.9 or newer)
      - x86_64
      - :ref:`tier-1`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ target-version = ['py38', 'py39', 'py310', 'py311']
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
 skip = "pp* cp36-* cp37-* *win32"
-test-requires = "networkx testtools fixtures"
+test-requires = "networkx"
 test-command = "python -m unittest discover {project}/tests/rustworkx_tests"
 before-build = "pip install -U setuptools-rust"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ environment = 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
-before-all = "apk add apk add --no-cache curl gcc && curl https://sh.rustup.rs -sSf | sh -s -- -y && source $HOME/.cargo/env && rustup install stable && rustup default stable"
+before-all = "apk add --no-cache curl gcc && curl https://sh.rustup.rs -sSf | sh -s -- -y && source $HOME/.cargo/env && rustup install stable && rustup default stable"
 
 [[tool.cibuildwheel.overrides]]
 select = "*i686"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,12 +25,12 @@ test-skip = "cp37-* cp38-*"
 
 [[tool.cibuildwheel.overrides]]
 select = "*i686"
-skip = "pp* cp36-* cp37-* *win32" "*-musllinux*"
-before_test = 'yum install openblas-devel'
+skip = "pp* cp36-* cp37-* *win32 *-musllinux*"
+before_test = "yum install openblas-devel"
 
 [[tool.cibuildwheel.overrides]]
 select = "*ppc64le"
-before_test = 'yum install openblas-devel'
+before_test = "yum install openblas-devel"
 
 [tool.cibuildwheel.macos]
 environment = "MACOSX_DEPLOYMENT_TARGET=10.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,13 @@ before-all = "apk add apk add --no-cache curl gcc && curl https://sh.rustup.rs -
 test-skip = "cp37-* cp38-*"
 
 [[tool.cibuildwheel.overrides]]
-select = "*i686*"
-before_test = 'python -m pip install numpy --config-settings=setup-args="-Dallow-noblas=true"'
+select = "*i686"
+skip = "pp* cp36-* cp37-* *win32" "*-musllinux*"
+before_test = 'yum install openblas-devel'
 
 [[tool.cibuildwheel.overrides]]
-select = "*ppc64le*"
-before_test = 'python -m pip install numpy --config-settings=setup-args="-Dallow-noblas=true"'
+select = "*ppc64le"
+before_test = 'yum install openblas-devel'
 
 [tool.cibuildwheel.macos]
 environment = "MACOSX_DEPLOYMENT_TARGET=10.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ target-version = ['py38', 'py39', 'py310', 'py311']
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
-skip = "pp* cp36-* cp37-* *win32" "*musllinux*i686"
+skip = "pp* cp36-* cp37-* *win32 *musllinux*i686"
 test-requires = "networkx"
 test-command = "python -m unittest discover {project}/tests/rustworkx_tests"
 before-build = "pip install -U setuptools-rust"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,24 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100
-target-version = ['py37', 'py38', 'py39', 'py310']
+target-version = ['py38', 'py39', 'py310', 'py311']
+
+[tool.cibuildwheel]
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
+skip = "pp* cp36-* cp37-* *win32"
+test-requires = "networkx testtools fixtures"
+test-command = "python -m unittest discover {project}/tests/rustworkx_tests"
+before-build = "pip install -U setuptools-rust"
+
+[tool.cibuildwheel.linux]
+before-all = "yum install -y wget && {package}/tools/install_rust.sh"
+environment = 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true"'
+
+[[tool.cibuildwheel.overrides]]
+select = "*-musllinux*"
+before-all = "apk add apk add --no-cache curl gcc && curl https://sh.rustup.rs -sSf | sh -s -- -y && source $HOME/.cargo/env && rustup install stable && rustup default stable"
+test-skip = "cp37-* cp38-*"
+
+[tool.cibuildwheel.macos]
+environment = "MACOSX_DEPLOYMENT_TARGET=10.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ skip = "pp* cp36-* cp37-* *win32 *musllinux*i686"
 test-requires = "networkx"
 test-command = "python -m unittest discover {project}/tests/rustworkx_tests"
 before-build = "pip install -U setuptools-rust"
-test-skip = "cp38-*musllinux*"
+test-skip = "cp38-*musllinux* *-*linux_s390x -*linux_ppc64le"
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y wget && {package}/tools/install_rust.sh"
@@ -25,10 +25,6 @@ before-all = "apk add apk add --no-cache curl gcc && curl https://sh.rustup.rs -
 
 [[tool.cibuildwheel.overrides]]
 select = "*i686"
-before-test = 'python -m pip install numpy --config-settings=setup-args="-Dallow-noblas=true"'
-
-[[tool.cibuildwheel.overrides]]
-select = "*ppc64le"
 before-test = 'python -m pip install numpy --config-settings=setup-args="-Dallow-noblas=true"'
 
 [tool.cibuildwheel.macos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,11 @@ target-version = ['py38', 'py39', 'py310', 'py311']
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
-skip = "pp* cp36-* cp37-* *win32"
+skip = "pp* cp36-* cp37-* *win32" "*musllinux*i686"
 test-requires = "networkx"
 test-command = "python -m unittest discover {project}/tests/rustworkx_tests"
 before-build = "pip install -U setuptools-rust"
+test-skip = "cp38-*musllinux*"
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y wget && {package}/tools/install_rust.sh"
@@ -21,16 +22,14 @@ environment = 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true"
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
 before-all = "apk add apk add --no-cache curl gcc && curl https://sh.rustup.rs -sSf | sh -s -- -y && source $HOME/.cargo/env && rustup install stable && rustup default stable"
-test-skip = "cp37-* cp38-*"
 
 [[tool.cibuildwheel.overrides]]
 select = "*i686"
-skip = "pp* cp36-* cp37-* *win32 *-musllinux*"
-before_test = "yum install openblas-devel"
+before-all = "yum install openblas-devel"
 
 [[tool.cibuildwheel.overrides]]
 select = "*ppc64le"
-before_test = "yum install openblas-devel"
+before-all = "yum install openblas-devel"
 
 [tool.cibuildwheel.macos]
 environment = "MACOSX_DEPLOYMENT_TARGET=10.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,4 +28,4 @@ select = "*i686"
 before-test = 'python -m pip install numpy --config-settings=setup-args="-Dallow-noblas=true"'
 
 [tool.cibuildwheel.macos]
-environment = "MACOSX_DEPLOYMENT_TARGET=10.9"
+environment = "MACOSX_DEPLOYMENT_TARGET=10.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,11 @@ before-all = "apk add apk add --no-cache curl gcc && curl https://sh.rustup.rs -
 
 [[tool.cibuildwheel.overrides]]
 select = "*i686"
-before-all = "yum install openblas-devel"
+before-test = 'python -m pip install numpy --config-settings=setup-args="-Dallow-noblas=true"'
 
 [[tool.cibuildwheel.overrides]]
 select = "*ppc64le"
-before-all = "yum install openblas-devel"
+before-test = 'python -m pip install numpy --config-settings=setup-args="-Dallow-noblas=true"'
 
 [tool.cibuildwheel.macos]
 environment = "MACOSX_DEPLOYMENT_TARGET=10.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,5 +23,13 @@ select = "*-musllinux*"
 before-all = "apk add apk add --no-cache curl gcc && curl https://sh.rustup.rs -sSf | sh -s -- -y && source $HOME/.cargo/env && rustup install stable && rustup default stable"
 test-skip = "cp37-* cp38-*"
 
+[[tool.cibuildwheel.overrides]]
+select = "*i686*"
+before_test = 'python -m pip install numpy --config-settings=setup-args="-Dallow-noblas=true"'
+
+[[tool.cibuildwheel.overrides]]
+select = "*ppc64le*"
+before_test = 'python -m pip install numpy --config-settings=setup-args="-Dallow-noblas=true"'
+
 [tool.cibuildwheel.macos]
 environment = "MACOSX_DEPLOYMENT_TARGET=10.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ skip = "pp* cp36-* cp37-* *win32 *musllinux*i686"
 test-requires = "networkx"
 test-command = "python -m unittest discover {project}/tests/rustworkx_tests"
 before-build = "pip install -U setuptools-rust"
-test-skip = "cp38-*musllinux* *-*linux_s390x -*linux_ppc64le"
+test-skip = "cp38-*musllinux* *linux_s390x *ppc64le"
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y wget && {package}/tools/install_rust.sh"

--- a/releasenotes/notes/platform-updates-e9b296144e633c95.yaml
+++ b/releasenotes/notes/platform-updates-e9b296144e633c95.yaml
@@ -14,3 +14,13 @@ upgrade:
     functional (although the likelihood they are is still high as it works on
     other platforms). If any issues are encountered with ppc64le Linux please
     open an issue.
+  - |
+    For macOS the minimum version of macOS is now 10.12. Previously, the
+    precompiled binary wheel packages for macOS x86_64 were published with
+    support for >=10.9. However, because of changes in the
+    `support policy <https://blog.rust-lang.org/2023/09/25/Increasing-Apple-Version-Requirements.html>`__
+    for the Rust programming language the minimum version needed to raised
+    to macOS 10.12. If you're using Qiskit on macOS 10.9 you can probably
+    build Qiskit from source while the rustworkx MSRV (minimum supported Rust
+    version) is < 1.74, but the precompiled binaries published to PyPI will
+    only be compatible with macOS >= 10.12.

--- a/releasenotes/notes/platform-updates-e9b296144e633c95.yaml
+++ b/releasenotes/notes/platform-updates-e9b296144e633c95.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Added support for musl Linux platforms on x86_64 and aarch64 at :ref:`tier 3`.
+    Added support for musl Linux platforms on x86_64 and aarch64 at :ref:`tier-3`.

--- a/releasenotes/notes/platform-updates-e9b296144e633c95.yaml
+++ b/releasenotes/notes/platform-updates-e9b296144e633c95.yaml
@@ -2,3 +2,15 @@
 features:
   - |
     Added support for musl Linux platforms on x86_64 and aarch64 at :ref:`tier-3`.
+upgrade:
+  - |
+    Support for the Linux ppc64le pllatform has changed from tier 3 to tier 4
+    (as documented in :ref:`platform-suppport`). This is a result of no longer
+    being able to run tests during the pre-compiled wheel publishing jobs due
+    to constraints in the available CI infrastructure. There hopefully
+    shouldn't be any meaningful impact resulting from this change, but as there
+    are no longer tests being run to validate the binaries prior to publishing
+    them there are no longer guarantees that the wheels for ppc64le are fully
+    functional (although the likelihood they are is still high as it works on
+    other platforms). If any issues are encountered with ppc64le Linux please
+    open an issue.

--- a/releasenotes/notes/platform-updates-e9b296144e633c95.yaml
+++ b/releasenotes/notes/platform-updates-e9b296144e633c95.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added support for musl Linux platforms on x86_64 and aarch64 at :ref:`tier 3`.

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX :: Linux",

--- a/tests/retworkx_backwards_compat/graph/test_max_weight_matching.py
+++ b/tests/retworkx_backwards_compat/graph/test_max_weight_matching.py
@@ -14,10 +14,9 @@
 # https://github.com/networkx/networkx/blob/3351206a3ce5b3a39bb2fc451e93ef545b96c95b/networkx/algorithms/tests/test_matching.py
 
 import random
+import unittest
 
-import fixtures
 import networkx
-import testtools
 
 import retworkx
 
@@ -26,14 +25,7 @@ def match_dict_to_set(match):
     return {(u, v) for (u, v) in set(map(frozenset, match.items()))}
 
 
-class TestMaxWeightMatching(testtools.TestCase):
-    def setUp(self):
-        super().setUp()
-        stdout = self.useFixture(fixtures.StringStream("stdout")).stream
-        self.useFixture(fixtures.MonkeyPatch("sys.stdout", stdout))
-        stderr = self.useFixture(fixtures.StringStream("stderr")).stream
-        self.useFixture(fixtures.MonkeyPatch("sys.stderr", stderr))
-
+class TestMaxWeightMatching(unittest.TestCase):
     def compare_match_sets(self, rx_match, expected_match):
         for (u, v) in rx_match:
             if (u, v) not in expected_match and (v, u) not in expected_match:

--- a/tests/rustworkx_tests/graph/test_max_weight_matching.py
+++ b/tests/rustworkx_tests/graph/test_max_weight_matching.py
@@ -14,10 +14,9 @@
 # https://github.com/networkx/networkx/blob/3351206a3ce5b3a39bb2fc451e93ef545b96c95b/networkx/algorithms/tests/test_matching.py
 
 import random
+import unittest
 
-import fixtures
 import networkx
-import testtools
 
 import rustworkx
 
@@ -26,14 +25,7 @@ def match_dict_to_set(match):
     return {(u, v) for (u, v) in set(map(frozenset, match.items()))}
 
 
-class TestMaxWeightMatching(testtools.TestCase):
-    def setUp(self):
-        super().setUp()
-        stdout = self.useFixture(fixtures.StringStream("stdout")).stream
-        self.useFixture(fixtures.MonkeyPatch("sys.stdout", stdout))
-        stderr = self.useFixture(fixtures.StringStream("stderr")).stream
-        self.useFixture(fixtures.MonkeyPatch("sys.stderr", stderr))
-
+class TestMaxWeightMatching(unittest.TestCase):
     def compare_match_sets(self, rx_match, expected_match):
         for (u, v) in rx_match:
             if (u, v) not in expected_match and (v, u) not in expected_match:


### PR DESCRIPTION
As part of the 0.13.2 release we added support for Python 3.12 and musllinux to rustworkx. However, these changes did not happen on main yet. This commit applies the necessary changes to the main branch for the 0.14.0 and future releases. Also to simplify the configuration of the cibuildwheel jobs this combines #753 into this PR so that the configuration is centralized in the pyproject.toml.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
