### PR TITLE
Bump version strings post release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,7 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustworkx"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ahash",
  "fixedbitset",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "rustworkx-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ahash",
  "fixedbitset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.64"
 authors = ["Matthew Treinish <mtreinish@kortar.org>"]
@@ -57,7 +57,7 @@ rand_pcg.workspace = true
 rayon.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rustworkx-core = { path = "rustworkx-core", version = "=0.14.0" }
+rustworkx-core = { path = "rustworkx-core", version = "=0.15.0" }
 
 [dependencies.pyo3]
 version = "0.20.2"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,9 +24,9 @@ copyright = '2021, rustworkx Contributors'
 docs_url_prefix = ""
 
 # The short X.Y version.
-version = '0.14.0'
+version = '0.15'
 # The full version, including alpha/beta/rc tags.
-release = '0.14.0'
+release = '0.15.0'
 
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.autosummary',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ mpl_extras = ["matplotlib>=3.0"]
 graphviz_extras = ["pillow>=5.4"]
 
 PKG_NAME = os.getenv("RUSTWORKX_PKG_NAME", "rustworkx")
-PKG_VERSION = "0.14.0"
+PKG_VERSION = "0.15.0"
 PKG_PACKAGES = ["rustworkx", "rustworkx.visualization"]
 PKG_INSTALL_REQUIRES = ["numpy>=1.16.0,<2"]
 RUST_EXTENSIONS = [RustExtension("rustworkx.rustworkx", "Cargo.toml",


### PR DESCRIPTION
Now that rustworkx 0.14.0 has been released this commit bumps all the version strings for the rustworkx and rustworkx-core to be 0.15.0. This now indicates the development version on the main branch is 0.15.0 and differentiates it from the released 0.14.0.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
