### PR TITLE
Save next nodes in Floyd-Warshall numpy variants for path reconstruction

### DIFF
--- a/docs/source/api/algorithm_functions/shortest_paths.rst
+++ b/docs/source/api/algorithm_functions/shortest_paths.rst
@@ -19,6 +19,7 @@ Shortest Paths
    rustworkx.distance_matrix
    rustworkx.floyd_warshall
    rustworkx.floyd_warshall_numpy
+   rustworkx.floyd_warshall_successor_and_distance_numpy
    rustworkx.astar_shortest_path
    rustworkx.k_shortest_path_lengths
    rustworkx.num_shortest_paths_unweighted

--- a/docs/source/api/algorithm_functions/shortest_paths.rst
+++ b/docs/source/api/algorithm_functions/shortest_paths.rst
@@ -19,7 +19,6 @@ Shortest Paths
    rustworkx.distance_matrix
    rustworkx.floyd_warshall
    rustworkx.floyd_warshall_numpy
-   rustworkx.floyd_warshall_successor_and_distance_numpy
    rustworkx.astar_shortest_path
    rustworkx.k_shortest_path_lengths
    rustworkx.num_shortest_paths_unweighted

--- a/docs/source/api/pydigraph_api_functions.rst
+++ b/docs/source/api/pydigraph_api_functions.rst
@@ -17,6 +17,7 @@ the functions from the explicitly typed based on the data type.
    rustworkx.digraph_distance_matrix
    rustworkx.digraph_floyd_warshall
    rustworkx.digraph_floyd_warshall_numpy
+   rustworkx.digraph_floyd_warshall_successor_and_distance_numpy
    rustworkx.digraph_adjacency_matrix
    rustworkx.digraph_all_simple_paths
    rustworkx.digraph_all_pairs_all_simple_paths

--- a/docs/source/api/pygraph_api_functions.rst
+++ b/docs/source/api/pygraph_api_functions.rst
@@ -17,6 +17,7 @@ typed API based on the data type.
    rustworkx.graph_distance_matrix
    rustworkx.graph_floyd_warshall
    rustworkx.graph_floyd_warshall_numpy
+   rustworkx.graph_floyd_warshall_successor_and_distance_numpy
    rustworkx.graph_adjacency_matrix
    rustworkx.graph_all_simple_paths
    rustworkx.graph_all_pairs_all_simple_paths

