### PR TITLE
run clippy CI job on all targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Rust Format
         run: cargo fmt --all -- --check
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
       - name: Black Codestyle Format
         run: black --check --diff retworkx rustworkx retworkx tests
       - name: Python Lint

--- a/rustworkx-core/src/centrality.rs
+++ b/rustworkx-core/src/centrality.rs
@@ -477,7 +477,7 @@ mod test_edge_betweenness_centrality {
 
     #[test]
     fn test_undirected_graph_normalized() {
-        let graph = petgraph::graph::UnGraph::<(), ()>::from_edges(&[
+        let graph = petgraph::graph::UnGraph::<(), ()>::from_edges([
             (0, 6),
             (0, 4),
             (0, 1),
@@ -496,7 +496,7 @@ mod test_edge_betweenness_centrality {
         ]);
         let output = edge_betweenness_centrality(&graph, true, 50);
         let result = output.iter().map(|x| x.unwrap()).collect::<Vec<f64>>();
-        let expected_values = vec![
+        let expected_values = [
             0.1023809, 0.0547619, 0.0922619, 0.05654762, 0.09940476, 0.125, 0.09940476, 0.12440476,
             0.12857143, 0.12142857, 0.13511905, 0.125, 0.06547619, 0.08869048, 0.08154762,
         ];
@@ -507,7 +507,7 @@ mod test_edge_betweenness_centrality {
 
     #[test]
     fn test_undirected_graph_unnormalized() {
-        let graph = petgraph::graph::UnGraph::<(), ()>::from_edges(&[
+        let graph = petgraph::graph::UnGraph::<(), ()>::from_edges([
             (0, 2),
             (0, 4),
             (0, 1),
@@ -523,7 +523,7 @@ mod test_edge_betweenness_centrality {
         ]);
         let output = edge_betweenness_centrality(&graph, false, 50);
         let result = output.iter().map(|x| x.unwrap()).collect::<Vec<f64>>();
-        let expected_values = vec![
+        let expected_values = [
             3.83333, 5.5, 5.33333, 3.5, 2.5, 3.0, 3.5, 4.0, 3.66667, 6.5, 3.5, 2.16667,
         ];
         for i in 0..12 {
@@ -533,7 +533,7 @@ mod test_edge_betweenness_centrality {
 
     #[test]
     fn test_directed_graph_normalized() {
-        let graph = petgraph::graph::DiGraph::<(), ()>::from_edges(&[
+        let graph = petgraph::graph::DiGraph::<(), ()>::from_edges([
             (0, 1),
             (1, 0),
             (1, 3),
@@ -547,7 +547,7 @@ mod test_edge_betweenness_centrality {
         ]);
         let output = edge_betweenness_centrality(&graph, true, 50);
         let result = output.iter().map(|x| x.unwrap()).collect::<Vec<f64>>();
-        let expected_values = vec![0.2, 0.2, 0.1, 0.1, 0.1, 0.05, 0.1, 0.3, 0.35, 0.2];
+        let expected_values = [0.2, 0.2, 0.1, 0.1, 0.1, 0.05, 0.1, 0.3, 0.35, 0.2];
         for i in 0..10 {
             assert_almost_equal!(result[i], expected_values[i], 1e-4);
         }
@@ -555,7 +555,7 @@ mod test_edge_betweenness_centrality {
 
     #[test]
     fn test_directed_graph_unnormalized() {
-        let graph = petgraph::graph::DiGraph::<(), ()>::from_edges(&[
+        let graph = petgraph::graph::DiGraph::<(), ()>::from_edges([
             (0, 4),
             (1, 0),
             (1, 3),
@@ -569,7 +569,7 @@ mod test_edge_betweenness_centrality {
         ]);
         let output = edge_betweenness_centrality(&graph, false, 50);
         let result = output.iter().map(|x| x.unwrap()).collect::<Vec<f64>>();
-        let expected_values = vec![4.5, 3.0, 6.5, 1.5, 1.5, 1.5, 1.5, 4.5, 2.0, 7.5];
+        let expected_values = [4.5, 3.0, 6.5, 1.5, 1.5, 1.5, 1.5, 4.5, 2.0, 7.5];
         for i in 0..10 {
             assert_almost_equal!(result[i], expected_values[i], 1e-4);
         }
@@ -578,7 +578,7 @@ mod test_edge_betweenness_centrality {
     #[test]
     fn test_stable_graph_with_removed_edges() {
         let mut graph: StableGraph<(), (), Undirected> =
-            StableGraph::from_edges(&[(0, 1), (1, 2), (2, 3), (3, 0)]);
+            StableGraph::from_edges([(0, 1), (1, 2), (2, 3), (3, 0)]);
         graph.remove_edge(edge_index(1));
         let result = edge_betweenness_centrality(&graph, false, 50);
         let expected_values = vec![Some(3.0), None, Some(3.0), Some(4.0)];
@@ -815,7 +815,7 @@ mod test_eigenvector_centrality {
     }
     #[test]
     fn test_no_convergence() {
-        let g = petgraph::graph::UnGraph::<i32, ()>::from_edges(&[(0, 1), (1, 2)]);
+        let g = petgraph::graph::UnGraph::<i32, ()>::from_edges([(0, 1), (1, 2)]);
         let output: Result<Option<Vec<f64>>> =
             eigenvector_centrality(&g, |_| Ok(1.), Some(0), None);
         let result = output.unwrap();
@@ -847,7 +847,7 @@ mod test_eigenvector_centrality {
 
     #[test]
     fn test_undirected_path_graph() {
-        let g = petgraph::graph::UnGraph::<i32, ()>::from_edges(&[(0, 1), (1, 2)]);
+        let g = petgraph::graph::UnGraph::<i32, ()>::from_edges([(0, 1), (1, 2)]);
         let output: Result<Option<Vec<f64>>> = eigenvector_centrality(&g, |_| Ok(1.), None, None);
         let result = output.unwrap().unwrap();
         let expected_values: Vec<f64> = vec![0.5, 0.7071, 0.5];
@@ -905,7 +905,7 @@ mod test_katz_centrality {
     }
     #[test]
     fn test_no_convergence() {
-        let g = petgraph::graph::UnGraph::<i32, ()>::from_edges(&[(0, 1), (1, 2)]);
+        let g = petgraph::graph::UnGraph::<i32, ()>::from_edges([(0, 1), (1, 2)]);
         let output: Result<Option<Vec<f64>>> =
             katz_centrality(&g, |_| Ok(1.), None, None, None, Some(0), None);
         let result = output.unwrap();
@@ -914,7 +914,7 @@ mod test_katz_centrality {
 
     #[test]
     fn test_incomplete_beta() {
-        let g = petgraph::graph::UnGraph::<i32, ()>::from_edges(&[(0, 1), (1, 2)]);
+        let g = petgraph::graph::UnGraph::<i32, ()>::from_edges([(0, 1), (1, 2)]);
         let beta_map: HashMap<usize, f64> = [(0, 1.0)].iter().cloned().collect();
         let output: Result<Option<Vec<f64>>> =
             katz_centrality(&g, |_| Ok(1.), None, Some(beta_map), None, None, None);
@@ -924,7 +924,7 @@ mod test_katz_centrality {
 
     #[test]
     fn test_complete_beta() {
-        let g = petgraph::graph::UnGraph::<i32, ()>::from_edges(&[(0, 1), (1, 2)]);
+        let g = petgraph::graph::UnGraph::<i32, ()>::from_edges([(0, 1), (1, 2)]);
         let beta_map: HashMap<usize, f64> =
             [(0, 0.5), (1, 1.0), (2, 0.5)].iter().cloned().collect();
         let output: Result<Option<Vec<f64>>> =

--- a/rustworkx-core/src/centrality.rs
+++ b/rustworkx-core/src/centrality.rs
@@ -850,7 +850,7 @@ mod test_eigenvector_centrality {
         let g = petgraph::graph::UnGraph::<i32, ()>::from_edges([(0, 1), (1, 2)]);
         let output: Result<Option<Vec<f64>>> = eigenvector_centrality(&g, |_| Ok(1.), None, None);
         let result = output.unwrap().unwrap();
-        let expected_values: Vec<f64> = vec![0.5, 0.7071, 0.5];
+        let expected_values: Vec<f64> = vec![0.5, std::f64::consts::FRAC_1_SQRT_2, 0.5];
         for i in 0..3 {
             assert_almost_equal!(expected_values[i], result[i], 1e-4);
         }

--- a/rustworkx-core/src/coloring.rs
+++ b/rustworkx-core/src/coloring.rs
@@ -506,7 +506,7 @@ mod test_node_coloring {
     #[test]
     fn test_greedy_node_color_simple_graph() {
         // Simple graph
-        let graph = Graph::<(), (), Undirected>::from_edges(&[(0, 1), (0, 2)]);
+        let graph = Graph::<(), (), Undirected>::from_edges([(0, 1), (0, 2)]);
         let colors = greedy_node_color(&graph);
         let expected_colors: DictMap<NodeIndex, usize> = [
             (NodeIndex::new(0), 0),
@@ -521,7 +521,7 @@ mod test_node_coloring {
     #[test]
     fn test_greedy_node_color_simple_graph_large_degree() {
         // Graph with multiple edges
-        let graph = Graph::<(), (), Undirected>::from_edges(&[
+        let graph = Graph::<(), (), Undirected>::from_edges([
             (0, 1),
             (0, 2),
             (0, 2),
@@ -544,7 +544,7 @@ mod test_node_coloring {
     fn test_two_color_directed() {
         let edge_list = vec![(0, 1), (1, 2), (2, 3), (3, 4)];
 
-        let graph = DiGraph::<i32, i32>::from_edges(&edge_list);
+        let graph = DiGraph::<i32, i32>::from_edges(edge_list);
         let coloring = two_color(&graph).unwrap();
         let mut expected_colors = DictMap::new();
         expected_colors.insert(NodeIndex::new(0), 1);
@@ -559,7 +559,7 @@ mod test_node_coloring {
     fn test_two_color_directed_not_bipartite() {
         let edge_list = vec![(0, 1), (1, 2), (2, 3), (3, 0), (3, 1)];
 
-        let graph = DiGraph::<i32, i32>::from_edges(&edge_list);
+        let graph = DiGraph::<i32, i32>::from_edges(edge_list);
         let coloring = two_color(&graph);
         assert_eq!(None, coloring)
     }
@@ -568,7 +568,7 @@ mod test_node_coloring {
     fn test_two_color_undirected_not_bipartite() {
         let edge_list = vec![(0, 1), (1, 2), (2, 3), (3, 0), (3, 1)];
 
-        let graph = UnGraph::<i32, i32>::from_edges(&edge_list);
+        let graph = UnGraph::<i32, i32>::from_edges(edge_list);
         let coloring = two_color(&graph);
         assert_eq!(None, coloring)
     }
@@ -577,7 +577,7 @@ mod test_node_coloring {
     fn test_two_color_directed_with_isolates() {
         let edge_list = vec![(0, 1), (1, 2), (2, 3), (3, 4)];
 
-        let mut graph = DiGraph::<i32, i32>::from_edges(&edge_list);
+        let mut graph = DiGraph::<i32, i32>::from_edges(edge_list);
         graph.add_node(10);
         graph.add_node(11);
         let coloring = two_color(&graph).unwrap();
@@ -596,7 +596,7 @@ mod test_node_coloring {
     fn test_two_color_undirected_with_isolates() {
         let edge_list = vec![(0, 1), (1, 2), (2, 3), (3, 4)];
 
-        let mut graph = UnGraph::<i32, i32>::from_edges(&edge_list);
+        let mut graph = UnGraph::<i32, i32>::from_edges(edge_list);
         graph.add_node(10);
         graph.add_node(11);
         let coloring = two_color(&graph).unwrap();
@@ -633,7 +633,7 @@ mod test_edge_coloring {
     #[test]
     fn test_greedy_edge_color_simple_graph() {
         // Graph with an edge removed
-        let graph = Graph::<(), (), Undirected>::from_edges(&[(0, 1), (1, 2), (2, 3)]);
+        let graph = Graph::<(), (), Undirected>::from_edges([(0, 1), (1, 2), (2, 3)]);
         let colors = greedy_edge_color(&graph);
         let expected_colors: DictMap<EdgeIndex, usize> = [
             (EdgeIndex::new(0), 1),
@@ -648,7 +648,7 @@ mod test_edge_coloring {
     #[test]
     fn test_greedy_edge_color_graph_with_removed_edges() {
         // Simple graph
-        let mut graph = Graph::<(), (), Undirected>::from_edges(&[(0, 1), (1, 2), (2, 3), (3, 0)]);
+        let mut graph = Graph::<(), (), Undirected>::from_edges([(0, 1), (1, 2), (2, 3), (3, 0)]);
         graph.remove_edge(edge_index(1));
         let colors = greedy_edge_color(&graph);
         let expected_colors: DictMap<EdgeIndex, usize> = [
@@ -730,7 +730,7 @@ mod test_misra_gries_edge_coloring {
 
     #[test]
     fn test_simple_graph() {
-        let graph = Graph::<(), (), Undirected>::from_edges(&[(0, 1), (0, 2), (0, 3), (3, 4)]);
+        let graph = Graph::<(), (), Undirected>::from_edges([(0, 1), (0, 2), (0, 3), (3, 4)]);
         let colors = misra_gries_edge_color(&graph);
         check_edge_coloring(&graph, &colors);
 

--- a/rustworkx-core/src/connectivity/all_simple_paths.rs
+++ b/rustworkx-core/src/connectivity/all_simple_paths.rs
@@ -239,7 +239,7 @@ mod tests {
         let d = graph.add_node(3);
         let e = graph.add_node(4);
 
-        graph.extend_with_edges(&[(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1)]);
+        graph.extend_with_edges([(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1)]);
 
         let mut to_set = HashSet::new();
         to_set.insert(d);
@@ -259,7 +259,7 @@ mod tests {
         let d = graph.add_node(3);
         let e = graph.add_node(4);
 
-        graph.extend_with_edges(&[(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1), (c, e, 1)]);
+        graph.extend_with_edges([(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1), (c, e, 1)]);
 
         let mut to_set = HashSet::new();
         to_set.insert(d);
@@ -287,7 +287,7 @@ mod tests {
         let d = graph.add_node(3);
         let e = graph.add_node(4);
 
-        graph.extend_with_edges(&[(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1), (c, e, 1)]);
+        graph.extend_with_edges([(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1), (c, e, 1)]);
 
         let mut to_set = HashSet::new();
         to_set.insert(d);
@@ -312,7 +312,7 @@ mod tests {
         let d = graph.add_node(3);
         let e = graph.add_node(4);
 
-        graph.extend_with_edges(&[
+        graph.extend_with_edges([
             (a, b, 1),
             (a, c, 1),
             (a, d, 1),
@@ -350,7 +350,7 @@ mod tests {
         let d = graph.add_node(3);
         let e = graph.add_node(4);
 
-        graph.extend_with_edges(&[(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1), (c, e, 1)]);
+        graph.extend_with_edges([(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1), (c, e, 1)]);
 
         let mut to_set = HashSet::new();
         to_set.insert(d);
@@ -372,7 +372,7 @@ mod tests {
         let d = graph.add_node(3);
         let e = graph.add_node(4);
 
-        graph.extend_with_edges(&[(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1), (c, e, 1)]);
+        graph.extend_with_edges([(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1), (c, e, 1)]);
 
         let mut to_set = HashSet::new();
         to_set.insert(d);
@@ -394,7 +394,7 @@ mod tests {
         let d = graph.add_node(3);
         let e = graph.add_node(4);
 
-        graph.extend_with_edges(&[(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1)]);
+        graph.extend_with_edges([(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1)]);
 
         let mut to_set = HashSet::new();
         to_set.insert(c);
@@ -415,7 +415,7 @@ mod tests {
         let c = graph.add_node(2);
         let d = graph.add_node(3);
 
-        graph.extend_with_edges(&[(a, b, 1), (b, c, 1), (c, d, 1), (d, a, 1), (b, d, 1)]);
+        graph.extend_with_edges([(a, b, 1), (b, c, 1), (c, d, 1), (d, a, 1), (b, d, 1)]);
 
         let mut to_set = HashSet::new();
         to_set.insert(d);
@@ -434,7 +434,7 @@ mod tests {
         let c = graph.add_node(2);
         let d = graph.add_node(3);
 
-        graph.extend_with_edges(&[(a, b, 1), (b, c, 1), (c, d, 1), (d, a, 1), (b, d, 1)]);
+        graph.extend_with_edges([(a, b, 1), (b, c, 1), (c, d, 1), (d, a, 1), (b, d, 1)]);
 
         let mut to_set = HashSet::new();
         to_set.insert(c);
@@ -456,7 +456,7 @@ mod tests {
         let d = graph.add_node(3);
         let e = graph.add_node(4);
 
-        graph.extend_with_edges(&[(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1)]);
+        graph.extend_with_edges([(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1)]);
 
         let mut to_set = HashSet::new();
         to_set.insert(a);
@@ -477,7 +477,7 @@ mod tests {
         let e = graph.add_node(4);
         let f = graph.add_node(5);
 
-        graph.extend_with_edges(&[
+        graph.extend_with_edges([
             (a, b, 1),
             (b, c, 1),
             (c, d, 1),
@@ -544,7 +544,7 @@ mod tests {
         let d = graph.add_node(3);
         let e = graph.add_node(4);
 
-        graph.extend_with_edges(&[(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1)]);
+        graph.extend_with_edges([(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1)]);
 
         let mut to_set = HashSet::new();
         to_set.insert(d);
@@ -564,7 +564,7 @@ mod tests {
         let d = graph.add_node(3);
         let e = graph.add_node(4);
 
-        graph.extend_with_edges(&[(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1), (c, e, 1)]);
+        graph.extend_with_edges([(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1), (c, e, 1)]);
 
         let mut to_set = HashSet::new();
         to_set.insert(d);
@@ -585,7 +585,7 @@ mod tests {
         let d = graph.add_node(3);
         let e = graph.add_node(4);
 
-        graph.extend_with_edges(&[(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1), (c, e, 1)]);
+        graph.extend_with_edges([(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1), (c, e, 1)]);
 
         let mut to_set = HashSet::new();
         to_set.insert(d);
@@ -606,7 +606,7 @@ mod tests {
         let d = graph.add_node(3);
         let e = graph.add_node(4);
 
-        graph.extend_with_edges(&[(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1)]);
+        graph.extend_with_edges([(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1)]);
 
         let mut to_set = HashSet::new();
         to_set.insert(c);
@@ -627,7 +627,7 @@ mod tests {
         let d = graph.add_node(3);
         let e = graph.add_node(4);
 
-        graph.extend_with_edges(&[(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1)]);
+        graph.extend_with_edges([(a, b, 1), (b, c, 1), (c, d, 1), (d, e, 1)]);
 
         let mut to_set = HashSet::new();
         to_set.insert(a);
@@ -648,7 +648,7 @@ mod tests {
         let e = graph.add_node(4);
         let f = graph.add_node(5);
 
-        graph.extend_with_edges(&[
+        graph.extend_with_edges([
             (a, b, 1),
             (b, c, 1),
             (c, d, 1),

--- a/rustworkx-core/src/connectivity/biconnected.rs
+++ b/rustworkx-core/src/connectivity/biconnected.rs
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_articulation_points_repetitions() {
-        let graph = UnGraph::<(), ()>::from_edges(&[(0, 1), (1, 2), (1, 3)]);
+        let graph = UnGraph::<(), ()>::from_edges([(0, 1), (1, 2), (1, 3)]);
 
         let a_points = articulation_points(&graph, None);
 
@@ -203,8 +203,7 @@ mod tests {
     #[test]
     fn test_articulation_points_cycle() {
         // create a cycle graph
-        let graph =
-            UnGraph::<(), ()>::from_edges(&[(0, 1), (1, 2), (2, 0), (1, 3), (3, 4), (4, 1)]);
+        let graph = UnGraph::<(), ()>::from_edges([(0, 1), (1, 2), (2, 0), (1, 3), (3, 4), (4, 1)]);
 
         let a_points = articulation_points(&graph, None);
 
@@ -214,8 +213,7 @@ mod tests {
     #[test]
     fn test_biconnected_components_cycle() {
         // create a cycle graph
-        let graph =
-            UnGraph::<(), ()>::from_edges(&[(0, 1), (1, 2), (2, 0), (1, 3), (3, 4), (4, 1)]);
+        let graph = UnGraph::<(), ()>::from_edges([(0, 1), (1, 2), (2, 0), (1, 3), (3, 4), (4, 1)]);
 
         let mut components = HashMap::new();
         let _ = articulation_points(&graph, Some(&mut components));
@@ -236,7 +234,7 @@ mod tests {
     #[test]
     fn test_biconnected_components1() {
         // exmaple from https://web.archive.org/web/20121229123447/http://www.ibluemojo.com/school/articul_algorithm.html
-        let graph = UnGraph::<(), ()>::from_edges(&[
+        let graph = UnGraph::<(), ()>::from_edges([
             (0, 1),
             (0, 5),
             (0, 6),
@@ -315,7 +313,7 @@ mod tests {
         let i = graph.add_node("I");
         let j = graph.add_node("J");
 
-        graph.extend_with_edges(&[
+        graph.extend_with_edges([
             (a, b),
             (b, c),
             (c, a),

--- a/rustworkx-core/src/connectivity/chain.rs
+++ b/rustworkx-core/src/connectivity/chain.rs
@@ -180,7 +180,7 @@ mod tests {
 
     #[test]
     fn test_decomposition() {
-        let graph = UnGraph::<(), ()>::from_edges(&[
+        let graph = UnGraph::<(), ()>::from_edges([
             //  DFS tree edges.
             (1, 2),
             (2, 3),

--- a/rustworkx-core/src/connectivity/conn_components.rs
+++ b/rustworkx-core/src/connectivity/conn_components.rs
@@ -197,7 +197,7 @@ mod test_conn_components {
 
     #[test]
     fn test_connected_components() {
-        let graph = Graph::<(), (), Undirected>::from_edges(&[
+        let graph = Graph::<(), (), Undirected>::from_edges([
             (0, 1),
             (1, 2),
             (2, 3),
@@ -216,7 +216,7 @@ mod test_conn_components {
 
     #[test]
     fn test_bfs_undirected() {
-        let graph = Graph::<(), (), Directed>::from_edges(&[
+        let graph = Graph::<(), (), Directed>::from_edges([
             (0, 1),
             (1, 2),
             (2, 3),

--- a/rustworkx-core/src/connectivity/core_number.rs
+++ b/rustworkx-core/src/connectivity/core_number.rs
@@ -139,7 +139,7 @@ mod tests {
     #[test]
     fn test_directed_all_3() {
         let edge_list = vec![(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)];
-        let graph = DiGraph::<i32, i32>::from_edges(&edge_list);
+        let graph = DiGraph::<i32, i32>::from_edges(edge_list);
         let res: Vec<(usize, usize)> = core_number(graph)
             .iter()
             .map(|(k, v)| (k.index(), *v))
@@ -198,7 +198,7 @@ mod tests {
             example_core.push((i, 1));
         }
         example_core.push((20, 0));
-        let mut graph = DiGraph::<i32, i32>::from_edges(&edge_list);
+        let mut graph = DiGraph::<i32, i32>::from_edges(edge_list);
         graph.add_node(0);
         let res: Vec<(usize, usize)> = core_number(graph)
             .iter()

--- a/rustworkx-core/src/connectivity/cycle_basis.rs
+++ b/rustworkx-core/src/connectivity/cycle_basis.rs
@@ -148,7 +148,7 @@ mod tests {
             (7, 8),
             (8, 9),
         ];
-        let graph = UnGraph::<i32, i32>::from_edges(&edge_list);
+        let graph = UnGraph::<i32, i32>::from_edges(edge_list);
         let expected = vec![vec![0, 1, 2, 3], vec![0, 1, 6, 7, 8], vec![0, 3, 4, 5]];
         let res_0 = cycle_basis(&graph, Some(NodeIndex::new(0)));
         assert_eq!(sorted_cycle(res_0), expected);
@@ -174,7 +174,7 @@ mod tests {
             (7, 8),
             (8, 9),
         ];
-        let mut graph = UnGraph::<i32, i32>::from_edges(&edge_list);
+        let mut graph = UnGraph::<i32, i32>::from_edges(edge_list);
         graph.add_edge(NodeIndex::new(1), NodeIndex::new(1), 0);
         let res_0 = cycle_basis(&graph, Some(NodeIndex::new(0)));
         assert_eq!(

--- a/rustworkx-core/src/connectivity/find_cycle.rs
+++ b/rustworkx-core/src/connectivity/find_cycle.rs
@@ -140,7 +140,7 @@ mod tests {
             (7, 8),
             (8, 9),
         ];
-        let graph = DiGraph::<i32, i32>::from_edges(&edge_list);
+        let graph = DiGraph::<i32, i32>::from_edges(edge_list);
         let mut res: Vec<(usize, usize)> = find_cycle(&graph, Some(NodeIndex::new(0)))
             .iter()
             .map(|(s, t)| (s.index(), t.index()))
@@ -174,7 +174,7 @@ mod tests {
             (7, 8),
             (8, 9),
         ];
-        let mut graph = DiGraph::<i32, i32>::from_edges(&edge_list);
+        let mut graph = DiGraph::<i32, i32>::from_edges(edge_list);
         graph.add_edge(NodeIndex::new(1), NodeIndex::new(1), 0);
         let res: Vec<(usize, usize)> = find_cycle(&graph, Some(NodeIndex::new(0)))
             .iter()

--- a/rustworkx-core/src/connectivity/isolates.rs
+++ b/rustworkx-core/src/connectivity/isolates.rs
@@ -112,7 +112,7 @@ mod tests {
             (7, 8),
             (8, 9),
         ];
-        let mut graph = DiGraph::<i32, i32>::from_edges(&edge_list);
+        let mut graph = DiGraph::<i32, i32>::from_edges(edge_list);
         graph.add_node(10);
         graph.add_node(11);
         let res: Vec<usize> = isolates(&graph).into_iter().map(|x| x.index()).collect();
@@ -135,7 +135,7 @@ mod tests {
             (7, 8),
             (8, 9),
         ];
-        let mut graph = UnGraph::<i32, i32>::from_edges(&edge_list);
+        let mut graph = UnGraph::<i32, i32>::from_edges(edge_list);
         graph.add_node(10);
         graph.add_node(11);
         let res: Vec<usize> = isolates(&graph).into_iter().map(|x| x.index()).collect();

--- a/rustworkx-core/src/line_graph.rs
+++ b/rustworkx-core/src/line_graph.rs
@@ -116,8 +116,7 @@ mod test_line_graph {
     #[test]
     fn test_simple_graph() {
         // Simple graph
-        let input_graph =
-            Graph::<(), (), Undirected>::from_edges(&[(0, 1), (2, 3), (3, 4), (4, 5)]);
+        let input_graph = Graph::<(), (), Undirected>::from_edges([(0, 1), (2, 3), (3, 4), (4, 5)]);
 
         let (output_graph, output_edge_map): (
             petgraph::graph::UnGraph<(), ()>,

--- a/rustworkx-core/src/token_swapper.rs
+++ b/rustworkx-core/src/token_swapper.rs
@@ -639,9 +639,8 @@ mod test_token_swapper {
         // Remove self-loops
         let nodes: Vec<_> = g.node_indices().collect();
         for node in nodes {
-            let edge = g.find_edge(node, node);
-            if edge.is_some() {
-                g.remove_edge(edge.unwrap());
+            if let Some(edge) = g.find_edge(node, node) {
+                g.remove_edge(edge);
             }
         }
         // Make sure the graph is connected by adding C_n
@@ -705,10 +704,10 @@ mod test_token_swapper {
             (NodeIndex::new(0), NodeIndex::new(2)),
             (NodeIndex::new(3), NodeIndex::new(3)),
         ]);
-        match token_swapper(&g, mapping, Some(10), Some(4), Some(50)) {
-            Ok(_) => panic!("This should error"),
-            Err(_) => (),
-        };
+        assert!(
+            token_swapper(&g, mapping, Some(10), Some(4), Some(50)).is_err(),
+            "This should error"
+        );
     }
 
     #[test]
@@ -720,9 +719,9 @@ mod test_token_swapper {
         let d = g.add_node(());
         g.add_edge(c, d, ());
         let mapping = HashMap::from([(a, b), (b, a)]);
-        match token_swapper(&g, mapping, Some(10), Some(4), Some(50)) {
-            Ok(_) => panic!("This should error"),
-            Err(_) => (),
-        };
+        assert!(
+            token_swapper(&g, mapping, Some(10), Some(4), Some(50)).is_err(),
+            "This should error"
+        );
     }
 }

--- a/rustworkx-core/src/token_swapper.rs
+++ b/rustworkx-core/src/token_swapper.rs
@@ -495,7 +495,7 @@ mod test_token_swapper {
     #[test]
     fn test_simple_swap() {
         // Simple arbitrary swap
-        let g = petgraph::graph::UnGraph::<(), ()>::from_edges(&[(0, 1), (1, 2), (2, 3)]);
+        let g = petgraph::graph::UnGraph::<(), ()>::from_edges([(0, 1), (1, 2), (2, 3)]);
         let mapping = HashMap::from([
             (NodeIndex::new(0), NodeIndex::new(0)),
             (NodeIndex::new(1), NodeIndex::new(3)),
@@ -509,7 +509,7 @@ mod test_token_swapper {
     #[test]
     fn test_small_swap() {
         // Reverse all small swap
-        let g = petgraph::graph::UnGraph::<(), ()>::from_edges(&[
+        let g = petgraph::graph::UnGraph::<(), ()>::from_edges([
             (0, 1),
             (1, 2),
             (2, 3),
@@ -537,7 +537,7 @@ mod test_token_swapper {
     #[test]
     fn test_happy_swap_chain() {
         // Reverse all happy swap chain > 2
-        let g = petgraph::graph::UnGraph::<(), ()>::from_edges(&[
+        let g = petgraph::graph::UnGraph::<(), ()>::from_edges([
             (0, 1),
             (0, 2),
             (0, 3),
@@ -573,7 +573,7 @@ mod test_token_swapper {
     #[test]
     fn test_partial_simple() {
         // Simple partial swap
-        let g = petgraph::graph::UnGraph::<(), ()>::from_edges(&[(0, 1), (1, 2), (2, 3)]);
+        let g = petgraph::graph::UnGraph::<(), ()>::from_edges([(0, 1), (1, 2), (2, 3)]);
         let mapping = HashMap::from([(NodeIndex::new(0), NodeIndex::new(3))]);
         let mut new_map = mapping.clone();
         let swaps =
@@ -588,7 +588,7 @@ mod test_token_swapper {
     fn test_partial_simple_remove_node() {
         // Simple partial swap
         let mut g =
-            petgraph::graph::UnGraph::<(), ()>::from_edges(&[(0, 1), (1, 2), (2, 3), (3, 4)]);
+            petgraph::graph::UnGraph::<(), ()>::from_edges([(0, 1), (1, 2), (2, 3), (3, 4)]);
         let mapping = HashMap::from([(NodeIndex::new(0), NodeIndex::new(3))]);
         g.remove_node(NodeIndex::new(2));
         g.add_edge(NodeIndex::new(1), NodeIndex::new(3), ());
@@ -604,7 +604,7 @@ mod test_token_swapper {
     #[test]
     fn test_partial_small() {
         // Partial inverting on small path graph
-        let g = petgraph::graph::UnGraph::<(), ()>::from_edges(&[(0, 1), (1, 2), (2, 3)]);
+        let g = petgraph::graph::UnGraph::<(), ()>::from_edges([(0, 1), (1, 2), (2, 3)]);
         let mapping = HashMap::from([
             (NodeIndex::new(0), NodeIndex::new(3)),
             (NodeIndex::new(1), NodeIndex::new(2)),
@@ -675,7 +675,7 @@ mod test_token_swapper {
 
     #[test]
     fn test_disjoint_graph_works() {
-        let g = petgraph::graph::UnGraph::<(), ()>::from_edges(&[(0, 1), (2, 3)]);
+        let g = petgraph::graph::UnGraph::<(), ()>::from_edges([(0, 1), (2, 3)]);
         let mapping = HashMap::from([
             (NodeIndex::new(1), NodeIndex::new(0)),
             (NodeIndex::new(0), NodeIndex::new(1)),
@@ -698,7 +698,7 @@ mod test_token_swapper {
 
     #[test]
     fn test_disjoint_graph_fails() {
-        let g = petgraph::graph::UnGraph::<(), ()>::from_edges(&[(0, 1), (2, 3)]);
+        let g = petgraph::graph::UnGraph::<(), ()>::from_edges([(0, 1), (2, 3)]);
         let mapping = HashMap::from([
             (NodeIndex::new(2), NodeIndex::new(0)),
             (NodeIndex::new(1), NodeIndex::new(1)),

--- a/rustworkx-core/tests/centrality.rs
+++ b/rustworkx-core/tests/centrality.rs
@@ -16,7 +16,7 @@ use rustworkx_core::petgraph::graph::{DiGraph, UnGraph};
 
 #[test]
 fn test_simple() {
-    let g = UnGraph::<i32, ()>::from_edges(&[(1, 2), (2, 3), (3, 4), (1, 4)]);
+    let g = UnGraph::<i32, ()>::from_edges([(1, 2), (2, 3), (3, 4), (1, 4)]);
     let c = closeness_centrality(&g, true);
     assert_eq!(
         vec![
@@ -32,7 +32,7 @@ fn test_simple() {
 
 #[test]
 fn test_wf_improved() {
-    let g = UnGraph::<i32, ()>::from_edges(&[(0, 1), (1, 2), (2, 3), (4, 5), (5, 6)]);
+    let g = UnGraph::<i32, ()>::from_edges([(0, 1), (1, 2), (2, 3), (4, 5), (5, 6)]);
     let c = closeness_centrality(&g, true);
     assert_eq!(
         vec![
@@ -63,7 +63,7 @@ fn test_wf_improved() {
 
 #[test]
 fn test_digraph() {
-    let g = DiGraph::<i32, ()>::from_edges(&[(0, 1), (1, 2)]);
+    let g = DiGraph::<i32, ()>::from_edges([(0, 1), (1, 2)]);
     let c = closeness_centrality(&g, true);
     assert_eq!(vec![Some(0.), Some(1. / 2.), Some(2. / 3.)], c);
 
@@ -73,7 +73,7 @@ fn test_digraph() {
 
 #[test]
 fn test_k5() {
-    let g = UnGraph::<i32, ()>::from_edges(&[
+    let g = UnGraph::<i32, ()>::from_edges([
         (0, 1),
         (0, 2),
         (0, 3),
@@ -94,7 +94,7 @@ fn test_k5() {
 
 #[test]
 fn test_path() {
-    let g = UnGraph::<i32, ()>::from_edges(&[(0, 1), (1, 2)]);
+    let g = UnGraph::<i32, ()>::from_edges([(0, 1), (1, 2)]);
     let c = closeness_centrality(&g, true);
     assert_eq!(vec![Some(2.0 / 3.0), Some(1.0), Some(2.0 / 3.0)], c);
 }

--- a/rustworkx-core/tests/planar.rs
+++ b/rustworkx-core/tests/planar.rs
@@ -17,7 +17,7 @@ use rustworkx_core::planar::is_planar;
 
 #[test]
 fn test_simple_planar_graph() {
-    let graph = UnGraph::<(), ()>::from_edges(&[
+    let graph = UnGraph::<(), ()>::from_edges([
         (1, 2),
         (2, 3),
         (3, 4),
@@ -36,7 +36,7 @@ fn test_simple_planar_graph() {
 
 #[test]
 fn test_planar_grid_3_3_graph() {
-    let graph = UnGraph::<(), ()>::from_edges(&[
+    let graph = UnGraph::<(), ()>::from_edges([
         // row edges
         (0, 1),
         (1, 2),
@@ -58,7 +58,7 @@ fn test_planar_grid_3_3_graph() {
 
 #[test]
 fn test_planar_with_self_loop() {
-    let graph = UnGraph::<(), ()>::from_edges(&[
+    let graph = UnGraph::<(), ()>::from_edges([
         (1, 1),
         (2, 2),
         (3, 3),
@@ -80,7 +80,7 @@ fn test_planar_with_self_loop() {
 #[test]
 fn test_goldner_harary_planar_graph() {
     // test goldner-harary graph (a maximal planar graph)
-    let graph = UnGraph::<(), ()>::from_edges(&[
+    let graph = UnGraph::<(), ()>::from_edges([
         (1, 2),
         (1, 3),
         (1, 4),
@@ -115,21 +115,21 @@ fn test_goldner_harary_planar_graph() {
 
 #[test]
 fn test_multiple_components_planar_graph() {
-    let graph = UnGraph::<(), ()>::from_edges(&[(1, 2), (2, 3), (3, 1), (4, 5), (5, 6), (6, 4)]);
+    let graph = UnGraph::<(), ()>::from_edges([(1, 2), (2, 3), (3, 1), (4, 5), (5, 6), (6, 4)]);
     let res = is_planar(&graph);
     assert!(res)
 }
 
 #[test]
 fn test_planar_multi_graph() {
-    let graph = UnGraph::<(), ()>::from_edges(&[(0, 1), (0, 1), (0, 1), (1, 2), (2, 0)]);
+    let graph = UnGraph::<(), ()>::from_edges([(0, 1), (0, 1), (0, 1), (1, 2), (2, 0)]);
     let res = is_planar(&graph);
     assert!(res)
 }
 
 #[test]
 fn test_k3_3_non_planar() {
-    let graph = UnGraph::<(), ()>::from_edges(&[
+    let graph = UnGraph::<(), ()>::from_edges([
         (0, 3),
         (0, 4),
         (0, 5),
@@ -141,12 +141,12 @@ fn test_k3_3_non_planar() {
         (2, 5),
     ]);
     let res = is_planar(&graph);
-    assert_eq!(res, false)
+    assert!(!res)
 }
 
 #[test]
 fn test_k5_non_planar() {
-    let graph = UnGraph::<(), ()>::from_edges(&[
+    let graph = UnGraph::<(), ()>::from_edges([
         (0, 1),
         (0, 2),
         (0, 3),
@@ -159,12 +159,12 @@ fn test_k5_non_planar() {
         (3, 4),
     ]);
     let res = is_planar(&graph);
-    assert_eq!(res, false)
+    assert!(!res)
 }
 
 #[test]
 fn test_multiple_components_non_planar() {
-    let graph = UnGraph::<(), ()>::from_edges(&[
+    let graph = UnGraph::<(), ()>::from_edges([
         (0, 1),
         (0, 2),
         (0, 3),
@@ -180,13 +180,13 @@ fn test_multiple_components_non_planar() {
         (8, 6),
     ]);
     let res = is_planar(&graph);
-    assert_eq!(res, false)
+    assert!(!res)
 }
 
 #[test]
 fn test_non_planar() {
     // tests a graph that has no subgraph directly isomorphic to K5 or K3_3.
-    let graph = UnGraph::<(), ()>::from_edges(&[
+    let graph = UnGraph::<(), ()>::from_edges([
         (1, 5),
         (1, 6),
         (1, 7),
@@ -199,12 +199,12 @@ fn test_non_planar() {
         (4, 7),
     ]);
     let res = is_planar(&graph);
-    assert_eq!(res, false)
+    assert!(!res)
 }
 
 #[test]
 fn test_planar_graph1() {
-    let graph = UnGraph::<(), ()>::from_edges(&[
+    let graph = UnGraph::<(), ()>::from_edges([
         (3, 10),
         (2, 13),
         (1, 13),
@@ -222,7 +222,7 @@ fn test_planar_graph1() {
 
 #[test]
 fn test_non_planar_graph2() {
-    let graph = UnGraph::<(), ()>::from_edges(&[
+    let graph = UnGraph::<(), ()>::from_edges([
         (1, 2),
         (4, 13),
         (0, 13),
@@ -242,12 +242,12 @@ fn test_non_planar_graph2() {
         (2, 8),
     ]);
     let res = is_planar(&graph);
-    assert_eq!(res, false)
+    assert!(!res)
 }
 
 #[test]
 fn test_non_planar_graph3() {
-    let graph = UnGraph::<(), ()>::from_edges(&[
+    let graph = UnGraph::<(), ()>::from_edges([
         (0, 7),
         (3, 11),
         (3, 4),
@@ -264,5 +264,5 @@ fn test_non_planar_graph3() {
         (5, 13),
     ]);
     let res = is_planar(&graph);
-    assert_eq!(res, false)
+    assert!(!res)
 }

--- a/rustworkx-core/tests/test_connectivity.rs
+++ b/rustworkx-core/tests/test_connectivity.rs
@@ -20,7 +20,7 @@ use rustworkx_core::connectivity;
 
 #[test]
 fn test_is_connected() {
-    let graph = Graph::<(), (), Undirected>::from_edges(&[
+    let graph = Graph::<(), (), Undirected>::from_edges([
         (0, 1),
         (1, 2),
         (2, 3),


### PR DESCRIPTION
configures the clippy CI job to run on all targets and addresses all existing `clippy::all` errors and warnings