### PR TITLE
Adding edge coloring algorithm for bipartite graphs

### DIFF
--- a/releasenotes/notes/edge-color-bipartite-70d52fc23c49ab4f.yaml
+++ b/releasenotes/notes/edge-color-bipartite-70d52fc23c49ab4f.yaml
@@ -1,0 +1,27 @@
+---
+features:
+  - | 
+    Added a new exception class :class:`~.GraphNotBipartite` which is raised when a 
+    graph is not bipartite. The sole user of this exception is the :func:`~.graph_if_bipartite_edge_color` 
+    which will raise it when the user provided graph is not bipartite.
+  - |
+    Added a new function, :func:`~.graph_if_bipartite_edge_color` to color edges
+    of a :class:`~.PyGraph` object. The function first checks whether a graph is
+    bipartite, raising exception of type :class:`~.GraphNotBipartite` if this is not the case.
+    Otherwise, the function calls the algorithm for edge-coloring bipartite graphs,
+    and returns a dictionary with key being the edge index and value being the assigned
+    color.
+    
+    The implemented algorithm the paper "A simple algorithm for edge-coloring 
+    bipartite multigraphs" by Noga Alon, 2003.
+       
+    The coloring produces at most d colors where d is the maximum degree of a node in the graph.
+    The algorithm runs in time ``O (m log m)``, where ``m`` is the number of edges in the graph.
+    
+    .. jupyter-execute::
+    
+        import rustworkx as rx
+    
+        graph = rustworkx.generators.cycle_graph(8)
+        edge_colors = rustworkx.rustworkx.graph_if_bipartite_edge_color(graph)
+        assert edge_colors == ({0: 0, 1: 1, 2: 0, 3: 1, 4: 0, 5: 1, 6: 0, 7: 1}

--- a/rustworkx-core/src/bipartite_coloring.rs
+++ b/rustworkx-core/src/bipartite_coloring.rs
@@ -807,10 +807,7 @@ mod test_bipartite_coloring {
         let l_nodes = vec![];
         let r_nodes = vec![];
         let colors = bipartite_edge_color(&graph, &l_nodes, &r_nodes);
-        let expected_colors: DictMap<EdgeIndex, usize> = [
-        ]
-        .into_iter()
-        .collect();
+        let expected_colors: DictMap<EdgeIndex, usize> = [].into_iter().collect();
         assert_eq!(colors, expected_colors);
     }
 
@@ -820,10 +817,7 @@ mod test_bipartite_coloring {
         let l_nodes = vec![];
         let r_nodes = vec![];
         let colors = bipartite_edge_color(&graph, &l_nodes, &r_nodes);
-        let expected_colors: DictMap<EdgeIndex, usize> = [
-        ]
-        .into_iter()
-        .collect();
+        let expected_colors: DictMap<EdgeIndex, usize> = [].into_iter().collect();
         assert_eq!(colors, expected_colors);
     }
 

--- a/rustworkx-core/src/bipartite_coloring.rs
+++ b/rustworkx-core/src/bipartite_coloring.rs
@@ -21,9 +21,8 @@ use crate::coloring::two_color;
 use petgraph::prelude::StableGraph;
 use petgraph::stable_graph::{EdgeIndex, NodeIndex};
 use petgraph::visit::{
-    EdgeCount, EdgeRef, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges,
-    IntoEdgesDirected, IntoNodeIdentifiers, NodeCount,
-    NodeIndexable,
+    EdgeCount, EdgeRef, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges, IntoEdgesDirected,
+    IntoNodeIdentifiers, NodeCount, NodeIndexable,
 };
 use petgraph::{Incoming, Outgoing, Undirected};
 use std::error::Error;
@@ -446,12 +445,7 @@ pub fn bipartite_edge_color<G>(
     r_nodes: &Vec<G::NodeId>,
 ) -> DictMap<G::EdgeId, usize>
 where
-    G: GraphBase
-        + NodeCount
-        + IntoNodeIdentifiers
-        + EdgeCount
-        + GraphProp
-        + IntoEdgesDirected,
+    G: GraphBase + NodeCount + IntoNodeIdentifiers + EdgeCount + GraphProp + IntoEdgesDirected,
     G::NodeId: Eq + Hash,
     G::EdgeId: Eq + Hash,
 {

--- a/rustworkx-core/src/bipartite_coloring.rs
+++ b/rustworkx-core/src/bipartite_coloring.rs
@@ -1,0 +1,712 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+use std::cmp::{max, min};
+use crate::dictmap::*;
+
+use std::hash::Hash;
+
+use hashbrown::HashMap;
+
+use crate::coloring::two_color;
+use petgraph::visit::{EdgeCount, EdgeIndexable, EdgeRef, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges, IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount, NodeIndexable, Visitable};
+use std::error::Error;
+use std::fmt;
+use petgraph::data::DataMap;
+use petgraph::{Graph, Undirected};
+use petgraph::graph::{edge_index, Node, NodeIndex, UnGraph};
+use petgraph::prelude::StableGraph;
+use petgraph::stable_graph::EdgeIndex;
+use rayon_cond::CondIterator::Parallel;
+
+
+/// Error returned by bipartite coloring if the graph is not bipartite
+/// is impossible
+#[derive(Debug, PartialEq, Eq, Ord, PartialOrd, Copy, Clone)]
+pub struct GraphNotBipartite;
+
+impl Error for GraphNotBipartite {}
+impl fmt::Display for GraphNotBipartite {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "No mapping possible.")
+    }
+}
+
+#[derive(Clone, Debug)]
+struct EdgeData {
+    // multiplicity of the edge
+    multiplicity: usize,
+    // true if considered a bad edge
+    bad: bool,
+}
+
+type EdgedGraph = StableGraph<(), EdgeData, Undirected>;
+type Matching = Vec<(NodeIndex, NodeIndex)>;
+
+
+struct RegularBipartiteMultiGraph {
+    graph: EdgedGraph,
+    degree: usize,
+    l_nodes:  Vec<NodeIndex>,
+    r_nodes: Vec<NodeIndex>,
+
+}
+
+
+
+
+impl RegularBipartiteMultiGraph
+{
+    fn new() -> Self {
+        let graph: EdgedGraph = StableGraph::default();
+
+        RegularBipartiteMultiGraph {
+            graph: graph,
+            degree: 0,
+            l_nodes: vec![],
+            r_nodes: vec![]
+        }
+    }
+
+    fn copy(parent: &RegularBipartiteMultiGraph) -> Self {
+        RegularBipartiteMultiGraph {
+            graph: parent.graph.clone(),
+            degree: parent.degree.clone(),
+            l_nodes: parent.l_nodes.clone(),
+            r_nodes: parent.r_nodes.clone()
+        }
+    }
+
+    fn copy_without_edges(parent: &RegularBipartiteMultiGraph) -> Self {
+        let mut graph_copy:  EdgedGraph = parent.graph.clone();
+        graph_copy.clear_edges();
+        RegularBipartiteMultiGraph {
+            graph: graph_copy,
+            degree: 0,
+            l_nodes: parent.l_nodes.clone(),
+            r_nodes: parent.r_nodes.clone()
+        }
+    }
+
+    fn add_edge(&mut self, a: NodeIndex, b: NodeIndex, multiplicity: usize, bad: bool) {
+        let edge = self.graph.find_edge(a, b);
+        if edge.is_some() {
+            let mut edge_data = self.graph.edge_weight_mut(edge.unwrap()).unwrap();
+            edge_data.multiplicity += multiplicity;
+        }
+        else {
+            let edge_data = EdgeData {multiplicity, bad};
+            self.graph.add_edge(a, b, edge_data);
+        }
+    }
+
+    fn remove_edge(&mut self, a: NodeIndex, b: NodeIndex, multiplicity: usize) {
+        let edge = self.graph.find_edge(a, b);
+        let mut edge_data = self.graph.edge_weight_mut(edge.unwrap()).unwrap();
+        edge_data.multiplicity -= multiplicity;
+        if edge_data.multiplicity == 0 {
+            self.graph.remove_edge(edge.unwrap());
+        }
+    }
+
+    fn add_matching(&mut self, matching: &Matching) {
+        for (a, b) in matching {
+            self.add_edge(*a, *b, 1, false);
+        }
+        self.degree += 1;
+    }
+
+    fn remove_matching(&mut self, matching: &Matching) {
+        for (a, b) in matching {
+            self.remove_edge(*a, *b, 1);
+        }
+        self.degree -= 1;
+    }
+
+    fn print(&self) {
+        let nodes: Vec<_> = self.graph.node_indices().collect();
+        let edges: Vec<_> = self.graph.edge_references().collect();
+        println!("===============");
+        println!("degree: {:?}", self.degree);
+        println!("nodes:");
+        for node in nodes {
+            println!("  {:?}", node);
+        }
+        println!("edges:");
+        for edge in edges {
+            println!("  {:?}", edge);
+        }
+        // println!("map: {:?}", self.node_map);
+        // println!("revmap: {:?}", self.rev_node_map);
+        println!("l_nodes: {:?}", self.l_nodes);
+        println!("r_nodes: {:?}", self.r_nodes);
+        println!("===============");
+    }
+
+}
+
+
+
+pub fn bipartite_edge_color<G>(input_graph: G, input_l_nodes: Vec<G::NodeId>, input_r_nodes: Vec<G::NodeId>) -> DictMap<G::EdgeId, usize>
+where G: GraphBase + NodeCount + NodeIndexable + IntoNodeIdentifiers + IntoEdges + EdgeCount + EdgeIndexable,
+G::NodeId: Eq + Hash,
+G::EdgeId: Eq + Hash,
+{
+    let mut rbmg: RegularBipartiteMultiGraph = RegularBipartiteMultiGraph::new();
+
+    let mut node_map: HashMap<G::NodeId, NodeIndex> = HashMap::with_capacity(input_graph.node_count());
+    let mut rev_node_map: HashMap<NodeIndex, G::NodeId> = HashMap::with_capacity(input_graph.node_count());
+
+    let input_graph_node_indices: Vec<G::NodeId> = input_graph.node_identifiers().collect();
+
+    // Compute maximum degree of a node in input_graph
+    let mut max_degree: usize = 0;
+    for input_node_id in &input_graph_node_indices {
+        let mut node_degree = 0;
+        for edge in input_graph.edges(*input_node_id) {
+            node_degree += 1;
+        }
+        max_degree = max(max_degree, node_degree);
+    }
+    println!("max degree is {:?}", max_degree);
+    // Add nodes to multi-graph
+    // ToDo: add optimization to combine nodes
+    for input_node_id in &input_graph_node_indices {
+        let rbmg_node_id = rbmg.graph.add_node(());
+        node_map.insert(*input_node_id, rbmg_node_id);
+        rev_node_map.insert(rbmg_node_id, *input_node_id);
+    }
+
+    // Set l_nodes and r_nodes
+    for input_node_id in input_l_nodes {
+        rbmg.l_nodes.push(*node_map.get(&input_node_id).unwrap());
+    }
+    for input_node_id in input_r_nodes {
+        rbmg.r_nodes.push(*node_map.get(&input_node_id).unwrap());
+    }
+
+    // Adds edges (note that input_graph may have multiple edges between the same
+    // pair of vertices
+    for edge in input_graph.edge_references() {
+        // todo: endpoints
+        let mapped_source = *node_map.get(&edge.source()).unwrap();
+        let mapped_target = *node_map.get(&edge.target()).unwrap();
+        rbmg.add_edge(mapped_source, mapped_target, 1, false);
+    }
+
+    // Create additional left or right vertices
+    let n: usize = max(rbmg.l_nodes.len(), rbmg.r_nodes.len());
+
+    while rbmg.l_nodes.len() < n {
+        let new_node_index = rbmg.graph.add_node(());
+        // todo: possibly update reverse node map
+        rbmg.l_nodes.push(new_node_index);
+    }
+
+    while rbmg.r_nodes.len() < n {
+        let new_node_index = rbmg.graph.add_node(());
+        // todo: possibly update reverse node map
+        rbmg.r_nodes.push(new_node_index);
+    }
+
+    let mut l_index = 0;
+    let mut r_index = 0;
+
+    while l_index < n {
+        let l_degree: usize = rbmg.graph.edges(rbmg.l_nodes[l_index]).map(|e| e.weight().multiplicity).sum();
+        if l_degree == max_degree {
+            l_index += 1;
+            continue
+        }
+        let r_degree: usize = rbmg.graph.edges(rbmg.r_nodes[r_index]).map(|e| e.weight().multiplicity).sum();
+        if r_degree == max_degree {
+            r_index += 1;
+            continue
+        }
+
+        println!("max_degree = {:?}, l_index = {:?}, l_degree = {:?}, r_index = {:?}, r_degree = {:?} ", max_degree, l_index, l_degree, r_index, r_degree);
+        let multiplicity = min(max_degree - l_degree, max_degree - r_degree);
+        rbmg.add_edge(rbmg.l_nodes[l_index], rbmg.r_nodes[r_index], multiplicity, false);
+    }
+    rbmg.degree = max_degree;
+
+    rbmg.print();
+
+
+    let coloring = rbmg_edge_color(&rbmg);
+    println!("Discovered coloring {:?}", coloring);
+
+    // Let's build map (NodeIndex, NodeIndex) -> list of colors
+    let mut endpoints_to_colors: DictMap<(NodeIndex, NodeIndex), Vec<usize>> = DictMap::with_capacity(rbmg.graph.edge_count());
+    for (color, matching) in coloring.iter().enumerate()
+    {
+        for (a, b) in matching {
+            let (a0, b0) = if a.index() < b.index() {(a, b)} else {(b, a)};
+            println!("a0 = {:?}, b0 = {:?}, colors = {}", a0, b0, color);
+            // println!("=> a = {:?}, aind = {:?}, b = {:?}, bind = {:?}", a, a.index(), b, b.index());
+            // let mut colors =
+            if let Some(colors) = endpoints_to_colors.get_mut(&(*a0, *b0)) {
+                colors.push(color);
+            }
+            else {
+                endpoints_to_colors.insert((*a0, *b0), vec![color]);
+            }
+        }
+    }
+    println!("and the hashmap is:");
+    println!("{:?}", endpoints_to_colors);
+
+    // Iterate over all edges in the original graph...
+    let mut edge_coloring: DictMap<G::EdgeId, usize> = DictMap::with_capacity(input_graph.edge_count());
+
+    for edge in input_graph.edge_references() {
+        let a = *node_map.get(&edge.source()).unwrap();
+        let b = *node_map.get(&edge.target()).unwrap();
+        let (a0, b0) = if a.index() < b.index() {(a, b)} else {(b, a)};
+        let colors = endpoints_to_colors.get_mut(&(a0, b0)).unwrap();
+        let last_color = colors.last().unwrap();
+        //EdgeIndexable::to_index(&input_graph, edge.id())
+        edge_coloring.insert(edge.id(), *last_color);
+        colors.pop();
+    }
+
+    edge_coloring
+}
+
+
+/// Returns a set of Euler cycles for a possibly disconnected graph.
+///
+///
+
+fn other_node(graph: &EdgedGraph, edge_index: EdgeIndex, node_index: NodeIndex) -> NodeIndex {
+    let (node1, node2) = graph.edge_endpoints(edge_index).unwrap();
+    return if node_index == node1 {node2} else {node1};
+}
+
+
+fn euler_cycles(input_graph: &EdgedGraph) -> Vec<Vec<EdgeIndex>>
+{
+    let mut cycles: Vec<Vec<EdgeIndex>> = Vec::new();
+
+    let mut graph = input_graph.clone();
+    let mut in_component = vec![false; graph.node_bound()];
+
+    let node_indices: Vec<NodeIndex> = graph.node_identifiers().collect();
+
+    for node_id in node_indices {
+        if in_component[node_id.index()] {
+            continue
+        }
+        let mut stack: Vec<(NodeIndex, Option<EdgeIndex>)> = vec![(node_id, None)];
+        let mut cycle: Vec<EdgeIndex> = vec![];
+        while !stack.is_empty() {
+            let (last_node_id, last_edge_id) = stack.last().unwrap();
+            in_component[last_node_id.index()] = true;
+
+            // println!("examining node = {:?}, edge = {:?}", last_node_id, last_edge_id);
+
+            let new_edge = graph.edges(*last_node_id).next();
+            // println!("=> new_edge = {:?}", new_edge);
+
+            if new_edge.is_none() {
+                // println!("adding {:?} to cycle", last_edge_id);
+                if last_edge_id.is_some() {
+                    cycle.push(last_edge_id.unwrap());
+                }
+                stack.pop();
+            }
+            else {
+                let new_edge_id = new_edge.unwrap().id();
+                let new_node_id =other_node(&graph, new_edge_id, *last_node_id);
+                stack.push((new_node_id, Some(new_edge_id)));
+                // println!("pushing {:?}, {:?} to stack", new_node_id, new_edge_id);
+
+                // println!("BEFORE REMOVING");
+                // print_graph(&graph);
+                graph.remove_edge(new_edge_id);
+                // println!("AFTER REMOVING");
+                // print_graph(&graph);
+
+
+
+            }
+        }
+        println!("new cycle = {:?}", cycle);
+        cycles.push(cycle);
+    }
+
+    cycles
+}
+
+fn rbmg_split_into_two(g: &RegularBipartiteMultiGraph) -> (RegularBipartiteMultiGraph, RegularBipartiteMultiGraph) {
+    if g.degree % 2 == 1 {
+        panic!("Cannot split multi-graph of odd degree.")
+    }
+
+    let mut h1: RegularBipartiteMultiGraph = RegularBipartiteMultiGraph::copy_without_edges(&g);
+    h1.degree = g.degree.clone() / 2;
+
+    let mut h2: RegularBipartiteMultiGraph = RegularBipartiteMultiGraph::copy_without_edges(&g);
+    h2.degree = g.degree.clone() / 2;
+
+    let mut r: EdgedGraph = g.graph.clone();
+    r.clear_edges();
+
+    for edge in g.graph.edge_references() {
+        let multiplicity = edge.weight().multiplicity;
+        let bad = edge.weight().bad;
+        if multiplicity >= 2 {
+            h1.add_edge(edge.source(), edge.target(), multiplicity / 2, bad);
+            h2.add_edge(edge.source(), edge.target(), multiplicity / 2, bad);
+        }
+        if multiplicity % 2 == 1 {
+            r.add_edge(edge.source(), edge.target(), EdgeData  { multiplicity: 1, bad: bad });
+        }
+    }
+
+    println!("r:");
+    print_graph(&r);
+    let cycles = euler_cycles(&r);
+    println!("detected cycles = {:?}", cycles);
+
+    for cycle in cycles.into_iter() {
+        for i in 0..cycle.len() {
+            let (source, target) = r.edge_endpoints(cycle[i]).unwrap();
+            let bad = r.edge_weight(cycle[i]).unwrap().bad;
+            if i % 2 == 0 {
+                h1.add_edge(source, target, 1, bad);
+            }
+            else {
+                h2.add_edge(source, target, 1, bad);
+            }
+        }
+    }
+
+
+    (h1, h2)
+}
+
+
+fn rbmg_find_perfect_matching(g: &RegularBipartiteMultiGraph) -> Matching {
+    let k = g.degree;
+    let n = g.l_nodes.len();
+    let m = k * n;
+    let t =m.next_power_of_two();
+    let t2 = t.trailing_zeros();
+    let alpha = t / k;
+    let beta = t - k * alpha;
+
+
+
+    println!("rbmg_find_perfect_matching: k = {}, n = {}, m = {}, t = {}, t2 = {}", k, n, m, t, t2);
+
+    println!("printing g");
+    g.print();
+
+
+    let mut h1: RegularBipartiteMultiGraph = RegularBipartiteMultiGraph::copy_without_edges(&g);
+    h1.degree = t;
+
+    for edge in g.graph.edge_references() {
+        h1.add_edge(edge.source(), edge.target(), alpha * edge.weight().multiplicity, false);
+    }
+
+    // Choose an arbitrary matching left[i] -- right[i]
+    for i in 0..n {
+        h1.add_edge(g.l_nodes[i], g.r_nodes[i], beta, true);
+    }
+
+    println!("printing h1 initially");
+    println!("============");
+    h1.print();
+
+    // Recursively split until we find a matching
+    for _ in 0..t2 {
+        let (h2, h3): (RegularBipartiteMultiGraph, RegularBipartiteMultiGraph) = rbmg_split_into_two(&h1);
+        let bad_h2: usize = h2.graph.edge_references().map(|e| e.weight().bad as usize).sum();
+        let bad_h3: usize = h3.graph.edge_references().map(|e| e.weight().bad as usize).sum();
+        h1 = if bad_h2 <= bad_h3 {h2} else {h3};
+        println!("printing h1 after split");
+        println!("============");
+        h1.print();
+
+    }
+
+
+
+    let mut matching: Matching = Vec::with_capacity(n);
+
+    for edge in h1.graph.edge_references() {
+        matching.push((edge.source(), edge.target()));
+    }
+
+
+    println!("rbmg_find_perfect_matching: matching = {:?}", matching);
+    matching
+
+}
+
+fn rbmg_edge_color_when_power_of_two(g: &RegularBipartiteMultiGraph) -> Vec<Matching> {
+    if !g.degree.is_power_of_two() {
+        panic!("degree is not power of 2");
+    }
+
+    let mut coloring: Vec<Matching>= Vec::with_capacity(g.degree);
+
+    if g.degree == 1 {
+        println!("degree is 1 ");
+        let mut matching: Matching = Vec::with_capacity(g.l_nodes.len());
+        for edge in g.graph.edge_references() {
+            matching.push((edge.source(), edge.target()));
+        }
+        coloring.push(matching);
+        return coloring;
+    }
+
+    let (h1, h2) = rbmg_split_into_two(&g);
+    let mut h1_coloring =rbmg_edge_color_when_power_of_two(&h1);
+    let mut h2_coloring =rbmg_edge_color_when_power_of_two(&h2);
+    coloring.append(& mut h1_coloring);
+    coloring.append(& mut h2_coloring);
+
+    if coloring.len() != g.degree {
+        panic!("wrong len of coloring!!");
+    }
+
+    coloring
+}
+
+
+
+fn rbmg_edge_color(g0: &RegularBipartiteMultiGraph) -> Vec<Matching> {
+    // todo: rename to clone, and maybe don't even need to implement clone()
+    let mut g: RegularBipartiteMultiGraph = RegularBipartiteMultiGraph::copy(g0);
+
+    println!("Want to color rbmg");
+    g.print();
+
+
+    let mut coloring: Vec<Matching>= Vec::with_capacity(g.degree);
+
+    if g.degree == 0 {
+        println!("degree is 1 ");
+        return coloring
+    }
+
+    if g.degree == 1 {
+        println!("degree is 1 ");
+        let mut matching: Matching = Vec::with_capacity(g.l_nodes.len());
+        for edge in g.graph.edge_references() {
+            matching.push((edge.source(), edge.target()));
+        }
+        coloring.push(matching);
+        return coloring;
+    }
+
+    let mut odd_degree_matching: Option<Matching> = None;
+
+    if g.degree % 2 == 1 {
+        println!("degree is odd {:?}", g.degree);
+        let matching = rbmg_find_perfect_matching(&g);
+        println!("Ok, for odd degree have matching {:?}", matching);
+        g.remove_matching(&matching);
+        odd_degree_matching = Some(matching);
+    }
+
+    println!("and now degree is {:?}", g.degree);
+
+    // Split graph into two regular bipartite multigraphs of half-degree
+    let (mut h1, mut h2) = rbmg_split_into_two(&g);
+
+    // Recursively color h1
+    let h1_coloring = rbmg_edge_color(&h1);
+
+    // Transfer some matchings from H1 to H2 to make the degree of H2 to be a power of 2
+    let r = h2.degree.next_power_of_two();
+    let num_classes_to_move= r - h2.degree;
+    println!("r = {:?}, num_to_move = {:?}", r, num_classes_to_move);
+
+    for i in 0..num_classes_to_move {
+        h2.add_matching(&h1_coloring[i]);
+    }
+    println!("check: g0.degree = {:?}, g.degree = {:?}, h2 degree {:?}", g0.degree, g.degree, h2.degree);
+
+    // Edge-color h2 by recursive splitting
+    let mut h2_coloring = rbmg_edge_color_when_power_of_two(&h2);
+
+    // Now, create the matching
+
+    coloring = h2_coloring;
+
+    // Add remaining colors from h1
+    for i in num_classes_to_move..h1_coloring.len() {
+        coloring.push(h1_coloring[i].clone());
+    }
+
+    if odd_degree_matching.is_some() {
+        coloring.push(odd_degree_matching.unwrap());
+    }
+
+    if coloring.len() != g0.degree {
+        panic!("Wrong output coloring length");
+    }
+    coloring
+}
+
+
+fn print_graph(r: &EdgedGraph) {
+    let nodes: Vec<_> = r.node_indices().collect();
+    let edges: Vec<_> = r.edge_references().collect();
+    println!("===============");
+    println!("nodes:");
+    for node in nodes {
+        println!("  {:?}", node);
+    }
+    println!("edges:");
+    for edge in edges {
+        println!("  {:?}", edge);
+    }
+    println!("=======");
+}
+
+
+fn print_original_graph(r: &Graph<(), (), Undirected>) {
+    let nodes: Vec<_> = r.node_indices().collect();
+    let edges: Vec<_> = r.edge_references().collect();
+    println!("===============");
+    println!("nodes:");
+    for node in nodes {
+        println!("  {:?}", node);
+    }
+    println!("edges:");
+    for edge in edges {
+        println!("  {:?}", edge);
+    }
+    println!("=======");
+}
+
+
+
+#[cfg(test)]
+mod test_bipartite_coloring {
+    use petgraph::data::Element::Node;
+    // use crate::bipartite_coloring::greedy_edge_color;
+    use crate::dictmap::DictMap;
+    use crate::petgraph::Graph;
+
+    // use crate::bipartite_coloring::{bipartite_edge_color, RegularBipartiteMultiGraph};
+
+    use crate::bipartite_coloring::{bipartite_edge_color, EdgedGraph, euler_cycles, print_graph, print_original_graph, RegularBipartiteMultiGraph};
+    use petgraph::graph::{edge_index, EdgeIndex};
+    use petgraph::prelude::StableGraph;
+    use petgraph::stable_graph::NodeIndex;
+    use petgraph::visit::{IntoEdgeReferences, IntoNodeIdentifiers};
+    use petgraph::Undirected;
+    use crate::bipartite_coloring::EdgeData;
+    //
+    // #[test]
+    // fn test_bipartite_edge_color() {
+    //     let edge_list = vec![(0, 1), (0, 2), (0, 3), (1, 4), (2, 5), (3, 6)];
+    //     let graph = Graph::<(), (), Undirected>::from_edges(&edge_list);
+    //     println!("{:?}", graph);
+    //     let nodes: Vec<_> = graph.node_indices().collect();
+    //     let edges: Vec<_> = graph.edge_references().collect();
+    //     println!("{:?}", nodes);
+    //     println!("{:?}", edges);
+    //     bipartite_edge_color(&graph);
+    //
+    //     // println!("{:?}", graph.raw_edges());
+    // }
+
+    #[test]
+    fn test_inner() {
+        let mut graph: EdgedGraph = StableGraph::default();
+        graph.add_node(());
+        graph.add_node(());
+        graph.add_node(());
+        graph.add_edge(NodeIndex::new(0), NodeIndex::new(1), EdgeData { multiplicity: 2, bad: false });
+        graph.add_edge(NodeIndex::new(2), NodeIndex::new(1), EdgeData { multiplicity: 5, bad: true });
+
+        let nodes: Vec<_> = graph.node_indices().collect();
+        let edges: Vec<_> = graph.edge_references().collect();
+        println!("{:?}", nodes);
+        println!("{:?}", edges);
+
+
+        let edge1 = graph.find_edge(NodeIndex::new(1), NodeIndex::new(2));
+        println!("edge1: {:?}", edge1);
+
+        let edge2 = graph.find_edge(NodeIndex::new(0), NodeIndex::new(2));
+        println!("edge1: {:?}", edge2);
+
+    }
+
+
+    #[test]
+    fn test2() {
+        let edge_list = vec![(0, 1), (0, 2), (0, 3), (1, 4), (2, 5), (3, 6), (4, 1)];
+        let original_graph = Graph::<(), (), Undirected>::from_edges(&edge_list);
+        let left = vec![NodeIndex::new(0), NodeIndex::new(4), NodeIndex::new(5), NodeIndex::new(6) ];
+        let right = vec![NodeIndex::new(1), NodeIndex::new(2), NodeIndex::new(3)];
+
+
+        let output = bipartite_edge_color(&original_graph, left, right);
+        print_original_graph(&original_graph);
+        println!("FINAL FINAL {:?}", output);
+
+
+        //
+        // multigraph.graph.add_node(0);
+        // multigraph.graph.add_node(1);
+        // multigraph.graph.add_node(2);
+        //
+        // multigraph.add_edge(NodeIndex::new(0), NodeIndex::new(1), 2, false);
+        // multigraph.add_edge(NodeIndex::new(0), NodeIndex::new(1), 3, false);
+        // multigraph.add_edge(NodeIndex::new(0), NodeIndex::new(2), 4, true);
+        // multigraph.add_edge(NodeIndex::new(1), NodeIndex::new(0), 5, false);
+        //
+        //
+        // multigraph.print();
+
+    }
+
+    // #[test]
+    // fn test3() {
+    //     let edge_list = vec![(0, 1), (1, 2), (0, 3), (2, 3), (0, 2), (0, 5), (5, 2), (4, 6), (6, 4)];
+    //     let original_graph = Graph::<(), (), Undirected>::from_edges(&edge_list);
+    //
+    //     let cycles = euler_cycles(&original_graph);
+    //     println!("cycles: {:?}", cycles);
+    // }
+
+    //     let mut graph: Graph<()), EdgeData, Undirected> = Graph::new_undirected();
+    //     graph.add_node(0);
+    //     graph.add_node(1);
+    //     graph.add_node(2);
+    //     graph.add_edge(NodeIndex::new(0), NodeIndex::new(1), EdgeData { multiplicity: 2, bad: false });
+    //     graph.add_edge(NodeIndex::new(2), NodeIndex::new(1), EdgeData { multiplicity: 5, bad: true });
+    //
+    //     let nodes: Vec<_> = graph.node_indices().collect();
+    //     let edges: Vec<_> = graph.edge_references().collect();
+    //     println!("{:?}", nodes);
+    //     println!("{:?}", edges);
+    //
+    //
+    //     let edge1 = graph.find_edge(NodeIndex::new(1), NodeIndex::new(2));
+    //     println!("edge1: {:?}", edge1);
+    //
+    //     let edge2 = graph.find_edge(NodeIndex::new(0), NodeIndex::new(2));
+    //     println!("edge1: {:?}", edge2);
+    //
+    // }
+
+}

