### PR TITLE
Update Coveralls Github Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,7 +119,7 @@ jobs:
         run: tox -estubs
   coverage:
     if: github.repository_owner == 'Qiskit'
-    needs: [build_lint]
+    needs: [tests]
     name: Coverage
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,10 +156,10 @@ jobs:
           name: coverage
           path: coveralls.info
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: coveralls.info
+          file: coveralls.info
   docs:
     if: github.repository_owner == 'Qiskit'
     needs: [tests]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,7 +119,7 @@ jobs:
         run: tox -estubs
   coverage:
     if: github.repository_owner == 'Qiskit'
-    needs: [tests]
+    needs: [build_lint]
     name: Coverage
     runs-on: ubuntu-latest
     steps:
@@ -159,7 +159,8 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: coveralls.info
+          format: lcov
+          file: ./coveralls.info
   docs:
     if: github.repository_owner == 'Qiskit'
     needs: [tests]


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

This updates the Coveralls Github Action to use v2. This automatic update slipped through the cracks because we use the released version in the `master` branch while development has moved to the `main` branch.

This will also fix the warnings about using Node.js version 16 which will be removed by Github sometime