### PR TITLE
Prepare 0.14.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,7 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustworkx"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "ahash",
  "fixedbitset",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "rustworkx-core"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "ahash",
  "fixedbitset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 rust-version = "1.64"
 authors = ["Matthew Treinish <mtreinish@kortar.org>"]
@@ -57,7 +57,7 @@ rand_pcg.workspace = true
 rayon.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rustworkx-core = { path = "rustworkx-core", version = "=0.14.0" }
+rustworkx-core = { path = "rustworkx-core", version = "=0.14.1" }
 
 [dependencies.pyo3]
 version = "0.20.2"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,9 +24,9 @@ copyright = '2021, rustworkx Contributors'
 docs_url_prefix = ""
 
 # The short X.Y version.
-version = '0.14.0'
+version = '0.14'
 # The full version, including alpha/beta/rc tags.
-release = '0.14.0'
+release = '0.14.1'
 
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.autosummary',

--- a/releasenotes/notes/prepare-0.14.1-e5065553a44eb035.yaml
+++ b/releasenotes/notes/prepare-0.14.1-e5065553a44eb035.yaml
@@ -1,7 +1,7 @@
 ---
 prelude: >
   The rustworkx 0.14.1 release is a small bug fix release that fixes two issues,
-  first it address a performance regression that was introduced in 0.12.0
+  firstly it address a performance regression that was introduced in 0.12.0
   for accessing items of custom sequence return types such as
   :class:`.NodeIndices`. Secondly, it fixes a build configuration issue for
   Linux ppc64le with Python 3.12 and 3.8 which prevented publishing wheels in

--- a/releasenotes/notes/prepare-0.14.1-e5065553a44eb035.yaml
+++ b/releasenotes/notes/prepare-0.14.1-e5065553a44eb035.yaml
@@ -1,0 +1,28 @@
+---
+prelude: >
+  The rustworkx 0.14.1 release is a small bug fix release that fixes two issues,
+  first it address a performance regression that was introduced in 0.12.0
+  for accessing items of custom sequence return types such as
+  :class:`.NodeIndices`. Secondly, it fixes a build configuration issue for
+  Linux ppc64le with Python 3.12 and 3.8 which prevented publishing wheels in
+  0.14.0.
+
+fixes:
+  - |
+    Fixed an performance issue with the custom sequence return type classes'
+    ``__getitem__`` method (used for element access and iteration). When support
+    for slice access was added to these classes in rustworkx 0.12.0 this was
+    previously implemented in a way that added unnecessary overhead to index
+    based access, which has been corrected. This fix applies to ``__getitem__``
+    on:
+
+      * :class:`.BFSSuccessors`
+      * :class:`.BFSPredecessors`
+      * :class:`.NodeIndices`
+      * :class:`.EdgeIndices`
+      * :class:`.EdgeList`
+      * :class:`.WeightedEdgeList`
+      * :class:`.Chains`
+
+    See `#1090 <https://github.com/Qiskit/rustworkx/issues/1090>`__ for more
+    details.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ mpl_extras = ["matplotlib>=3.0"]
 graphviz_extras = ["pillow>=5.4"]
 
 PKG_NAME = os.getenv("RUSTWORKX_PKG_NAME", "rustworkx")
-PKG_VERSION = "0.14.0"
+PKG_VERSION = "0.14.1"
 PKG_PACKAGES = ["rustworkx", "rustworkx.visualization"]
 PKG_INSTALL_REQUIRES = ["numpy>=1.16.0,<2"]
 RUST_EXTENSIONS = [RustExtension("rustworkx.rustworkx", "Cargo.toml",


### PR DESCRIPTION
This commit prepares for a 0.14.1 release which just includes #1109 to fix ppc64le builds and #1096 to fix the overhead of `__getitem__` on custom sequence return types.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