--- a/rustworkx-core/src/bipartite_coloring.rs
+++ b/rustworkx-core/src/bipartite_coloring.rs
@@ -10,24 +10,27 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-use std::cmp::{max, min};
 use crate::dictmap::*;
+use std::cmp::{max, min};
 
 use std::hash::Hash;
 
 use hashbrown::HashMap;
 
 use crate::coloring::two_color;
-use petgraph::visit::{EdgeCount, EdgeIndexable, EdgeRef, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges, IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount, NodeIndexable, Visitable};
-use std::error::Error;
-use std::fmt;
 use petgraph::data::DataMap;
-use petgraph::{Graph, Undirected};
 use petgraph::graph::{edge_index, Node, NodeIndex, UnGraph};
 use petgraph::prelude::StableGraph;
 use petgraph::stable_graph::EdgeIndex;
+use petgraph::visit::{
+    EdgeCount, EdgeIndexable, EdgeRef, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges,
+    IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount, NodeIndexable, Visitable,
+};
+use petgraph::{Graph, Undirected};
 use rayon_cond::CondIterator::Parallel;
-
+use std::error::Error;
+use std::fmt;
+use std::fmt::Debug;
 
 /// Error returned by bipartite coloring if the graph is not bipartite
 /// is impossible
@@ -52,20 +55,14 @@ struct EdgeData {
 type EdgedGraph = StableGraph<(), EdgeData, Undirected>;
 type Matching = Vec<(NodeIndex, NodeIndex)>;
 
-
 struct RegularBipartiteMultiGraph {
     graph: EdgedGraph,
     degree: usize,
-    l_nodes:  Vec<NodeIndex>,
+    l_nodes: Vec<NodeIndex>,
     r_nodes: Vec<NodeIndex>,
-
 }
 
-
-
-
-impl RegularBipartiteMultiGraph
-{
+impl RegularBipartiteMultiGraph {
     fn new() -> Self {
         let graph: EdgedGraph = StableGraph::default();
 
@@ -73,7 +70,7 @@ impl RegularBipartiteMultiGraph
             graph: graph,
             degree: 0,
             l_nodes: vec![],
-            r_nodes: vec![]
+            r_nodes: vec![],
         }
     }
 
@@ -82,18 +79,18 @@ impl RegularBipartiteMultiGraph
             graph: parent.graph.clone(),
             degree: parent.degree.clone(),
             l_nodes: parent.l_nodes.clone(),
-            r_nodes: parent.r_nodes.clone()
+            r_nodes: parent.r_nodes.clone(),
         }
     }
 
     fn copy_without_edges(parent: &RegularBipartiteMultiGraph) -> Self {
-        let mut graph_copy:  EdgedGraph = parent.graph.clone();
+        let mut graph_copy: EdgedGraph = parent.graph.clone();
         graph_copy.clear_edges();
         RegularBipartiteMultiGraph {
             graph: graph_copy,
             degree: 0,
             l_nodes: parent.l_nodes.clone(),
-            r_nodes: parent.r_nodes.clone()
+            r_nodes: parent.r_nodes.clone(),
         }
     }
 
