### PR TITLE
Fix backport branch post 0.14.0 release

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -33,4 +33,4 @@ pull_request_rules:
     actions:
       backport:
         branches:
-          - stable/0.13
+          - stable/0.14


### PR DESCRIPTION
In #1070 we updated the version numbers of rustworkx to indicate the main branch is developing the next release. However, in that PR we neglected to update the mergify backport branch. This means when we tag a PR to main as stable backport potential mergify will incorrectly backport the PR to stable/0.13 instead of stable/0.14. This commit corrects this oversight and updates the mergify config to backport to the correct branch.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