--- a/rustworkx/shortest_path.pyi
+++ b/rustworkx/shortest_path.pyi
@@ -224,8 +224,23 @@ def digraph_floyd_warshall_numpy(
     as_undirected: bool | None = ...,
     default_weight: float | None = ...,
     parallel_threshold: int | None = ...,
-) -> Tuple[np.ndarray, np.ndarray]: ...
+) -> np.ndarray: ...
 def graph_floyd_warshall_numpy(
+    graph: PyGraph[_S, _T],
+    /,
+    weight_fn: Callable[[_T], float] | None = ...,
+    default_weight: float | None = ...,
+    parallel_threshold: int | None = ...,
+) -> np.ndarray: ...
+def digraph_floyd_warshall_successor_and_distance_numpy(
+    graph: PyDiGraph[_S, _T],
+    /,
+    weight_fn: Callable[[_T], float] | None = ...,
+    as_undirected: bool | None = ...,
+    default_weight: float | None = ...,
+    parallel_threshold: int | None = ...,
+) -> Tuple[np.ndarray, np.ndarray]: ...
+def graph_floyd_warshall_successor_and_distance_numpy(
     graph: PyGraph[_S, _T],
     /,
     weight_fn: Callable[[_T], float] | None = ...,

--- a/rustworkx/shortest_path.pyi
+++ b/rustworkx/shortest_path.pyi
@@ -15,7 +15,7 @@ from .iterators import *
 from .graph import PyGraph
 from .digraph import PyDiGraph
 
-from typing import TypeVar, Callable
+from typing import TypeVar, Callable, Tuple
 
 _S = TypeVar("_S")
 _T = TypeVar("_T")
@@ -224,14 +224,14 @@ def digraph_floyd_warshall_numpy(
     as_undirected: bool | None = ...,
     default_weight: float | None = ...,
     parallel_threshold: int | None = ...,
-) -> np.ndarray: ...
+) -> Tuple[np.ndarray, np.ndarray]: ...
 def graph_floyd_warshall_numpy(
     graph: PyGraph[_S, _T],
     /,
     weight_fn: Callable[[_T], float] | None = ...,
     default_weight: float | None = ...,
     parallel_threshold: int | None = ...,
-) -> np.ndarray: ...
+) -> Tuple[np.ndarray, np.ndarray]: ...
 def find_negative_cycle(
     graph: PyDiGraph[_S, _T],
     edge_cost_fn: Callable[[_T], float],

--- a/rustworkx/shortest_path.pyi
+++ b/rustworkx/shortest_path.pyi
@@ -15,7 +15,7 @@ from .iterators import *
 from .graph import PyGraph
 from .digraph import PyDiGraph
 
-from typing import TypeVar, Callable, Tuple
+from typing import TypeVar, Callable
 
 _S = TypeVar("_S")
 _T = TypeVar("_T")
@@ -239,14 +239,14 @@ def digraph_floyd_warshall_successor_and_distance_numpy(
     as_undirected: bool | None = ...,
     default_weight: float | None = ...,
     parallel_threshold: int | None = ...,
-) -> Tuple[np.ndarray, np.ndarray]: ...
+) -> tuple[np.ndarray, np.ndarray]: ...
 def graph_floyd_warshall_successor_and_distance_numpy(
     graph: PyGraph[_S, _T],
     /,
     weight_fn: Callable[[_T], float] | None = ...,
     default_weight: float | None = ...,
     parallel_threshold: int | None = ...,
-) -> Tuple[np.ndarray, np.ndarray]: ...
+) -> tuple[np.ndarray, np.ndarray]: ...
 def find_negative_cycle(
     graph: PyDiGraph[_S, _T],
     edge_cost_fn: Callable[[_T], float],

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -165,7 +165,7 @@ use super::dag_algo::is_directed_acyclic_graph;
 ///
 /// :param bool check_cycle: When this is set to ``True`` the created
 ///     ``PyDiGraph`` has runtime cycle detection enabled.
-/// :param bool multgraph: When this is set to ``False`` the created
+/// :param bool multigraph: When this is set to ``False`` the created
 ///     ``PyDiGraph`` object will not be a multigraph. When ``False`` if a
 ///     method call is made that would add parallel edges the the weight/weight
 ///     from that method call will be used to update the existing edge in place.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,6 +389,12 @@ fn rustworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(digraph_floyd_warshall))?;
     m.add_wrapped(wrap_pyfunction!(graph_floyd_warshall_numpy))?;
     m.add_wrapped(wrap_pyfunction!(digraph_floyd_warshall_numpy))?;
+    m.add_wrapped(wrap_pyfunction!(
+        graph_floyd_warshall_successor_and_distance_numpy
+    ))?;
+    m.add_wrapped(wrap_pyfunction!(
+        digraph_floyd_warshall_successor_and_distance_numpy
+    ))?;
     m.add_wrapped(wrap_pyfunction!(collect_runs))?;
     m.add_wrapped(wrap_pyfunction!(collect_bicolor_runs))?;
     m.add_wrapped(wrap_pyfunction!(layers))?;

--- a/src/shortest_path/mod.rs
+++ b/src/shortest_path/mod.rs
@@ -942,6 +942,7 @@ pub fn graph_floyd_warshall_numpy(
         weight_fn,
         true,
         default_weight,
+        false,
         parallel_threshold,
     )?;
     Ok(matrix.into_pyarray(py).into())
@@ -965,9 +966,13 @@ pub fn graph_floyd_warshall_successor_and_distance_numpy(
         weight_fn,
         true,
         default_weight,
+        true,
         parallel_threshold,
     )?;
-    Ok((matrix.into_pyarray(py).into(), next.into_pyarray(py).into()))
+    Ok((
+        matrix.into_pyarray(py).into(),
+        next.unwrap().into_pyarray(py).into(),
+    ))
 }
 
 /// Find all-pairs shortest path lengths using Floyd's algorithm
@@ -1024,6 +1029,7 @@ pub fn digraph_floyd_warshall_numpy(
         weight_fn,
         as_undirected,
         default_weight,
+        false,
         parallel_threshold,
     )?;
     Ok(matrix.into_pyarray(py).into())
@@ -1048,9 +1054,13 @@ pub fn digraph_floyd_warshall_successor_and_distance_numpy(
         weight_fn,
         as_undirected,
         default_weight,
+        true,
         parallel_threshold,
     )?;