@@ -102,9 +99,8 @@ impl RegularBipartiteMultiGraph
         if edge.is_some() {
             let mut edge_data = self.graph.edge_weight_mut(edge.unwrap()).unwrap();
             edge_data.multiplicity += multiplicity;
-        }
-        else {
-            let edge_data = EdgeData {multiplicity, bad};
+        } else {
+            let edge_data = EdgeData { multiplicity, bad };
             self.graph.add_edge(a, b, edge_data);
         }
     }
@@ -151,20 +147,30 @@ impl RegularBipartiteMultiGraph
         println!("r_nodes: {:?}", self.r_nodes);
         println!("===============");
     }
-
 }
 
-
-
-pub fn bipartite_edge_color<G>(input_graph: G, input_l_nodes: Vec<G::NodeId>, input_r_nodes: Vec<G::NodeId>) -> DictMap<G::EdgeId, usize>
-where G: GraphBase + NodeCount + NodeIndexable + IntoNodeIdentifiers + IntoEdges + EdgeCount + EdgeIndexable,
-G::NodeId: Eq + Hash,
-G::EdgeId: Eq + Hash,
+pub fn bipartite_edge_color<G>(
+    input_graph: G,
+    input_l_nodes: &Vec<G::NodeId>,
+    input_r_nodes: &Vec<G::NodeId>,
+) -> DictMap<G::EdgeId, usize>
+where
+    G: GraphBase
+        + NodeCount
+        + NodeIndexable
+        + IntoNodeIdentifiers
+        + IntoEdges
+        + EdgeCount
+        + EdgeIndexable,
+    G::NodeId: Eq + Hash,
+    G::EdgeId: Eq + Hash,
 {
     let mut rbmg: RegularBipartiteMultiGraph = RegularBipartiteMultiGraph::new();
 
-    let mut node_map: HashMap<G::NodeId, NodeIndex> = HashMap::with_capacity(input_graph.node_count());
-    let mut rev_node_map: HashMap<NodeIndex, G::NodeId> = HashMap::with_capacity(input_graph.node_count());
+    let mut node_map: HashMap<G::NodeId, NodeIndex> =
+        HashMap::with_capacity(input_graph.node_count());
+    let mut rev_node_map: HashMap<NodeIndex, G::NodeId> =
+        HashMap::with_capacity(input_graph.node_count());
 
     let input_graph_node_indices: Vec<G::NodeId> = input_graph.node_identifiers().collect();
 
@@ -177,7 +183,7 @@ G::EdgeId: Eq + Hash,
         }
         max_degree = max(max_degree, node_degree);
     }
