### PR TITLE
Improve performance of custom-iterator `__getitem__`

### DIFF
--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -411,8 +411,8 @@ trait PyGCProtocol {
 
 #[derive(FromPyObject)]
 enum SliceOrInt<'a> {
-    Slice(&'a PySlice),
     Int(isize),
+    Slice(&'a PySlice),
 }
 
 trait PyConvertToPyArray {


### PR DESCRIPTION
Flipping the order of `Slice` and `Int` in `SliceOrInt` so that `Int` comes first means that the `FromPyObject` derivation will then try `Int` first, which is the correct variant in like 99.9% of uses of the struct. This has the impact of improving int `__getitem__` times in the custom iterators by about 3x (from 205ns to 61ns on my machine), which has knock-on effects for the implicit iterators Python defines for these classes.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

This implements the performance improvement I mentioned in https://github.com/Qiskit/rustworkx/issues/1090#issuecomment-1954836685.  I can also look into defining manual Python-space iterators (rather than using the implicit one based on `__getitem__`), if that's an interesting path - I haven't tried it yet, so I don't know if there's more performance to be had.