### PR TITLE
Fix `docs-clean` tox job

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ commands =
 skip_install = true
 deps =
 allowlist_externals = rm
-commands = rm -rf {toxinidir}/docs/build {toxinidir}/docs/apiref
+commands = rm -rf {toxinidir}/docs/build {toxinidir}/docs/source/apiref
 
 [testenv:black]
 basepython = python3


### PR DESCRIPTION
The API reference autosummary stubs are in `docs/source/apiref`, rather than loose in `docs/apiref`.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
