### PR TITLE
Add missing musl skip for ppc64le builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -258,7 +258,7 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_SKIP: cp36-* cp37-* cp39-* cp310-* cp311-* pp* *win32
+          CIBW_SKIP: cp36-* cp37-* cp39-* cp310-* cp311-* pp* *win32 *musl*
           CIBW_ARCHS_LINUX: ppc64le
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This commit fixes an issue in the ppc64le wheel builds. One of the two ppc64le wheel build jobs was incorrectly attempting to build wheels for musl environments which isn't a supported platform and the jobs failed to configure. This commit just adds the missing skip for those environments to the job configuration to fix this issue.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
