### PR TITLE
Add barabasi_albert_graph random graph functions

### DIFF
--- a/docs/source/api/random_graph_generator_functions.rst
+++ b/docs/source/api/random_graph_generator_functions.rst
@@ -11,3 +11,5 @@ Random Graph Generator Functions
     rustworkx.directed_gnm_random_graph
     rustworkx.undirected_gnm_random_graph
     rustworkx.random_geometric_graph
+    rustworkx.barabasi_albert_graph
+    rustworkx.directed_barabasi_albert_graph

--- a/releasenotes/notes/add-albert-graph-5a7d393e1fe18e9d.yaml
+++ b/releasenotes/notes/add-albert-graph-5a7d393e1fe18e9d.yaml
@@ -9,11 +9,11 @@ features:
         .. jupyter-execute::
 
             import rustworkx
-            from rustworkx.visualization import graphviz_draw
+            from rustworkx.visualization import mpl_draw
 
             starting_graph = rustworkx.generators.path_graph(10)
             random_graph = rustworkx.barabasi_albert_graph(20, 10, initial_graph=starting_graph)
-            graphviz_draw(random_graph, method="neato")
+            mpl_draw(random_graph)
   - |
     Added a new function to the rustworkx-core module ``rustworkx_core::generators``
     ``barabasi_albert_graph()`` which is used to generate a random graph

--- a/releasenotes/notes/add-albert-graph-5a7d393e1fe18e9d.yaml
+++ b/releasenotes/notes/add-albert-graph-5a7d393e1fe18e9d.yaml
@@ -1,0 +1,20 @@
+---
+features:
+  - |
+    Added two new random graph generator functions,
+    :func:`.directed_barabasi_albert_graph` and :func:`.barabasi_albert_graph`,
+    to generate a random graph using Barabási–Albert preferential attachment to
+    extend an input graph. For example:
+
+        .. jupyter-execute::
+
+            import rustworkx
+            from rustworkx.visualization import graphviz_draw
+
+            starting_graph = rustworkx.generators.path_graph(10)
+            random_graph = rustworkx.barabasi_albert_graph(20, 10, initial_graph=starting_graph)
+            graphviz_draw(random_graph, method="neato")
+  - |
+    Added a new function to the rustworkx-core module ``rustworkx_core::generators``
+    ``barabasi_albert_graph()`` which is used to generate a random graph
+    using Barabási–Albert preferential attachment to extend an input graph.

--- a/rustworkx-core/src/generators/mod.rs
+++ b/rustworkx-core/src/generators/mod.rs
@@ -56,6 +56,7 @@ pub use hexagonal_lattice_graph::hexagonal_lattice_graph;
 pub use lollipop_graph::lollipop_graph;
 pub use path_graph::path_graph;
 pub use petersen_graph::petersen_graph;
+pub use random_graph::barabasi_albert_graph;
 pub use random_graph::gnm_random_graph;
 pub use random_graph::gnp_random_graph;
 pub use random_graph::random_geometric_graph;

--- a/rustworkx-core/src/generators/random_graph.rs
+++ b/rustworkx-core/src/generators/random_graph.rs
@@ -466,7 +466,7 @@ where
     for<'b> &'b G: GraphBase<NodeId = G::NodeId> + IntoEdgesDirected + IntoNodeIdentifiers,
     F: FnMut() -> T,
     H: FnMut() -> M,
