### PR TITLE
Add musl aarch64 support at tier 4

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -154,6 +154,102 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: wheelhouse/
+  build_wheels_musl_aarch64:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    environment: release
+    permissions:
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: '3.8'
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel==2.16.2
+      - name: Build wheels
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_ARCHS_LINUX: aarch64
+          CIBW_BEFORE_ALL_LINUX: apk add --no-cache curl gcc && curl https://sh.rustup.rs
+            -sSf | sh -s -- -y && source $HOME/.cargo/env && rustup install
+            stable && rustup default stable
+          CIBW_ENVIRONMENT_LINUX: PATH="$PATH:$HOME/.cargo/bin:$HOME/.cargo/env"
+            CARGO_NET_GIT_FETCH_WITH_CLI="true"
+          CIBW_SKIP: cp36-* pp* *win32 *macosx* *manylinux* *686* *s390x* *x86* cp37-*
+            cp311-* cp312-*
+          CIBW_BEFORE_BUILD: pip install -U setuptools-rust
+          CIBW_TEST_REQUIRES: networkx testtools fixtures
+          CIBW_BUILD_FRONTEND: pip
+          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
+          CIBW_TEST_SKIP: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheelhouse/
+  build_wheels_musl_aarch64_part_2:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    environment: release
+    permissions:
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: '3.8'
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel==2.16.2
+      - name: Build wheels
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_ARCHS_LINUX: aarch64
+          CIBW_BEFORE_ALL_LINUX: apk add --no-cache curl gcc && curl https://sh.rustup.rs
+            -sSf | sh -s -- -y && source $HOME/.cargo/env && rustup install
+            stable && rustup default stable
+          CIBW_ENVIRONMENT_LINUX: PATH="$PATH:$HOME/.cargo/bin:$HOME/.cargo/env"
+            CARGO_NET_GIT_FETCH_WITH_CLI="true"
+          CIBW_SKIP: cp36-* pp* *win32 *macosx* *manylinux* *686* *s390x* *x86* cp37-*
+            cp38-* cp39-* cp310-*
+          CIBW_BEFORE_BUILD: pip install -U setuptools-rust
+          CIBW_TEST_REQUIRES: networkx testtools fixtures
+          CIBW_BUILD_FRONTEND: pip
+          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
+          CIBW_TEST_SKIP: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheelhouse/
   build_wheels_ppc64le:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -183,11 +183,6 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_LINUX: aarch64
-          CIBW_BEFORE_ALL_LINUX: apk add --no-cache curl gcc && curl https://sh.rustup.rs
-            -sSf | sh -s -- -y && source $HOME/.cargo/env && rustup install
-            stable && rustup default stable
-          CIBW_ENVIRONMENT_LINUX: PATH="$PATH:$HOME/.cargo/bin:$HOME/.cargo/env"
-            CARGO_NET_GIT_FETCH_WITH_CLI="true"
           CIBW_SKIP: cp36-* cp37-*
             cp311-* cp312-*
           CIBW_BUILD_FRONTEND: pip

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -183,8 +183,7 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_LINUX: aarch64
-          CIBW_SKIP: cp36-* cp37-*
-            cp311-* cp312-*
+          CIBW_SKIP: cp36-* cp37-* cp311-* cp312-*
           CIBW_BUILD_FRONTEND: pip
           CIBW_TEST_SKIP: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
       - uses: actions/upload-artifact@v3
@@ -223,17 +222,8 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_LINUX: aarch64
-          CIBW_BEFORE_ALL_LINUX: apk add --no-cache curl gcc && curl https://sh.rustup.rs
-            -sSf | sh -s -- -y && source $HOME/.cargo/env && rustup install
-            stable && rustup default stable
-          CIBW_ENVIRONMENT_LINUX: PATH="$PATH:$HOME/.cargo/bin:$HOME/.cargo/env"
-            CARGO_NET_GIT_FETCH_WITH_CLI="true"
-          CIBW_SKIP: cp36-* pp* *win32 *macosx* *manylinux* *686* *s390x* *x86* cp37-*
-            cp38-* cp39-* cp310-*
-          CIBW_BEFORE_BUILD: pip install -U setuptools-rust
-          CIBW_TEST_REQUIRES: networkx testtools fixtures
+          CIBW_SKIP: cp36-* cp37-* cp38-* cp39-* cp310-*
           CIBW_BUILD_FRONTEND: pip