-    println!("max degree is {:?}", max_degree);
+    // println!("max degree is {:?}", max_degree);
     // Add nodes to multi-graph
     // ToDo: add optimization to combine nodes
     for input_node_id in &input_graph_node_indices {
@@ -188,10 +194,10 @@ G::EdgeId: Eq + Hash,
 
     // Set l_nodes and r_nodes
     for input_node_id in input_l_nodes {
-        rbmg.l_nodes.push(*node_map.get(&input_node_id).unwrap());
+        rbmg.l_nodes.push(*node_map.get(input_node_id).unwrap());
     }
     for input_node_id in input_r_nodes {
-        rbmg.r_nodes.push(*node_map.get(&input_node_id).unwrap());
+        rbmg.r_nodes.push(*node_map.get(input_node_id).unwrap());
     }
 
     // Adds edges (note that input_graph may have multiple edges between the same
@@ -222,56 +228,74 @@ G::EdgeId: Eq + Hash,
     let mut r_index = 0;
 
     while l_index < n {
-        let l_degree: usize = rbmg.graph.edges(rbmg.l_nodes[l_index]).map(|e| e.weight().multiplicity).sum();
+        let l_degree: usize = rbmg
+            .graph
+            .edges(rbmg.l_nodes[l_index])
+            .map(|e| e.weight().multiplicity)
+            .sum();
         if l_degree == max_degree {
             l_index += 1;
-            continue
+            continue;
         }
-        let r_degree: usize = rbmg.graph.edges(rbmg.r_nodes[r_index]).map(|e| e.weight().multiplicity).sum();
+        let r_degree: usize = rbmg
+            .graph
+            .edges(rbmg.r_nodes[r_index])
+            .map(|e| e.weight().multiplicity)
+            .sum();
         if r_degree == max_degree {
             r_index += 1;
-            continue
+            continue;
         }
 
-        println!("max_degree = {:?}, l_index = {:?}, l_degree = {:?}, r_index = {:?}, r_degree = {:?} ", max_degree, l_index, l_degree, r_index, r_degree);
+        // println!("max_degree = {:?}, l_index = {:?}, l_degree = {:?}, r_index = {:?}, r_degree = {:?} ", max_degree, l_index, l_degree, r_index, r_degree);
         let multiplicity = min(max_degree - l_degree, max_degree - r_degree);
-        rbmg.add_edge(rbmg.l_nodes[l_index], rbmg.r_nodes[r_index], multiplicity, false);
+        rbmg.add_edge(
+            rbmg.l_nodes[l_index],
+            rbmg.r_nodes[r_index],
+            multiplicity,
+            false,
+        );
     }
     rbmg.degree = max_degree;
 
-    rbmg.print();
-
+    // rbmg.print();
 
     let coloring = rbmg_edge_color(&rbmg);
-    println!("Discovered coloring {:?}", coloring);
+    // println!("Discovered coloring {:?}", coloring);
 
     // Let's build map (NodeIndex, NodeIndex) -> list of colors
-    let mut endpoints_to_colors: DictMap<(NodeIndex, NodeIndex), Vec<usize>> = DictMap::with_capacity(rbmg.graph.edge_count());
-    for (color, matching) in coloring.iter().enumerate()
-    {
+    let mut endpoints_to_colors: DictMap<(NodeIndex, NodeIndex), Vec<usize>> =
+        DictMap::with_capacity(rbmg.graph.edge_count());
+    for (color, matching) in coloring.iter().enumerate() {
         for (a, b) in matching {
-            let (a0, b0) = if a.index() < b.index() {(a, b)} else {(b, a)};
-            println!("a0 = {:?}, b0 = {:?}, colors = {}", a0, b0, color);
-            // println!("=> a = {:?}, aind = {:?}, b = {:?}, bind = {:?}", a, a.index(), b, b.index());
-            // let mut colors =
+            let (a0, b0) = if a.index() < b.index() {
+                (a, b)
+            } else {
+                (b, a)
+            };
+            // println!("a0 = {:?}, b0 = {:?}, colors = {}", a0, b0, color);
             if let Some(colors) = endpoints_to_colors.get_mut(&(*a0, *b0)) {
                 colors.push(color);
-            }
-            else {
+            } else {
                 endpoints_to_colors.insert((*a0, *b0), vec![color]);
             }
         }
     }
-    println!("and the hashmap is:");
-    println!("{:?}", endpoints_to_colors);
+    // println!("and the hashmap is:");
+    // println!("{:?}", endpoints_to_colors);
 
     // Iterate over all edges in the original graph...
-    let mut edge_coloring: DictMap<G::EdgeId, usize> = DictMap::with_capacity(input_graph.edge_count());
+    let mut edge_coloring: DictMap<G::EdgeId, usize> =
+        DictMap::with_capacity(input_graph.edge_count());
 
     for edge in input_graph.edge_references() {
         let a = *node_map.get(&edge.source()).unwrap();
         let b = *node_map.get(&edge.target()).unwrap();
-        let (a0, b0) = if a.index() < b.index() {(a, b)} else {(b, a)};
+        let (a0, b0) = if a.index() < b.index() {
+            (a, b)
+        } else {
+            (b, a)
+        };
         let colors = endpoints_to_colors.get_mut(&(a0, b0)).unwrap();
         let last_color = colors.last().unwrap();
         //EdgeIndexable::to_index(&input_graph, edge.id())
@@ -282,6 +306,39 @@ G::EdgeId: Eq + Hash,
     edge_coloring
 }
 
+pub fn if_bipartite_edge_color<G>(
+    input_graph: G,
+) -> Result<DictMap<G::EdgeId, usize>, GraphNotBipartite>
+where
+    G: GraphBase
+        + NodeCount
+        + NodeIndexable
+        + IntoNodeIdentifiers
+        + IntoEdges
+        + EdgeCount
+        + EdgeIndexable
+        + IntoNeighborsDirected
+        + GraphProp,
+    G::NodeId: Eq + Hash + Debug,
+    G::EdgeId: Eq + Hash,
+{
+    let two_color_result = two_color(&input_graph);
+    if let Some(two_coloring) = two_color_result {
+        let mut l_nodes: Vec<G::NodeId> = Vec::new();
+        let mut r_nodes: Vec<G::NodeId> = Vec::new();
+        for (node_id, color) in &two_coloring {
+            // println!("HERE node_id = {:?} and color = {:?}", node_id, color);
+            if *color == 0 {
+                l_nodes.push(*node_id);
+            } else {
+                r_nodes.push(*node_id);
+            }
+        }
+        return Ok(bipartite_edge_color(&input_graph, &l_nodes, &r_nodes));
+    } else {
+        return Err(GraphNotBipartite {});
+    }
+}
 
 /// Returns a set of Euler cycles for a possibly disconnected graph.
 ///
@@ -289,12 +346,10 @@ G::EdgeId: Eq + Hash,
 
 fn other_node(graph: &EdgedGraph, edge_index: EdgeIndex, node_index: NodeIndex) -> NodeIndex {
     let (node1, node2) = graph.edge_endpoints(edge_index).unwrap();
-    return if node_index == node1 {node2} else {node1};
+    return if node_index == node1 { node2 } else { node1 };
 }
 
-
-fn euler_cycles(input_graph: &EdgedGraph) -> Vec<Vec<EdgeIndex>>
-{
+fn euler_cycles(input_graph: &EdgedGraph) -> Vec<Vec<EdgeIndex>> {
     let mut cycles: Vec<Vec<EdgeIndex>> = Vec::new();
 
     let mut graph = input_graph.clone();
@@ -304,7 +359,7 @@ fn euler_cycles(input_graph: &EdgedGraph) -> Vec<Vec<EdgeIndex>>
 
     for node_id in node_indices {
         if in_component[node_id.index()] {
-            continue
+            continue;
         }
         let mut stack: Vec<(NodeIndex, Option<EdgeIndex>)> = vec![(node_id, None)];
         let mut cycle: Vec<EdgeIndex> = vec![];
@@ -323,10 +378,9 @@ fn euler_cycles(input_graph: &EdgedGraph) -> Vec<Vec<EdgeIndex>>
                     cycle.push(last_edge_id.unwrap());
                 }
                 stack.pop();
-            }
-            else {
+            } else {
                 let new_edge_id = new_edge.unwrap().id();
-                let new_node_id =other_node(&graph, new_edge_id, *last_node_id);
+                let new_node_id = other_node(&graph, new_edge_id, *last_node_id);
                 stack.push((new_node_id, Some(new_edge_id)));
                 // println!("pushing {:?}, {:?} to stack", new_node_id, new_edge_id);
 
@@ -335,19 +389,18 @@ fn euler_cycles(input_graph: &EdgedGraph) -> Vec<Vec<EdgeIndex>>
                 graph.remove_edge(new_edge_id);
                 // println!("AFTER REMOVING");
                 // print_graph(&graph);
-
-
-
             }
         }
-        println!("new cycle = {:?}", cycle);
+        // println!("new cycle = {:?}", cycle);
         cycles.push(cycle);
     }
 
     cycles
 }
 
