### PR TITLE
Replace call to deprecated np.alltrue with np.all

### DIFF
--- a/rustworkx/visualization/matplotlib.py
+++ b/rustworkx/visualization/matplotlib.py
@@ -643,7 +643,7 @@ def draw_edges(
     if (
         np.iterable(edge_color)
         and (len(edge_color) == len(edge_pos))
-        and np.alltrue([isinstance(c, Number) for c in edge_color])
+        and np.all([isinstance(c, Number) for c in edge_color])
     ):
         if edge_cmap is not None:
             assert isinstance(edge_cmap, mpl.colors.Colormap)


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

The `np.alltrue` method will be removed in numpy 2.0.