-    G::NodeId: Eq + Hash + std::fmt::Debug,
+    G::NodeId: Eq + Hash,
 {
     if m < 1 || m >= n {
         return Err(InvalidInputError {});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,6 +454,8 @@ fn rustworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(directed_gnm_random_graph))?;
     m.add_wrapped(wrap_pyfunction!(undirected_gnm_random_graph))?;
     m.add_wrapped(wrap_pyfunction!(random_geometric_graph))?;
+    m.add_wrapped(wrap_pyfunction!(barabasi_albert_graph))?;
+    m.add_wrapped(wrap_pyfunction!(directed_barabasi_albert_graph))?;
     m.add_wrapped(wrap_pyfunction!(cycle_basis))?;
     m.add_wrapped(wrap_pyfunction!(simple_cycles))?;
     m.add_wrapped(wrap_pyfunction!(strongly_connected_components))?;

--- a/src/random_graph.rs
+++ b/src/random_graph.rs
@@ -386,14 +386,14 @@ pub fn random_geometric_graph(
 /// are preferentially attached to existing nodes with high degree. All the edges
 /// and nodes added to this graph will have weights of ``None``.
 ///
-/// The algorithm performed by this function are described in:
+/// The algorithm performed by this function is described in:
 ///
 /// A. L. Barabási and R. Albert "Emergence of scaling in random networks",
 /// Science 286, pp 509-512, 1999.
 ///
 /// :param int n: The number of nodes to extend the graph to.
 /// :param int m: The number of edges to attach from a new node to existing nodes.
-/// :param int seed: An optional seed to use for the random number generator
+/// :param int seed: An optional seed to use for the random number generator.
 /// :param PyGraph initial_graph: An optional initial graph to use as a starting
 ///     point. :func:`.star_graph` is used to create an ``m`` node star graph
 ///     to use as a starting point. If specified the input graph will be
@@ -447,7 +447,7 @@ pub fn barabasi_albert_graph(
 /// of the extension algorithm all edges are treated as weak (meaning directionality
 /// isn't considered).
 ///
-/// The algorithm performed by this function are described in:
+/// The algorithm performed by this function is described in:
 ///
 /// A. L. Barabási and R. Albert "Emergence of scaling in random networks",
 /// Science 286, pp 509-512, 1999.

--- a/src/random_graph.rs
+++ b/src/random_graph.rs
@@ -379,3 +379,125 @@ pub fn random_geometric_graph(
     };
     Ok(graph)
 }
+
+/// Generate a random graph using Barabási–Albert preferential attachment
+///
+/// A graph is grown to $n$ nodes by adding new nodes each with $m$ edges that
+/// are preferentially attached to existing nodes with high degree. All the edges
+/// and nodes added to this graph will have weights of ``None``.
+///
+/// The algorithm performed by this function are described in:
+///
+/// A. L. Barabási and R. Albert "Emergence of scaling in random networks",
+/// Science 286, pp 509-512, 1999.
+///
+/// :param int n: The number of nodes to extend the graph to.
+/// :param int m: The number of edges to attach from a new node to existing nodes.
+/// :param int seed: An optional seed to use for the random number generator
+/// :param PyGraph initial_graph: An optional initial graph to use as a starting
+///     point. :func:`.star_graph` is used to create an ``m`` node star graph
+///     to use as a starting point. If specified the input graph will be
+///     modified in place.
+///
+/// :return: A PyGraph object
+/// :rtype: PyGraph
+#[pyfunction]
+pub fn barabasi_albert_graph(
+    py: Python,
+    n: usize,
+    m: usize,
+    seed: Option<u64>,
+    initial_graph: Option<graph::PyGraph>,
+) -> PyResult<graph::PyGraph> {
+    let default_fn = || py.None();
+    if m < 1 {
+        return Err(PyValueError::new_err("m must be > 0"));
+    }
+    if m >= n {
+        return Err(PyValueError::new_err("m must be < n"));
+    }
+    let graph = match core_generators::barabasi_albert_graph(
+        n,
+        m,
+        seed,
+        initial_graph.map(|x| x.graph),
+        default_fn,
+        default_fn,
+    ) {
+        Ok(graph) => graph,
+        Err(_) => {
+            return Err(PyValueError::new_err(
+                "initial_graph has either less nodes than m, or more nodes than n",
+            ))
+        }
+    };
+    Ok(graph::PyGraph {
+        graph,
+        node_removed: false,
+        multigraph: true,
+        attrs: py.None(),
+    })
+}
+
+/// Generate a random graph using Barabási–Albert preferential attachment
+///
+/// A graph is grown to $n$ nodes by adding new nodes each with $m$ edges that
+/// are preferentially attached to existing nodes with high degree. All the edges
+/// and nodes added to this graph will have weights of ``None``. For the purposes
+/// of the extension algorithm all edges are treated as weak (meaning directionality
+/// isn't considered).
+///
+/// The algorithm performed by this function are described in:
+///
+/// A. L. Barabási and R. Albert "Emergence of scaling in random networks",
+/// Science 286, pp 509-512, 1999.
+///
+/// :param int n: The number of nodes to extend the graph to.
+/// :param int m: The number of edges to attach from a new node to existing nodes.
+/// :param int seed: An optional seed to use for the random number generator
+/// :param PyDiGraph initial_graph: An optional initial graph to use as a starting
+///     point. :func:`.star_graph` is used to create an ``m`` node star graph
+///     to use as a starting point. If specified the input graph will be
+///     modified in place.
+///
+/// :return: A PyDiGraph object
+/// :rtype: PyDiGraph
+#[pyfunction]
+pub fn directed_barabasi_albert_graph(
+    py: Python,
+    n: usize,
+    m: usize,
+    seed: Option<u64>,
+    initial_graph: Option<digraph::PyDiGraph>,
+) -> PyResult<digraph::PyDiGraph> {
+    let default_fn = || py.None();
+    if m < 1 {
+        return Err(PyValueError::new_err("m must be > 0"));
+    }
+    if m >= n {
+        return Err(PyValueError::new_err("m must be < n"));
+    }
+    let graph = match core_generators::barabasi_albert_graph(
+        n,
+        m,
+        seed,
+        initial_graph.map(|x| x.graph),
+        default_fn,
+        default_fn,
+    ) {
+        Ok(graph) => graph,
+        Err(_) => {
+            return Err(PyValueError::new_err(
+                "initial_graph has either less nodes than m, or more nodes than n",
+            ))
+        }
+    };
+    Ok(digraph::PyDiGraph {
+        graph,
+        node_removed: false,
+        check_cycle: false,
+        cycle_state: algo::DfsSpace::default(),
+        multigraph: false,
+        attrs: py.None(),
+    })
+}

--- a/tests/rustworkx_tests/test_random.py
+++ b/tests/rustworkx_tests/test_random.py
@@ -236,3 +236,45 @@ class TestRandomSubGraphIsomorphism(unittest.TestCase):
         self.assertTrue(
             rustworkx.is_subgraph_isomorphic(graph, subgraph, id_order=True, induced=False)
         )
+
+
+class TestBarabasiAlbertGraph(unittest.TestCase):
+    def test_barabasi_albert_graph(self):
+        graph = rustworkx.barabasi_albert_graph(500, 450, 42)
+        self.assertEqual(graph.num_nodes(), 500)
+        self.assertEqual(graph.num_edges(), (50 * 450) + 449)
+
+    def test_directed_barabasi_albert_graph(self):
+        graph = rustworkx.directed_barabasi_albert_graph(500, 450, 42)
+        self.assertEqual(graph.num_nodes(), 500)
+        self.assertEqual(graph.num_edges(), (50 * 450) + 449)
+
+    def test_barabasi_albert_graph_with_starting_graph(self):
+        initial_graph = rustworkx.generators.path_graph(450)
+        graph = rustworkx.barabasi_albert_graph(500, 450, 42, initial_graph)
+        self.assertEqual(graph.num_nodes(), 500)
+        self.assertEqual(graph.num_edges(), (50 * 450) + 449)
+
+    def test_directed_barabasi_albert_graph_with_starting_graph(self):
+        initial_graph = rustworkx.generators.directed_path_graph(450)
+        graph = rustworkx.directed_barabasi_albert_graph(500, 450, 42, initial_graph)
+        self.assertEqual(graph.num_nodes(), 500)
+        self.assertEqual(graph.num_edges(), (50 * 450) + 449)
+
+    def test_invalid_barabasi_albert_graph_args(self):
+        with self.assertRaises(ValueError):
+            rustworkx.barabasi_albert_graph(5, 400)
+        with self.assertRaises(ValueError):
+            rustworkx.barabasi_albert_graph(5, 0)
+        initial_graph = rustworkx.generators.path_graph(450)
+        with self.assertRaises(ValueError):
+            rustworkx.barabasi_albert_graph(5, 4, initial_graph=initial_graph)
+
+    def test_invalid_directed_barabasi_albert_graph_args(self):
+        with self.assertRaises(ValueError):
+            rustworkx.directed_barabasi_albert_graph(5, 400)
+        with self.assertRaises(ValueError):
+            rustworkx.directed_barabasi_albert_graph(5, 0)
+        initial_graph = rustworkx.generators.directed_path_graph(450)
+        with self.assertRaises(ValueError):
+            rustworkx.directed_barabasi_albert_graph(5, 4, initial_graph=initial_graph)


### PR DESCRIPTION
This commit adds new random graph functions to rustworkx and rustworkx-core to implement a random graph generator using the Barabási–Albert preferential attachment method. It takes an input graph (defaulting to a star graph) and then extends it to a given size.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