-          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
           CIBW_TEST_SKIP: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -183,8 +183,8 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_LINUX: aarch64
-          CIBW_SKIP: *many* cp36-* cp37-* cp311-* cp312-*
-          CIBW_TEST_SKIP: *many* cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
+          CIBW_SKIP: cp36-* cp37-* cp311-* cp312-* *many*
+          CIBW_TEST_SKIP: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* *many*
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
@@ -221,8 +221,8 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_LINUX: aarch64
-          CIBW_SKIP: *many* cp36-* cp37-* cp38-* cp39-* cp310-*
-          CIBW_TEST_SKIP: *many* cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
+          CIBW_SKIP: cp36-* cp37-* cp38-* cp39-* cp310-* *many*
+          CIBW_TEST_SKIP: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* *many*
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -188,12 +188,9 @@ jobs:
             stable && rustup default stable
           CIBW_ENVIRONMENT_LINUX: PATH="$PATH:$HOME/.cargo/bin:$HOME/.cargo/env"
             CARGO_NET_GIT_FETCH_WITH_CLI="true"
-          CIBW_SKIP: cp36-* pp* *win32 *macosx* *manylinux* *686* *s390x* *x86* cp37-*
+          CIBW_SKIP: cp36-* cp37-*
             cp311-* cp312-*
-          CIBW_BEFORE_BUILD: pip install -U setuptools-rust
-          CIBW_TEST_REQUIRES: networkx testtools fixtures
           CIBW_BUILD_FRONTEND: pip
-          CIBW_TEST_COMMAND: python -m unittest discover {project}/tests/rustworkx_tests
           CIBW_TEST_SKIP: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -183,9 +183,8 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_LINUX: aarch64
-          CIBW_SKIP: cp36-* cp37-* cp311-* cp312-*
-          CIBW_BUILD_FRONTEND: pip
-          CIBW_TEST_SKIP: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
+          CIBW_SKIP: *many* cp36-* cp37-* cp311-* cp312-*
+          CIBW_TEST_SKIP: *many* cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
@@ -222,9 +221,8 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_LINUX: aarch64
-          CIBW_SKIP: cp36-* cp37-* cp38-* cp39-* cp310-*
-          CIBW_BUILD_FRONTEND: pip
-          CIBW_TEST_SKIP: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
+          CIBW_SKIP: *many* cp36-* cp37-* cp38-* cp39-* cp310-*
+          CIBW_TEST_SKIP: *many* cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -93,6 +93,10 @@ source.
      - x86_64
      - :ref:`tier-3`
      -
+   * - Linux (musl)
+     - aarch64
+     - :ref:`tier-4`
+     - 
    * - macOS (10.12 or newer)
      - x86_64
      - :ref:`tier-1`

--- a/releasenotes/notes/platform-updates-e9b296144e633c95.yaml
+++ b/releasenotes/notes/platform-updates-e9b296144e633c95.yaml
@@ -1,7 +1,8 @@
 ---
 features:
   - |
-    Added support for musl Linux platforms on x86_64 and aarch64 at :ref:`tier-3`.
+    Added support for musl Linux platforms on x86_64 at :ref:`tier-3`
+    and aarch64 at :ref:`tier-4`.
 upgrade:
   - |
     Support for the Linux ppc64le pllatform has changed from tier 3 to tier 4


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Follow up to #992 and #997

This adds support for musl aarch64 wheels.  

The wheels are unstested because of QEMU and NumPy. QEMU takes around 30+ minutes per Python version to build rustworkx.  NumPy doesn't provide wheels for this architecture, hence adding tests would balloon the time considerably just to compile NumPy.

After #891, we can improve this architecture support by adding tests