-fn rbmg_split_into_two(g: &RegularBipartiteMultiGraph) -> (RegularBipartiteMultiGraph, RegularBipartiteMultiGraph) {
+fn rbmg_split_into_two(
+    g: &RegularBipartiteMultiGraph,
+) -> (RegularBipartiteMultiGraph, RegularBipartiteMultiGraph) {
     if g.degree % 2 == 1 {
         panic!("Cannot split multi-graph of odd degree.")
     }
@@ -369,14 +422,21 @@ fn rbmg_split_into_two(g: &RegularBipartiteMultiGraph) -> (RegularBipartiteMulti
             h2.add_edge(edge.source(), edge.target(), multiplicity / 2, bad);
         }
         if multiplicity % 2 == 1 {
-            r.add_edge(edge.source(), edge.target(), EdgeData  { multiplicity: 1, bad: bad });
+            r.add_edge(
+                edge.source(),
+                edge.target(),
+                EdgeData {
+                    multiplicity: 1,
+                    bad: bad,
+                },
+            );
         }
     }
 
-    println!("r:");
-    print_graph(&r);
+    // println!("r:");
+    // print_graph(&r);
     let cycles = euler_cycles(&r);
-    println!("detected cycles = {:?}", cycles);
+    // println!("detected cycles = {:?}", cycles);
 
     for cycle in cycles.into_iter() {
         for i in 0..cycle.len() {
@@ -384,40 +444,39 @@ fn rbmg_split_into_two(g: &RegularBipartiteMultiGraph) -> (RegularBipartiteMulti
             let bad = r.edge_weight(cycle[i]).unwrap().bad;
             if i % 2 == 0 {
                 h1.add_edge(source, target, 1, bad);
-            }
-            else {
+            } else {
                 h2.add_edge(source, target, 1, bad);
             }
         }
     }
 
-
     (h1, h2)
 }
-
 
 fn rbmg_find_perfect_matching(g: &RegularBipartiteMultiGraph) -> Matching {
     let k = g.degree;
     let n = g.l_nodes.len();
     let m = k * n;
-    let t =m.next_power_of_two();
+    let t = m.next_power_of_two();
     let t2 = t.trailing_zeros();
     let alpha = t / k;
     let beta = t - k * alpha;
 
+    // println!("rbmg_find_perfect_matching: k = {}, n = {}, m = {}, t = {}, t2 = {}", k, n, m, t, t2);
 
-
-    println!("rbmg_find_perfect_matching: k = {}, n = {}, m = {}, t = {}, t2 = {}", k, n, m, t, t2);
-
-    println!("printing g");
-    g.print();
-
+    // println!("printing g");
+    // g.print();
 
     let mut h1: RegularBipartiteMultiGraph = RegularBipartiteMultiGraph::copy_without_edges(&g);
     h1.degree = t;
 
     for edge in g.graph.edge_references() {
-        h1.add_edge(edge.source(), edge.target(), alpha * edge.weight().multiplicity, false);
+        h1.add_edge(
+            edge.source(),
+            edge.target(),
+            alpha * edge.weight().multiplicity,
+            false,
+        );
     }
 
     // Choose an arbitrary matching left[i] -- right[i]
@@ -425,23 +484,29 @@ fn rbmg_find_perfect_matching(g: &RegularBipartiteMultiGraph) -> Matching {
         h1.add_edge(g.l_nodes[i], g.r_nodes[i], beta, true);
     }
 
-    println!("printing h1 initially");
-    println!("============");
-    h1.print();
+    // println!("printing h1 initially");
+    // println!("============");
+    // h1.print();
 
     // Recursively split until we find a matching
     for _ in 0..t2 {
-        let (h2, h3): (RegularBipartiteMultiGraph, RegularBipartiteMultiGraph) = rbmg_split_into_two(&h1);
-        let bad_h2: usize = h2.graph.edge_references().map(|e| e.weight().bad as usize).sum();
-        let bad_h3: usize = h3.graph.edge_references().map(|e| e.weight().bad as usize).sum();
-        h1 = if bad_h2 <= bad_h3 {h2} else {h3};
-        println!("printing h1 after split");
-        println!("============");
-        h1.print();
-
+        let (h2, h3): (RegularBipartiteMultiGraph, RegularBipartiteMultiGraph) =
+            rbmg_split_into_two(&h1);
+        let bad_h2: usize = h2
+            .graph
+            .edge_references()
+            .map(|e| e.weight().bad as usize)
+            .sum();
+        let bad_h3: usize = h3
+            .graph
+            .edge_references()
+            .map(|e| e.weight().bad as usize)
+            .sum();
+        h1 = if bad_h2 <= bad_h3 { h2 } else { h3 };
+        // println!("printing h1 after split");
+        // println!("============");
+        // h1.print();
     }
-
-
 
     let mut matching: Matching = Vec::with_capacity(n);
 
@@ -449,10 +514,8 @@ fn rbmg_find_perfect_matching(g: &RegularBipartiteMultiGraph) -> Matching {
         matching.push((edge.source(), edge.target()));
     }
 
-
-    println!("rbmg_find_perfect_matching: matching = {:?}", matching);
+    // println!("rbmg_find_perfect_matching: matching = {:?}", matching);
     matching
-
 }
 
 fn rbmg_edge_color_when_power_of_two(g: &RegularBipartiteMultiGraph) -> Vec<Matching> {
@@ -460,10 +523,10 @@ fn rbmg_edge_color_when_power_of_two(g: &RegularBipartiteMultiGraph) -> Vec<Matc
         panic!("degree is not power of 2");
     }
 
-    let mut coloring: Vec<Matching>= Vec::with_capacity(g.degree);
+    let mut coloring: Vec<Matching> = Vec::with_capacity(g.degree);
 
     if g.degree == 1 {
-        println!("degree is 1 ");
+        // println!("degree is 1 ");
         let mut matching: Matching = Vec::with_capacity(g.l_nodes.len());
         for edge in g.graph.edge_references() {
             matching.push((edge.source(), edge.target()));
@@ -473,10 +536,10 @@ fn rbmg_edge_color_when_power_of_two(g: &RegularBipartiteMultiGraph) -> Vec<Matc
     }
 
     let (h1, h2) = rbmg_split_into_two(&g);
-    let mut h1_coloring =rbmg_edge_color_when_power_of_two(&h1);
-    let mut h2_coloring =rbmg_edge_color_when_power_of_two(&h2);
-    coloring.append(& mut h1_coloring);
-    coloring.append(& mut h2_coloring);
+    let mut h1_coloring = rbmg_edge_color_when_power_of_two(&h1);
+    let mut h2_coloring = rbmg_edge_color_when_power_of_two(&h2);
+    coloring.append(&mut h1_coloring);
+    coloring.append(&mut h2_coloring);
 
     if coloring.len() != g.degree {
         panic!("wrong len of coloring!!");
@@ -485,25 +548,22 @@ fn rbmg_edge_color_when_power_of_two(g: &RegularBipartiteMultiGraph) -> Vec<Matc
     coloring
 }
 
-
-
 fn rbmg_edge_color(g0: &RegularBipartiteMultiGraph) -> Vec<Matching> {
     // todo: rename to clone, and maybe don't even need to implement clone()
     let mut g: RegularBipartiteMultiGraph = RegularBipartiteMultiGraph::copy(g0);
 
-    println!("Want to color rbmg");
-    g.print();
+    // println!("Want to color rbmg");
+    // g.print();
 
-
-    let mut coloring: Vec<Matching>= Vec::with_capacity(g.degree);
+    let mut coloring: Vec<Matching> = Vec::with_capacity(g.degree);
 
     if g.degree == 0 {
-        println!("degree is 1 ");
-        return coloring
+        // println!("degree is 1 ");
+        return coloring;
     }
 
     if g.degree == 1 {
-        println!("degree is 1 ");
+        // println!("degree is 1 ");
         let mut matching: Matching = Vec::with_capacity(g.l_nodes.len());
         for edge in g.graph.edge_references() {
             matching.push((edge.source(), edge.target()));
@@ -515,14 +575,14 @@ fn rbmg_edge_color(g0: &RegularBipartiteMultiGraph) -> Vec<Matching> {
     let mut odd_degree_matching: Option<Matching> = None;
 
     if g.degree % 2 == 1 {
-        println!("degree is odd {:?}", g.degree);
+        // println!("degree is odd {:?}", g.degree);
         let matching = rbmg_find_perfect_matching(&g);
-        println!("Ok, for odd degree have matching {:?}", matching);
+        // println!("Ok, for odd degree have matching {:?}", matching);
         g.remove_matching(&matching);
         odd_degree_matching = Some(matching);
     }
 
-    println!("and now degree is {:?}", g.degree);
+    // println!("and now degree is {:?}", g.degree);
 
     // Split graph into two regular bipartite multigraphs of half-degree
     let (mut h1, mut h2) = rbmg_split_into_two(&g);
@@ -532,13 +592,13 @@ fn rbmg_edge_color(g0: &RegularBipartiteMultiGraph) -> Vec<Matching> {
 
     // Transfer some matchings from H1 to H2 to make the degree of H2 to be a power of 2
     let r = h2.degree.next_power_of_two();
-    let num_classes_to_move= r - h2.degree;
-    println!("r = {:?}, num_to_move = {:?}", r, num_classes_to_move);
+    let num_classes_to_move = r - h2.degree;
+    // println!("r = {:?}, num_to_move = {:?}", r, num_classes_to_move);
 
     for i in 0..num_classes_to_move {
         h2.add_matching(&h1_coloring[i]);
     }
-    println!("check: g0.degree = {:?}, g.degree = {:?}, h2 degree {:?}", g0.degree, g.degree, h2.degree);
+    // println!("check: g0.degree = {:?}, g.degree = {:?}, h2 degree {:?}", g0.degree, g.degree, h2.degree);
 
     // Edge-color h2 by recursive splitting
     let mut h2_coloring = rbmg_edge_color_when_power_of_two(&h2);
@@ -562,7 +622,6 @@ fn rbmg_edge_color(g0: &RegularBipartiteMultiGraph) -> Vec<Matching> {
     coloring
 }
 
-
 fn print_graph(r: &EdgedGraph) {
     let nodes: Vec<_> = r.node_indices().collect();
     let edges: Vec<_> = r.edge_references().collect();
@@ -577,7 +636,6 @@ fn print_graph(r: &EdgedGraph) {
     }
     println!("=======");
 }
-
 
 fn print_original_graph(r: &Graph<(), (), Undirected>) {
     let nodes: Vec<_> = r.node_indices().collect();
@@ -594,8 +652,6 @@ fn print_original_graph(r: &Graph<(), (), Undirected>) {
     println!("=======");
 }
 
-
-
 #[cfg(test)]
 mod test_bipartite_coloring {
     use petgraph::data::Element::Node;
@@ -605,108 +661,182 @@ mod test_bipartite_coloring {
 
     // use crate::bipartite_coloring::{bipartite_edge_color, RegularBipartiteMultiGraph};
 
-    use crate::bipartite_coloring::{bipartite_edge_color, EdgedGraph, euler_cycles, print_graph, print_original_graph, RegularBipartiteMultiGraph};
+    use crate::bipartite_coloring::EdgeData;
+    use crate::bipartite_coloring::{
+        bipartite_edge_color, euler_cycles, if_bipartite_edge_color, print_graph,
+        print_original_graph, EdgedGraph, RegularBipartiteMultiGraph,
+    };
+    use crate::generators::petersen_graph;
+    use crate::generators::random_bipartite_graph;
+    use hashbrown::HashSet;
     use petgraph::graph::{edge_index, EdgeIndex};
     use petgraph::prelude::StableGraph;
     use petgraph::stable_graph::NodeIndex;
-    use petgraph::visit::{IntoEdgeReferences, IntoNodeIdentifiers};
+    use petgraph::visit::{
+        EdgeRef, IntoEdgeReferences, IntoEdges, IntoNodeIdentifiers, NodeIndexable,
+    };
     use petgraph::Undirected;
-    use crate::bipartite_coloring::EdgeData;
-    //
-    // #[test]
-    // fn test_bipartite_edge_color() {
-    //     let edge_list = vec![(0, 1), (0, 2), (0, 3), (1, 4), (2, 5), (3, 6)];
-    //     let graph = Graph::<(), (), Undirected>::from_edges(&edge_list);
-    //     println!("{:?}", graph);
-    //     let nodes: Vec<_> = graph.node_indices().collect();
-    //     let edges: Vec<_> = graph.edge_references().collect();
-    //     println!("{:?}", nodes);
-    //     println!("{:?}", edges);
-    //     bipartite_edge_color(&graph);
-    //
-    //     // println!("{:?}", graph.raw_edges());
-    // }
+    use std::fmt::Debug;
+    use std::hash::Hash;
 
-    #[test]
-    fn test_inner() {
-        let mut graph: EdgedGraph = StableGraph::default();
-        graph.add_node(());
-        graph.add_node(());
-        graph.add_node(());
-        graph.add_edge(NodeIndex::new(0), NodeIndex::new(1), EdgeData { multiplicity: 2, bad: false });
-        graph.add_edge(NodeIndex::new(2), NodeIndex::new(1), EdgeData { multiplicity: 5, bad: true });
+    fn check_valid_bipatite_edge_coloring<G>(graph: G, colors: &DictMap<G::EdgeId, usize>)
+    where
+        G: NodeIndexable + IntoEdges + IntoNodeIdentifiers,
+        G::EdgeId: Eq + Hash + Debug,
+    {
+        // Check that every edge has valid color
+        for edge in graph.edge_references() {
+            if !colors.contains_key(&edge.id()) {
+                panic!("Problem: edge {:?} has no color assigned.", &edge.id());
+            }
+        }
 
-        let nodes: Vec<_> = graph.node_indices().collect();
-        let edges: Vec<_> = graph.edge_references().collect();
-        println!("{:?}", nodes);
-        println!("{:?}", edges);
+        // Check that for every node all of its edges have different colors
+        // (i.e. the number of used colors is equal to the degree).
+        // Also compute number of colors used and maximum node degree.
+        let mut num_colors = 0;
+        let mut max_node_degree = 0;
+        let node_indices: Vec<G::NodeId> = graph.node_identifiers().collect();
+        for node in node_indices {
+            let mut cur_node_degree = 0;
+            let mut used_colors: HashSet<usize> = HashSet::new();
+            for edge in graph.edges(node) {
+                let color = colors.get(&edge.id()).unwrap();
+                used_colors.insert(*color);
+                cur_node_degree += 1;
+                if num_colors < *color + 1 {
+                    num_colors = *color + 1;
+                }
+            }
+            if used_colors.len() < cur_node_degree {
+                panic!(
+                    "Problem: node {:?} does not have enough colors.",
+                    NodeIndexable::to_index(&graph, node)
+                );
+            }
 
+            if cur_node_degree > max_node_degree {
+                max_node_degree = cur_node_degree
+            }
+        }
 
-        let edge1 = graph.find_edge(NodeIndex::new(1), NodeIndex::new(2));
-        println!("edge1: {:?}", edge1);
-
-        let edge2 = graph.find_edge(NodeIndex::new(0), NodeIndex::new(2));
-        println!("edge1: {:?}", edge2);
-
+        println!(
+            "=> checking: max_degree = {:?}, num_colors = {:?}",
+            max_node_degree, num_colors
+        );
+        // Check that number of colors used is at most max_node_degree + 1
+        // (note that number of colors is max_color + 1).
+        if max_node_degree < num_colors {
+            panic!(
+                "Problem: too many colors are used ({} colors used, {} max node degree)",
+                num_colors, max_node_degree
+            );
+        }
     }
 
+    #[test]
+    fn test_bipartite_multiple_edges() {
+        println!("Running test5");
+        let edge_list = vec![(0, 1), (0, 2), (0, 3), (1, 4), (2, 5), (3, 6), (4, 1)];
+        let graph = Graph::<(), (), Undirected>::from_edges(&edge_list);
+        print_original_graph(&graph);
+
+        let output = if_bipartite_edge_color(&graph);
+        println!("FINAL FINAL {:?}", output);
+    }
+
+    #[test]
+    fn test_bipartite_petersen_graphs() {
+        for i in 3..30 {
+            for j in 0..30 {
+                let n = 2 * i;
+                let k = 2 * j + 1;
+                if n <= 2 * k {
+                    continue;
+                }
+                let graph: petgraph::graph::UnGraph<(), ()> =
+                    petersen_graph(n, k, || (), || ()).unwrap();
+                match if_bipartite_edge_color(&graph) {
+                    Ok(edge_coloring) => {
+                        check_valid_bipatite_edge_coloring(&graph, &edge_coloring);
+                    }
+                    Err(_) => panic!("This should error"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_not_bipartite_petersen_graphs() {
+        for i in 3..30 {
+            for j in 1..31 {
+                let n = 2 * i;
+                let k = 2 * j;
+                if n > 2 * k {
+                    let graph: petgraph::graph::UnGraph<(), ()> =
+                        petersen_graph(n, k, || (), || ()).unwrap();
+                    match if_bipartite_edge_color(&graph) {
+                        Ok(edge_coloring) => panic!("This should error"),
+                        Err(_) => (),
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_bipartite_random_graphs() {
+        for num_l_nodes in vec![5, 10, 15, 20] {
+            for num_r_nodes in vec![5, 10, 15, 20] {
+                for probability in vec![0.1, 0.3, 0.5, 0.7, 0.9] {
+                    let graph: petgraph::graph::UnGraph<(), ()> = random_bipartite_graph(
+                        num_l_nodes,
+                        num_r_nodes,
+                        probability,
+                        Some(10),
+                        || (),
+                        || (),
+                    )
+                    .unwrap();
+                    match if_bipartite_edge_color(&graph) {
+                        Ok(edge_coloring) => {
+                            check_valid_bipatite_edge_coloring(&graph, &edge_coloring);
+                        }
+                        Err(_) => panic!("This should error"),
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_empty_graph() {
+        let mut graph = Graph::<(), (), Undirected>::new_undirected();
+        let a = graph.add_node(());
+        let b = graph.add_node(());
+        let c = graph.add_node(());
+        let d = graph.add_node(());
+        let left = vec![a, b];
+        let right = vec![c, d];
+        let output = bipartite_edge_color(&graph, &left, &right);
+        print_original_graph(&graph);
+        println!("FINAL FINAL {:?}", output);
+    }
 
     #[test]
     fn test2() {
         let edge_list = vec![(0, 1), (0, 2), (0, 3), (1, 4), (2, 5), (3, 6), (4, 1)];
         let original_graph = Graph::<(), (), Undirected>::from_edges(&edge_list);
-        let left = vec![NodeIndex::new(0), NodeIndex::new(4), NodeIndex::new(5), NodeIndex::new(6) ];
+        let left = vec![
+            NodeIndex::new(0),
+            NodeIndex::new(4),
+            NodeIndex::new(5),
+            NodeIndex::new(6),
+        ];
         let right = vec![NodeIndex::new(1), NodeIndex::new(2), NodeIndex::new(3)];
 
-
-        let output = bipartite_edge_color(&original_graph, left, right);
-        print_original_graph(&original_graph);
+        let output = bipartite_edge_color(&original_graph, &left, &right);
+        // print_original_graph(&original_graph);
         println!("FINAL FINAL {:?}", output);
-
-
-        //
-        // multigraph.graph.add_node(0);
-        // multigraph.graph.add_node(1);
-        // multigraph.graph.add_node(2);
-        //
-        // multigraph.add_edge(NodeIndex::new(0), NodeIndex::new(1), 2, false);
-        // multigraph.add_edge(NodeIndex::new(0), NodeIndex::new(1), 3, false);
-        // multigraph.add_edge(NodeIndex::new(0), NodeIndex::new(2), 4, true);
-        // multigraph.add_edge(NodeIndex::new(1), NodeIndex::new(0), 5, false);
-        //
-        //
-        // multigraph.print();
-
     }
-
-    // #[test]
-    // fn test3() {
-    //     let edge_list = vec![(0, 1), (1, 2), (0, 3), (2, 3), (0, 2), (0, 5), (5, 2), (4, 6), (6, 4)];
-    //     let original_graph = Graph::<(), (), Undirected>::from_edges(&edge_list);
-    //
-    //     let cycles = euler_cycles(&original_graph);
-    //     println!("cycles: {:?}", cycles);
-    // }
-
-    //     let mut graph: Graph<()), EdgeData, Undirected> = Graph::new_undirected();
-    //     graph.add_node(0);
-    //     graph.add_node(1);
-    //     graph.add_node(2);
-    //     graph.add_edge(NodeIndex::new(0), NodeIndex::new(1), EdgeData { multiplicity: 2, bad: false });
-    //     graph.add_edge(NodeIndex::new(2), NodeIndex::new(1), EdgeData { multiplicity: 5, bad: true });
-    //
-    //     let nodes: Vec<_> = graph.node_indices().collect();
-    //     let edges: Vec<_> = graph.edge_references().collect();
-    //     println!("{:?}", nodes);
-    //     println!("{:?}", edges);
-    //
-    //
-    //     let edge1 = graph.find_edge(NodeIndex::new(1), NodeIndex::new(2));
-    //     println!("edge1: {:?}", edge1);
-    //
-    //     let edge2 = graph.find_edge(NodeIndex::new(0), NodeIndex::new(2));
-    //     println!("edge1: {:?}", edge2);
-    //
-    // }
-
 }

--- a/rustworkx-core/src/bipartite_coloring.rs
+++ b/rustworkx-core/src/bipartite_coloring.rs
@@ -71,7 +71,7 @@ impl RegularBipartiteMultiGraph {
     fn clone(parent: &RegularBipartiteMultiGraph) -> Self {
         RegularBipartiteMultiGraph {
             graph: parent.graph.clone(),
-            degree: parent.degree.clone(),
+            degree: parent.degree,
             l_nodes: parent.l_nodes.clone(),
             r_nodes: parent.r_nodes.clone(),
         }
@@ -89,13 +89,15 @@ impl RegularBipartiteMultiGraph {
     }
 
     fn add_edge(&mut self, a: NodeIndex, b: NodeIndex, multiplicity: usize, bad: bool) {
-        let edge = self.graph.find_edge(a, b);
-        if edge.is_some() {
-            let mut edge_data = self.graph.edge_weight_mut(edge.unwrap()).unwrap();
-            edge_data.multiplicity += multiplicity;
-        } else {
-            let edge_data = EdgeData { multiplicity, bad };
-            self.graph.add_edge(a, b, edge_data);
+        match self.graph.find_edge(a, b) {
+            Some(edge) => {
+                let mut edge_data = self.graph.edge_weight_mut(edge).unwrap();
+                edge_data.multiplicity += multiplicity;
+            }
+            None => {
+                let edge_data = EdgeData { multiplicity, bad };
+                self.graph.add_edge(a, b, edge_data);
+            }
         }
     }
 
@@ -210,7 +212,7 @@ fn rbmg_split_into_two(
                 edge.target(),
                 EdgeData {
                     multiplicity: 1,
-                    bad: bad,
+                    bad,
                 },
             );
         }
@@ -642,9 +644,9 @@ where
                 r_nodes.push(*node_id);
             }
         }
-        return Ok(bipartite_edge_color(input_graph, &l_nodes, &r_nodes));
+        Ok(bipartite_edge_color(input_graph, &l_nodes, &r_nodes))
     } else {
-        return Err(GraphNotBipartite {});
+        Err(GraphNotBipartite {})
     }
 }
 

--- a/rustworkx-core/src/bipartite_coloring.rs
+++ b/rustworkx-core/src/bipartite_coloring.rs
@@ -456,8 +456,14 @@ where
     let max_degree = graph
         .node_identifiers()
         .map(|node| node_degree(&graph, node))
-        .max()
-        .unwrap();
+        .max();
+
+    if max_degree.is_none() {
+        // Corner-case that the graph has no nodes
+        let edge_coloring: DictMap<G::EdgeId, usize> = DictMap::new();
+        return edge_coloring;
+    }
+    let max_degree = max_degree.unwrap();
 
     // Add nodes to multi-graph
     // ToDo: add optimization to combine nodes
@@ -581,7 +587,7 @@ where
 ///
 /// The input to the algorithm is a graph. If the graph is bipartite, the
 /// output is an assignment of colors to the edges of the graph so that
-/// no two incident edges have the same color. The The algorithm runs in
+/// no two incident edges have the same color. The algorithm runs in
 /// time `O (m log m)`, where `m` is the number of edges of the graph.
 /// If the graph is not bipartite, `GraphNotBipartite` is returned instead.
 ///
@@ -797,6 +803,32 @@ mod test_bipartite_coloring {
 
     #[test]
     fn test_empty_graph_undirected() {
+        let graph = Graph::<(), (), Undirected>::default();
+        let l_nodes = vec![];
+        let r_nodes = vec![];
+        let colors = bipartite_edge_color(&graph, &l_nodes, &r_nodes);
+        let expected_colors: DictMap<EdgeIndex, usize> = [
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(colors, expected_colors);
+    }
+
+    #[test]
+    fn test_empty_graph_directed() {
+        let graph = Graph::<(), (), Directed>::default();
+        let l_nodes = vec![];
+        let r_nodes = vec![];
+        let colors = bipartite_edge_color(&graph, &l_nodes, &r_nodes);
+        let expected_colors: DictMap<EdgeIndex, usize> = [
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(colors, expected_colors);
+    }
+
+    #[test]
+    fn test_edgeless_graph_undirected() {
         let mut graph = Graph::<(), (), Undirected>::default();
         let a = graph.add_node(());
         let b = graph.add_node(());
@@ -810,7 +842,7 @@ mod test_bipartite_coloring {
     }
 
     #[test]
-    fn test_empty_graph_directed() {
+    fn test_edgeless_graph_directed() {
         let mut graph = Graph::<(), (), Directed>::default();
         let a = graph.add_node(());
         let b = graph.add_node(());

--- a/rustworkx-core/src/bipartite_coloring.rs
+++ b/rustworkx-core/src/bipartite_coloring.rs
@@ -716,27 +716,15 @@ mod test_bipartite_coloring {
 
     use crate::dictmap::DictMap;
     use crate::petgraph::Graph;
-    use petgraph::data::Element::Node;
-    use std::cmp::max;
 
-    use crate::bipartite_coloring::{
-        bipartite_edge_color, euler_cycles, if_bipartite_edge_color, node_degree, print_graph,
-        print_original_graph, EdgedGraph, RegularBipartiteMultiGraph,
-    };
-    use crate::bipartite_coloring::{print_original_graph_d, EdgeData};
-    use crate::generators::random_bipartite_graph;
-    use crate::generators::{heavy_hex_graph, petersen_graph};
     use hashbrown::HashSet;
-    use petgraph::graph::{edge_index, EdgeIndex};
-    use petgraph::prelude::StableGraph;
-    use petgraph::stable_graph::NodeIndex;
-    use petgraph::visit::{
-        EdgeRef, IntoEdgeReferences, IntoEdges, IntoEdgesDirected, IntoNodeIdentifiers,
-        NodeIndexable,
-    };
+
+    use crate::bipartite_coloring::{bipartite_edge_color, if_bipartite_edge_color};
+    use crate::generators::{heavy_hex_graph, petersen_graph, random_bipartite_graph};
+
+    use petgraph::graph::{EdgeIndex, NodeIndex};
+    use petgraph::visit::EdgeRef;
     use petgraph::{Directed, Incoming, Outgoing, Undirected};
-    use std::fmt::Debug;
-    use std::hash::Hash;
 
     // Correctness checking
 
@@ -794,7 +782,8 @@ mod test_bipartite_coloring {
 
         // Check that all edges from a given node have different colors
         for node in graph.node_indices() {
-            let node_degree = graph.edges_directed(node, Incoming).count() + graph.edges_directed(node, Outgoing).count();
+            let node_degree = graph.edges_directed(node, Incoming).count()
+                + graph.edges_directed(node, Outgoing).count();
             let node_colors: HashSet<usize> = graph
                 .edges_directed(node, Incoming)
                 .chain(graph.edges_directed(node, Outgoing))
@@ -1155,11 +1144,7 @@ mod test_bipartite_coloring {
                                 })
                                 .max()
                                 .unwrap();
-                            check_edge_coloring_directed(
-                                &graph,
-                                &edge_coloring,
-                                Some(max_degree),
-                            );
+                            check_edge_coloring_directed(&graph, &edge_coloring, Some(max_degree));
                         }
                         Err(_) => panic!("This should error"),
                     }

--- a/rustworkx-core/src/generators/mod.rs
+++ b/rustworkx-core/src/generators/mod.rs
@@ -58,5 +58,6 @@ pub use path_graph::path_graph;
 pub use petersen_graph::petersen_graph;
 pub use random_graph::gnm_random_graph;
 pub use random_graph::gnp_random_graph;
+pub use random_graph::random_bipartite_graph;
 pub use random_graph::random_geometric_graph;
 pub use star_graph::star_graph;

--- a/rustworkx-core/src/generators/random_graph.rs
+++ b/rustworkx-core/src/generators/random_graph.rs
@@ -469,8 +469,8 @@ where
             let random: f64 = between.sample(&mut rng);
             if random < probability {
                 graph.add_edge(
-                    graph.from_index(v as usize),
-                    graph.from_index((num_l_nodes + w) as usize),
+                    graph.from_index(v),
+                    graph.from_index(num_l_nodes + w),
                     default_edge_weight(),
                 );
             }

--- a/rustworkx-core/src/lib.rs
+++ b/rustworkx-core/src/lib.rs
@@ -70,6 +70,7 @@ use std::convert::Infallible;
 /// error can happen.
 pub type Result<T, E = Infallible> = core::result::Result<T, E>;
 
+pub mod bipartite_coloring;
 /// Module for centrality algorithms.
 pub mod centrality;
 /// Module for coloring algorithms.
@@ -77,6 +78,7 @@ pub mod coloring;
 pub mod connectivity;
 pub mod generators;
 pub mod line_graph;
+
 /// Module for maximum weight matching algorithms.
 pub mod max_weight_matching;
 pub mod planar;

--- a/src/coloring.rs
+++ b/src/coloring.rs
@@ -11,8 +11,10 @@
 // under the License.
 
 use crate::{digraph, graph};
+use crate::GraphNotBipartite;
 
 use rustworkx_core::coloring::{greedy_edge_color, greedy_node_color, two_color};
+use rustworkx_core::bipartite_coloring::{bipartite_edge_color, if_bipartite_edge_color};
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -135,4 +137,40 @@ pub fn digraph_two_color(py: Python, graph: &digraph::PyDiGraph) -> PyResult<Opt
         }
         None => Ok(None),
     }
+}
+
+/// Color edges of a graph by checking whether the graph is bipartite,
+/// and if so, calling the algorithm for edge-coloring bipartite graphs.
+///
+/// If the input graph is not bipartite, ``None`` is returned.
+///
+/// The implementation is based on the following paper:
+///
+/// Noga Alon. "A simple algorithm for edge-coloring bipartite multigraphs".
+/// Inf. Process. Lett. 85(6), (2003).
+/// <https://www.tau.ac.il/~nogaa/PDFS/lex2.pdf>
+///
+/// The algorithm runs in time `O (m log m)`, where `m` is the number of edges
+/// of the graph.
+///
+/// :param PyGraph graph: The graph to find the coloring for
+///
+/// :returns: A dictionary where keys are edge indices and the value is the color
+///  (provided that the graph is bipartite)
+/// :rtype: dict
+#[pyfunction]
+#[pyo3(text_signature = "(graph, /)")]
+pub fn graph_if_bipartite_edge_color(py: Python, graph: &graph::PyGraph) -> PyResult<PyObject> {
+    let colors=
+        match if_bipartite_edge_color(&graph.graph) {
+            Ok(colors) => colors,
+            Err(_) => {
+                return Err(GraphNotBipartite::new_err("Graph is not bipartite", ))
+            }
+        };
+    let out_dict = PyDict::new(py);
+    for (node, color) in colors {
+        out_dict.set_item(node.index(), color)?;
+    }
+    Ok(out_dict.into())
 }

--- a/src/coloring.rs
+++ b/src/coloring.rs
@@ -10,11 +10,11 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-use crate::{digraph, graph};
 use crate::GraphNotBipartite;
+use crate::{digraph, graph};
 
-use rustworkx_core::coloring::{greedy_edge_color, greedy_node_color, two_color};
 use rustworkx_core::bipartite_coloring::{bipartite_edge_color, if_bipartite_edge_color};
+use rustworkx_core::coloring::{greedy_edge_color, greedy_node_color, two_color};
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -161,13 +161,10 @@ pub fn digraph_two_color(py: Python, graph: &digraph::PyDiGraph) -> PyResult<Opt
 #[pyfunction]
 #[pyo3(text_signature = "(graph, /)")]
 pub fn graph_if_bipartite_edge_color(py: Python, graph: &graph::PyGraph) -> PyResult<PyObject> {
-    let colors=
-        match if_bipartite_edge_color(&graph.graph) {
-            Ok(colors) => colors,
-            Err(_) => {
-                return Err(GraphNotBipartite::new_err("Graph is not bipartite", ))
-            }
-        };
+    let colors = match if_bipartite_edge_color(&graph.graph) {
+        Ok(colors) => colors,
+        Err(_) => return Err(GraphNotBipartite::new_err("Graph is not bipartite")),
+    };
     let out_dict = PyDict::new(py);
     for (node, color) in colors {
         out_dict.set_item(node.index(), color)?;

--- a/src/coloring.rs
+++ b/src/coloring.rs
@@ -13,7 +13,7 @@
 use crate::GraphNotBipartite;
 use crate::{digraph, graph};
 
-use rustworkx_core::bipartite_coloring::{bipartite_edge_color, if_bipartite_edge_color};
+use rustworkx_core::bipartite_coloring::if_bipartite_edge_color;
 use rustworkx_core::coloring::{greedy_edge_color, greedy_node_color, two_color};
 
 use pyo3::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,8 @@ create_exception!(rustworkx, JSONSerializationError, PyException);
 create_exception!(rustworkx, NegativeCycle, PyException);
 // Failed to Converge on a solution
 create_exception!(rustworkx, FailedToConverge, PyException);
+// Graph is not bipartite
+create_exception!(rustworkx, GraphNotBipartite, PyException);
 
 #[pymodule]
 fn rustworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
@@ -352,6 +354,7 @@ fn rustworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
         py.get_type::<JSONSerializationError>(),
     )?;
     m.add("FailedToConverge", py.get_type::<FailedToConverge>())?;
+    m.add("GraphNotBipartite", py.get_type::<GraphNotBipartite>())?;
     m.add_wrapped(wrap_pyfunction!(bfs_successors))?;
     m.add_wrapped(wrap_pyfunction!(bfs_predecessors))?;
     m.add_wrapped(wrap_pyfunction!(graph_bfs_search))?;
@@ -442,6 +445,8 @@ fn rustworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(digraph_astar_shortest_path))?;
     m.add_wrapped(wrap_pyfunction!(graph_greedy_color))?;
     m.add_wrapped(wrap_pyfunction!(graph_greedy_edge_color))?;
+    m.add_wrapped(wrap_pyfunction!(graph_if_bipartite_edge_color))?;
+    // m.add_wrapped(wrap_pyfunction!(graph_bipartite_edge_color))?;
     m.add_wrapped(wrap_pyfunction!(graph_two_color))?;
     m.add_wrapped(wrap_pyfunction!(digraph_two_color))?;
     m.add_wrapped(wrap_pyfunction!(graph_is_bipartite))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,7 +446,6 @@ fn rustworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(graph_greedy_color))?;
     m.add_wrapped(wrap_pyfunction!(graph_greedy_edge_color))?;
     m.add_wrapped(wrap_pyfunction!(graph_if_bipartite_edge_color))?;
-    // m.add_wrapped(wrap_pyfunction!(graph_bipartite_edge_color))?;
     m.add_wrapped(wrap_pyfunction!(graph_two_color))?;
     m.add_wrapped(wrap_pyfunction!(digraph_two_color))?;
     m.add_wrapped(wrap_pyfunction!(graph_is_bipartite))?;

--- a/tests/rustworkx_tests/graph/test_coloring.py
+++ b/tests/rustworkx_tests/graph/test_coloring.py
@@ -106,3 +106,96 @@ class TestGraphEdgeColoring(unittest.TestCase):
         graph = rustworkx.generators.cycle_graph(7)
         edge_colors = rustworkx.graph_greedy_edge_color(graph)
         self.assertEqual({0: 0, 1: 1, 2: 0, 3: 1, 4: 0, 5: 1, 6: 2}, edge_colors)
+
+
+class TestBipartiteGraphEdgeColoring(unittest.TestCase):
+    def test_graph(self):
+        graph = rustworkx.PyGraph()
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        node_c = graph.add_node("c")
+        node_d = graph.add_node("d")
+
+        graph.add_edge(node_a, node_b, 1)
+        graph.add_edge(node_b, node_c, 1)
+        graph.add_edge(node_c, node_d, 1)
+        graph.add_edge(node_a, node_d, 1)
+
+        edge_colors = rustworkx.graph_if_bipartite_edge_color(graph)
+        self.assertEqual({0: 1, 1: 0, 2: 1, 3: 0}, edge_colors)
+
+    def test_graph_multiple_edges(self):
+        """Graph with multiple edges between two nodes."""
+        graph = rustworkx.PyGraph()
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        graph.add_edge(node_a, node_b, 1)
+        graph.add_edge(node_a, node_b, 1)
+        graph.add_edge(node_b, node_a, 1)
+        graph.add_edge(node_a, node_b, 1)
+        edge_colors = rustworkx.graph_if_bipartite_edge_color(graph)
+        self.assertEqual({0: 3, 1: 2, 2: 1, 3: 0}, edge_colors)
+
+    def test_graph_not_bipartite(self):
+        """Test that assert is raised on non-bipartite graphs."""
+        graph = rustworkx.PyGraph()
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        node_c = graph.add_node("c")
+        graph.add_edge(node_a, node_b, 1)
+        graph.add_edge(node_a, node_c, 1)
+        graph.add_edge(node_b, node_c, 1)
+        with self.assertRaises(rustworkx.GraphNotBipartite):
+            rustworkx.graph_if_bipartite_edge_color(graph)
+
+    def test_graph_not_bipartite_self_loop(self):
+        """Test that assert is raised on non-bipartite graphs."""
+        graph = rustworkx.PyGraph()
+        node_a = graph.add_node("a")
+        graph.add_edge(node_a, node_a, 1)
+        with self.assertRaises(rustworkx.GraphNotBipartite):
+            rustworkx.graph_if_bipartite_edge_color(graph)
+
+    def test_graph_with_holes(self):
+        """Graph with missing node and edge indices."""
+        graph = rustworkx.PyGraph()
+
+        node_a = graph.add_node("a")
+        node_b = graph.add_node("b")
+        node_c = graph.add_node("c")
+        node_d = graph.add_node("d")
+        node_e = graph.add_node("e")
+
+        graph.add_edge(node_a, node_b, 1)
+        graph.add_edge(node_b, node_c, 1)
+        graph.add_edge(node_c, node_d, 1)
+        graph.add_edge(node_d, node_e, 1)
+
+        graph.remove_node(node_c)
+
+        edge_colors = rustworkx.graph_if_bipartite_edge_color(graph)
+        self.assertEqual({0: 0, 3: 0}, edge_colors)
+
+    def test_graph_without_edges(self):
+        graph = rustworkx.PyGraph()
+        graph.add_node("a")
+        graph.add_node("b")
+        edge_colors = rustworkx.rustworkx.graph_if_bipartite_edge_color(graph)
+        self.assertEqual({}, edge_colors)
+
+    def test_empty_graph(self):
+        graph = rustworkx.PyGraph()
+        edge_colors = rustworkx.rustworkx.graph_if_bipartite_edge_color(graph)
+        self.assertEqual({}, edge_colors)
+
+    def test_cycle_graph(self):
+        graph = rustworkx.generators.cycle_graph(8)
+        edge_colors = rustworkx.rustworkx.graph_if_bipartite_edge_color(graph)
+        self.assertEqual({0: 0, 1: 1, 2: 0, 3: 1, 4: 0, 5: 1, 6: 0, 7: 1}, edge_colors)
+
+    def test_heavy_hex_graph(self):
+        """Test that we color the heavy hex with exactly 3 colors (it's bipartite and has max degree 3)."""
+        graph = rustworkx.generators.heavy_hex_graph(9)
+        edge_colors = rustworkx.rustworkx.graph_if_bipartite_edge_color(graph)
+        num_colors = max(edge_colors.values()) + 1
+        self.assertEqual(num_colors, 3)

--- a/tests/rustworkx_tests/graph/test_coloring.py
+++ b/tests/rustworkx_tests/graph/test_coloring.py
@@ -194,7 +194,8 @@ class TestBipartiteGraphEdgeColoring(unittest.TestCase):
         self.assertEqual({0: 0, 1: 1, 2: 0, 3: 1, 4: 0, 5: 1, 6: 0, 7: 1}, edge_colors)
 
     def test_heavy_hex_graph(self):
-        """Test that we color the heavy hex with exactly 3 colors (it's bipartite and has max degree 3)."""
+        """Test that we color the heavy hex with exactly 3 colors (it's bipartite
+        and has max degree 3)."""
         graph = rustworkx.generators.heavy_hex_graph(9)
         edge_colors = rustworkx.rustworkx.graph_if_bipartite_edge_color(graph)
         num_colors = max(edge_colors.values()) + 1


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

This PR adds a graph edge-coloring algorithm for bipartite graphs based on the paper "A simple algorithm for edge-coloring bipartite multigraphs" by Noga Alon, 2003. The algorithm edge-colors a graph with degree `d` using precisely `d` colors and has a runtime of `O(m log m)` where `m` is the number of edges in the graph.