### PR TITLE
Improve ergonomics of `tox` lint jobs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ target-version = ['py38', 'py39', 'py310', 'py311']
 [tool.ruff]
 line-length = 105 # more lenient than black due to long function signatures
 src = ["rustworkx", "setup.py", "retworkx", "tests"]
-select = [
+lint.select = [
     "E",   # pycodestyle
     "F",   # pyflakes
     "UP",  # pyupgrade
@@ -19,7 +19,7 @@ select = [
 target-version = "py38"
 extend-exclude = ["doc"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "rustworkx/__init__.py" = ["F405", "F403"]
 "*.pyi" = ["F403", "F405", "PYI001", "PYI002"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,11 +31,11 @@ commands =
 
 [testenv:lint]
 basepython = python3
+skip_install = true
 deps =
   black~=22.0
   ruff
-  setuptools-rust
-whitelist_externals=cargo
+allowlist_externals=cargo
 commands =
   black --check --diff {posargs} '../rustworkx' '../tests' '../retworkx'
   ruff check ../rustworkx ../retworkx . ../setup.py
@@ -68,6 +68,7 @@ commands = rm -rf {toxinidir}/docs/build {toxinidir}/docs/source/apiref
 
 [testenv:black]
 basepython = python3
+skip_install = true
 deps =
   black~=22.0
 commands = black {posargs} '../rustworkx' '../tests' '../retworkx'


### PR DESCRIPTION
This fixes the `lint` job for `tox>=4`, which uses `whitelist_externals` is removed in favour of `allowlist_externals`.  This also makes the `lint` and `black` runs skip installation of the package, which makes them much faster to use while making changes, and these are static analysis tools, so don't need to install.
