### PR TITLE
Pin Numpy < 2 in requirements

### DIFF
--- a/releasenotes/notes/numpy-2-pin-11bc3a379fb29bf7.yaml
+++ b/releasenotes/notes/numpy-2-pin-11bc3a379fb29bf7.yaml
@@ -1,0 +1,12 @@
+---
+other:
+  - |
+    This version of rustworkx is explicitly pinned to the Numpy 1.x series,
+    because it includes compiled extensions that are not yet compiled against
+    the as-yet-unreleased Numpy 2.x series.  We will release a new version of
+    rustworkx with Numpy 2.x support as soon as feasible.
+
+    We cannot prevent your package manager from resolving to older versions of
+    rustworkx (which do not have the same pin but are still likely to be
+    incompatible) if you forcibly try to install rustworkx alongside Numpy 2,
+    before we have released a compatible version.

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ graphviz_extras = ["pillow>=5.4"]
 PKG_NAME = os.getenv("RUSTWORKX_PKG_NAME", "rustworkx")
 PKG_VERSION = "0.14.0"
 PKG_PACKAGES = ["rustworkx", "rustworkx.visualization"]
-PKG_INSTALL_REQUIRES = ["numpy>=1.16.0"]
+PKG_INSTALL_REQUIRES = ["numpy>=1.16.0,<2"]
 RUST_EXTENSIONS = [RustExtension("rustworkx.rustworkx", "Cargo.toml",
                                  binding=Binding.PyO3, debug=rustworkx_debug)]
 


### PR DESCRIPTION
We have compiled extensions that are built against the Numpy C API. The Numpy transition guide for developers of downstream packages[1] encourages us to put in this pin until we have wheels built against the newer version, which is not expected to be fully ABI compatible (but extensions built against Numpy 2 _should_ work with older versions of Numpy).

Note that this won't prevent package managers from resolving _older_ versions of rustworkx (which don't have the pin) along with Numpy 2, but there's not a vast amount we can do about that now.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