-    Ok((matrix.into_pyarray(py).into(), next.into_pyarray(py).into()))
+    Ok((
+        matrix.into_pyarray(py).into(),
+        next.unwrap().into_pyarray(py).into(),
+    ))
 }
 
 /// Get the number of unweighted shortest paths from a source node

--- a/src/shortest_path/mod.rs
+++ b/src/shortest_path/mod.rs
@@ -935,8 +935,8 @@ pub fn graph_floyd_warshall_numpy(
     weight_fn: Option<PyObject>,
     default_weight: f64,
     parallel_threshold: usize,
-) -> PyResult<PyObject> {
-    let matrix = floyd_warshall::floyd_warshall_numpy(
+) -> PyResult<(PyObject, PyObject)> {
+    let (matrix, next) = floyd_warshall::floyd_warshall_numpy(
         py,
         &graph.graph,
         weight_fn,
@@ -944,7 +944,7 @@ pub fn graph_floyd_warshall_numpy(
         default_weight,
         parallel_threshold,
     )?;
-    Ok(matrix.into_pyarray(py).into())
+    Ok((matrix.into_pyarray(py).into(), next.into_pyarray(py).into()))
 }
 
 /// Find all-pairs shortest path lengths using Floyd's algorithm
@@ -994,8 +994,8 @@ pub fn digraph_floyd_warshall_numpy(
     as_undirected: bool,
     default_weight: f64,
     parallel_threshold: usize,
-) -> PyResult<PyObject> {
-    let matrix = floyd_warshall::floyd_warshall_numpy(
+) -> PyResult<(PyObject, PyObject)> {
+    let (matrix, next) = floyd_warshall::floyd_warshall_numpy(
         py,
         &graph.graph,
         weight_fn,
@@ -1003,7 +1003,7 @@ pub fn digraph_floyd_warshall_numpy(
         default_weight,
         parallel_threshold,
     )?;
-    Ok(matrix.into_pyarray(py).into())
+    Ok((matrix.into_pyarray(py).into(), next.into_pyarray(py).into()))
 }
 
 /// Get the number of unweighted shortest paths from a source node

--- a/src/shortest_path/mod.rs
+++ b/src/shortest_path/mod.rs
@@ -935,6 +935,29 @@ pub fn graph_floyd_warshall_numpy(
     weight_fn: Option<PyObject>,
     default_weight: f64,
     parallel_threshold: usize,
+) -> PyResult<PyObject> {
+    let (matrix, _) = floyd_warshall::floyd_warshall_numpy(
+        py,
+        &graph.graph,
+        weight_fn,
+        true,
+        default_weight,
+        parallel_threshold,
+    )?;
+    Ok(matrix.into_pyarray(py).into())
+}
+
+#[pyfunction]
+#[pyo3(
+signature=(graph, weight_fn=None, default_weight=1.0, parallel_threshold=300),
+text_signature = "(graph, /, weight_fn=None, default_weight=1.0, parallel_threshold=300)"
+)]
+pub fn graph_floyd_warshall_successor_and_distance_numpy(
+    py: Python,
+    graph: &graph::PyGraph,
+    weight_fn: Option<PyObject>,
+    default_weight: f64,
+    parallel_threshold: usize,
 ) -> PyResult<(PyObject, PyObject)> {
     let (matrix, next) = floyd_warshall::floyd_warshall_numpy(
         py,
@@ -984,10 +1007,34 @@ pub fn graph_floyd_warshall_numpy(
 /// :rtype: numpy.ndarray
 #[pyfunction]
 #[pyo3(
-    signature=(graph, weight_fn=None, as_undirected=false, default_weight=1.0, parallel_threshold=300),
-    text_signature = "(graph, /, weight_fn=None, as_undirected=False, default_weight=1.0, parallel_threshold=300)"
+signature=(graph, weight_fn=None, as_undirected=false, default_weight=1.0, parallel_threshold=300),
+text_signature = "(graph, /, weight_fn=None, as_undirected=False, default_weight=1.0, parallel_threshold=300)"
 )]
 pub fn digraph_floyd_warshall_numpy(
+    py: Python,
+    graph: &digraph::PyDiGraph,
+    weight_fn: Option<PyObject>,
+    as_undirected: bool,
+    default_weight: f64,
+    parallel_threshold: usize,
+) -> PyResult<PyObject> {
+    let (matrix, _) = floyd_warshall::floyd_warshall_numpy(
+        py,
+        &graph.graph,
+        weight_fn,
+        as_undirected,
+        default_weight,
+        parallel_threshold,
+    )?;
+    Ok(matrix.into_pyarray(py).into())
+}
+
+#[pyfunction]
+#[pyo3(
+signature=(graph, weight_fn=None, as_undirected=false, default_weight=1.0, parallel_threshold=300),
+text_signature = "(graph, /, weight_fn=None, as_undirected=False, default_weight=1.0, parallel_threshold=300)"
+)]
+pub fn digraph_floyd_warshall_successor_and_distance_numpy(
     py: Python,
     graph: &digraph::PyDiGraph,
     weight_fn: Option<PyObject>,

--- a/src/shortest_path/mod.rs
+++ b/src/shortest_path/mod.rs
@@ -1050,6 +1050,55 @@ pub fn graph_floyd_warshall_numpy(
     Ok(matrix.into_pyarray(py).into())
 }
 
+/// Find all-pairs shortest path lengths using Floyd's algorithm
+///
+/// Floyd's algorithm is used for finding shortest paths in dense graphs
+/// or graphs with negative weights (where Dijkstra's algorithm fails).
+///
+/// This function is multithreaded and will launch a pool with threads equal
+/// to the number of CPUs by default if the number of nodes in the graph is
+/// above the value of ``parallel_threshold`` (it defaults to 300).
+/// You can tune the number of threads with the ``RAYON_NUM_THREADS``
+/// environment variable. For example, setting ``RAYON_NUM_THREADS=4`` would
+/// limit the thread pool to 4 threads if parallelization was enabled.
+///
+/// :param PyGraph graph: The graph to run Floyd's algorithm on
+/// :param weight_fn: A callable object (function, lambda, etc) which
+///     will be passed the edge object and expected to return a ``float``. This
+///     tells rustworkx/rust how to extract a numerical weight as a ``float``
+///     for edge object. Some simple examples are::
+///
+///         graph_floyd_warshall_numpy(graph, weight_fn: lambda x: 1)
+///
+///     to return a weight of 1 for all edges. Also::
+///
+///         graph_floyd_warshall_numpy(graph, weight_fn: lambda x: float(x))
+///
+///     to cast the edge object as a float as the weight.
+/// :param int parallel_threshold: The number of nodes to execute
+///     the algorithm in parallel at. It defaults to 300, but this can
+///     be tuned
+///
+/// :returns: A tuple of two matrices.
+///     First one is a matrix of shortest path distances between nodes. If there is no
+///     path between two nodes then the corresponding matrix entry will be
+///     ``np.inf``.
+///     Second one is a matrix of **next** nodes for given source and target. If there is no
+///     path between two nodes then the corresponding matrix entry will be the same as
+///     a target node. To reconstruct the shortest path among nodes::
+///
+///         def reconstruct_path(source, target, successors):
+///             path = []
+///             if source == target:
+///                 return path
+///             curr = source
+///             while curr != target:
+///                 path.append(curr)
+///                 curr = successors[curr, target]
+///             path.append(target)
+///             return path
+///
+/// :rtype: (numpy.ndarray, numpy.ndarray)
 #[pyfunction]
 #[pyo3(
 signature=(graph, weight_fn=None, default_weight=1.0, parallel_threshold=300),
@@ -1137,6 +1186,57 @@ pub fn digraph_floyd_warshall_numpy(
     Ok(matrix.into_pyarray(py).into())
 }
 
+/// Find all-pairs shortest path lengths using Floyd's algorithm
+///
+/// Floyd's algorithm is used for finding shortest paths in dense graphs
+/// or graphs with negative weights (where Dijkstra's algorithm fails).
+///
+/// This function is multithreaded and will launch a pool with threads equal
+/// to the number of CPUs by default if the number of nodes in the graph is
+/// above the value of ``parallel_threshold`` (it defaults to 300).
+/// You can tune the number of threads with the ``RAYON_NUM_THREADS``
+/// environment variable. For example, setting ``RAYON_NUM_THREADS=4`` would
+/// limit the thread pool to 4 threads if parallelization was enabled.
+///
+/// :param PyDiGraph graph: The directed graph to run Floyd's algorithm on
+/// :param weight_fn: A callable object (function, lambda, etc) which
+///     will be passed the edge object and expected to return a ``float``. This
+///     tells rustworkx/rust how to extract a numerical weight as a ``float``
+///     for edge object. Some simple examples are::
+///
+///         graph_floyd_warshall_numpy(graph, weight_fn: lambda x: 1)
+///
+///     to return a weight of 1 for all edges. Also::
+///
+///         graph_floyd_warshall_numpy(graph, weight_fn: lambda x: float(x))
+///
+///     to cast the edge object as a float as the weight.
+/// :param as_undirected: If set to true each directed edge will be treated as
+///     bidirectional/undirected.
+/// :param int parallel_threshold: The number of nodes to execute
+///     the algorithm in parallel at. It defaults to 300, but this can
+///     be tuned
+///
+/// :returns: A tuple of two matrices.
+///     First one is a matrix of shortest path distances between nodes. If there is no
+///     path between two nodes then the corresponding matrix entry will be
+///     ``np.inf``.
+///     Second one is a matrix of **next** nodes for given source and target. If there is no
+///     path between two nodes then the corresponding matrix entry will be the same as
+///     a target node. To reconstruct the shortest path among nodes::
+///
+///         def reconstruct_path(source, target, successors):
+///             path = []
+///             if source == target:
+///                 return path
+///             curr = source
+///             while curr != target:
+///                 path.append(curr)
+///                 curr = successors[curr, target]
+///             path.append(target)
+///             return path
+///
+/// :rtype: (numpy.ndarray, numpy.ndarray)
 #[pyfunction]
 #[pyo3(
 signature=(graph, weight_fn=None, as_undirected=false, default_weight=1.0, parallel_threshold=300),

--- a/tests/rustworkx_tests/digraph/test_floyd_warshall.py
+++ b/tests/rustworkx_tests/digraph/test_floyd_warshall.py
@@ -289,6 +289,22 @@ class TestFloydWarshall(unittest.TestCase):
         self.assertEqual(dist[0, 3], 6)
         self.assertEqual(dist[0, 4], 8)
 
+    def test_floyd_warshall_successors_numpy(self):
+        graph = rustworkx.PyDiGraph()
+        graph.add_nodes_from(list(range(9)))
+        graph.add_edges_from_no_data(
+            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (0, 8)]
+        )
+        dist, succ = rustworkx.digraph_floyd_warshall_successor_and_distance_numpy(
+            graph, default_weight=2, parallel_threshold=self.parallel_threshold
+        )
+        self.assertEqual(succ[1, 1], 1)
+        self.assertEqual(succ[1, 4], 2)
+        self.assertEqual(succ[1, 6], 2)
+        self.assertEqual(succ[1, 7], 7)
+        self.assertEqual(succ[1, 8], 8)
+        self.assertEqual(succ[0, 8], 8)
+
 
 class TestParallelFloydWarshall(TestFloydWarshall):
     parallel_threshold = 0

--- a/tests/rustworkx_tests/graph/test_floyd_warshall.py
+++ b/tests/rustworkx_tests/graph/test_floyd_warshall.py
@@ -196,6 +196,22 @@ class TestFloydWarshall(unittest.TestCase):
         self.assertEqual(dist[0, 3], 6)
         self.assertEqual(dist[0, 4], 6)
 
+    def test_floyd_warshall_successors_numpy(self):
+        graph = rustworkx.PyGraph()
+        graph.add_nodes_from(list(range(9)))
+        graph.add_edges_from_no_data(
+            [(1, 2), (1, 7), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7), (0, 8)]
+        )
+        dist, succ = rustworkx.graph_floyd_warshall_successor_and_distance_numpy(
+            graph, default_weight=2, parallel_threshold=self.parallel_threshold
+        )
+        self.assertEqual(succ[1, 1], 1)
+        self.assertEqual(succ[1, 4], 2)
+        self.assertEqual(succ[1, 6], 7)
+        self.assertEqual(succ[1, 7], 7)
+        self.assertEqual(succ[1, 8], 8)
+        self.assertEqual(succ[0, 8], 8)
+
 
 class TestParallelFloydWarshall(TestFloydWarshall):
     parallel_threshold = 0


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

This PR adds "next node" matrix to the Floyd-Warshall implementations' return value.
This helps re-construct the shortest path from the result.

`digraph_floyd_warshall_numpy` and `graph_floyd_warshall_numpy` return **two** variable by applying this patch. In recent version, they returned only a length table.

The next node table is inherently dense, even though the graph is sparse. To not break the advantage of the implementation optimized for the sparse graph, I modified only numpy variants.