### PR TITLE
Upgrade PyO3 and rust-numpy to 0.21.0 and Bound API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef41cbb417ea83b30525259e30ccef6af39b31c240bda578889494c5392d331"
+checksum = "ec170733ca37175f5d75a5bea5911d6ff45d2cd52849ce98b685394e4f2f37f4"
 dependencies = [
  "libc",
  "ndarray",
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "a02a88a17e74cadbc8ce77855e1d6c8ad0ab82901a4a9b5046bd01c1c0bd95cd"
 dependencies = [
  "cfg-if",
  "hashbrown 0.14.3",
@@ -447,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "a5eb0b6ecba38961f6f4bd6cd5906dfab3cd426ff37b2eed5771006aa31656f1"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "ba8a6e48a29b5d22e4fdaf132d8ba8d3203ee9f06362d48f244346902a594ec3"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "4e80493c5965f94a747d0782a607b2328a4eea5391327b152b00e2f3b001cede"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -479,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "fcd7d86f42004025200e12a6a8119bd878329e6fddef8178eaafa4e4b5906c5b"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ fixedbitset = "0.4.2"
 hashbrown = { version = ">=0.13, <0.15", features = ["rayon"] }
 indexmap = { version = ">=1.9, <3", features = ["rayon"] }
 num-traits = "0.2"
-numpy = "0.20.0"
+numpy = "0.21.0"
 petgraph = "0.6.4"
 rand = "0.8"
 rand_pcg = "0.3"
@@ -60,7 +60,7 @@ serde_json = "1.0"
 rustworkx-core = { path = "rustworkx-core", version = "=0.15.0" }
 
 [dependencies.pyo3]
-version = "0.20.3"
+version = "0.21.0"
 features = ["extension-module", "hashbrown", "num-bigint", "num-complex", "indexmap"]
 
 [dependencies.ndarray]

--- a/src/coloring.rs
+++ b/src/coloring.rs
@@ -80,7 +80,7 @@ pub fn graph_greedy_color(
         }
         None => greedy_node_color(&graph.graph),
     };
-    let out_dict = PyDict::new(py);
+    let out_dict = PyDict::new_bound(py);
     for (node, color) in colors {
         out_dict.set_item(node.index(), color)?;
     }
@@ -108,7 +108,7 @@ pub fn graph_greedy_color(
 #[pyo3(text_signature = "(graph, /)")]
 pub fn graph_greedy_edge_color(py: Python, graph: &graph::PyGraph) -> PyResult<PyObject> {
     let colors = greedy_edge_color(&graph.graph);
-    let out_dict = PyDict::new(py);
+    let out_dict = PyDict::new_bound(py);
     for (node, color) in colors {
         out_dict.set_item(node.index(), color)?;
     }
@@ -142,7 +142,7 @@ pub fn graph_greedy_edge_color(py: Python, graph: &graph::PyGraph) -> PyResult<P
 #[pyo3(text_signature = "(graph, /)")]
 pub fn graph_misra_gries_edge_color(py: Python, graph: &graph::PyGraph) -> PyResult<PyObject> {
     let colors = misra_gries_edge_color(&graph.graph);
-    let out_dict = PyDict::new(py);
+    let out_dict = PyDict::new_bound(py);
     for (node, color) in colors {
         out_dict.set_item(node.index(), color)?;
     }
@@ -163,7 +163,7 @@ pub fn graph_misra_gries_edge_color(py: Python, graph: &graph::PyGraph) -> PyRes
 pub fn graph_two_color(py: Python, graph: &graph::PyGraph) -> PyResult<Option<PyObject>> {
     match two_color(&graph.graph) {
         Some(colors) => {
-            let out_dict = PyDict::new(py);
+            let out_dict = PyDict::new_bound(py);
             for (node, color) in colors {
                 out_dict.set_item(node.index(), color)?;
             }
@@ -187,7 +187,7 @@ pub fn graph_two_color(py: Python, graph: &graph::PyGraph) -> PyResult<Option<Py
 pub fn digraph_two_color(py: Python, graph: &digraph::PyDiGraph) -> PyResult<Option<PyObject>> {
     match two_color(&graph.graph) {
         Some(colors) => {
-            let out_dict = PyDict::new(py);
+            let out_dict = PyDict::new_bound(py);
             for (node, color) in colors {
                 out_dict.set_item(node.index(), color)?;
             }
@@ -223,7 +223,7 @@ pub fn graph_bipartite_edge_color(py: Python, graph: &graph::PyGraph) -> PyResul
         Ok(colors) => colors,
         Err(_) => return Err(GraphNotBipartite::new_err("Graph is not bipartite")),
     };
-    let out_dict = PyDict::new(py);
+    let out_dict = PyDict::new_bound(py);
     for (node, color) in colors {
         out_dict.set_item(node.index(), color)?;
     }

--- a/src/connectivity/johnson_simple_cycles.rs
+++ b/src/connectivity/johnson_simple_cycles.rs
@@ -25,7 +25,6 @@ use petgraph::visit::IntoNodeReferences;
 use petgraph::visit::NodeFiltered;
 use petgraph::Directed;
 
-use pyo3::iter::IterNextOutput;
 use pyo3::prelude::*;
 
 use crate::iterators::NodeIndices;
@@ -149,7 +148,7 @@ fn process_stack(
     block: &mut HashMap<NodeIndex, HashSet<NodeIndex>>,
     subgraph: &StableDiGraph<(), ()>,
     reverse_node_map: &HashMap<NodeIndex, NodeIndex>,
-) -> Option<IterNextOutput<NodeIndices, &'static str>> {
+) -> Option<NodeIndices> {
     while let Some((this_node, neighbors)) = stack.last_mut() {
         if let Some(next_node) = neighbors.pop() {
             if next_node == start_node {
@@ -159,7 +158,7 @@ fn process_stack(
                     out_path.push(reverse_node_map[n].index());
                     closed.insert(*n);
                 }
-                return Some(IterNextOutput::Yield(NodeIndices { nodes: out_path }));
+                return Some(NodeIndices { nodes: out_path });
             } else if blocked.insert(next_node) {
                 path.push(next_node);
                 stack.push((
@@ -195,14 +194,14 @@ impl SimpleCycleIter {
         slf.into()
     }
 
-    fn __next__(mut slf: PyRefMut<Self>) -> PyResult<IterNextOutput<NodeIndices, &'static str>> {
+    fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<NodeIndices>> {
         if slf.self_cycles.is_some() {
             let self_cycles = slf.self_cycles.as_mut().unwrap();
             let cycle_node = self_cycles.pop().unwrap();
             if self_cycles.is_empty() {
                 slf.self_cycles = None;
             }
-            return Ok(IterNextOutput::Yield(NodeIndices {
+            return Ok(Some(NodeIndices {
                 nodes: vec![cycle_node.index()],
             }));
         }
@@ -237,7 +236,7 @@ impl SimpleCycleIter {
             slf.subgraph = subgraph;
             slf.reverse_node_map = reverse_node_map;
             slf.node_map = node_map;
-            return Ok(res);
+            return Ok(Some(res));
         } else {
             subgraph.remove_node(slf.start_node);
             slf.scc
@@ -290,7 +289,7 @@ impl SimpleCycleIter {
                 slf.subgraph = subgraph;
                 slf.reverse_node_map = reverse_node_map;
                 slf.node_map = node_map;
-                return Ok(res);
+                return Ok(Some(res));
             }
             subgraph.remove_node(slf.start_node);
             slf.scc
@@ -306,6 +305,6 @@ impl SimpleCycleIter {
                     }
                 }));
         }
-        Ok(IterNextOutput::Return("Ended"))
+        Ok(None)
     }
 }

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -349,7 +349,7 @@ pub fn digraph_adjacency_matrix(
             }
         }
     }
-    Ok(matrix.into_pyarray(py).into())
+    Ok(matrix.into_pyarray_bound(py).into())
 }
 
 /// Return the adjacency matrix for a PyGraph class
@@ -442,7 +442,7 @@ pub fn graph_adjacency_matrix(
             }
         }
     }
-    Ok(matrix.into_pyarray(py).into())
+    Ok(matrix.into_pyarray_bound(py).into())
 }
 
 /// Compute the complement of an undirected graph.
@@ -839,7 +839,7 @@ pub fn graph_longest_simple_path(graph: &graph::PyGraph) -> Option<NodeIndices> 
 #[pyo3(text_signature = "(graph, /)")]
 pub fn graph_core_number(py: Python, graph: &graph::PyGraph) -> PyResult<PyObject> {
     let cores = connectivity::core_number(&graph.graph);
-    let out_dict = PyDict::new(py);
+    let out_dict = PyDict::new_bound(py);
     for (k, v) in cores {
         out_dict.set_item(k.index(), v)?;
     }
@@ -865,7 +865,7 @@ pub fn graph_core_number(py: Python, graph: &graph::PyGraph) -> PyResult<PyObjec
 #[pyo3(text_signature = "(graph, /)")]
 pub fn digraph_core_number(py: Python, graph: &digraph::PyDiGraph) -> PyResult<PyObject> {
     let cores = connectivity::core_number(&graph.graph);
-    let out_dict = PyDict::new(py);
+    let out_dict = PyDict::new_bound(py);
     for (k, v) in cores {
         out_dict.set_item(k.index(), v)?;
     }

--- a/src/dag_algo/mod.rs
+++ b/src/dag_algo/mod.rs
@@ -338,9 +338,9 @@ pub fn layers(
         next_layer = Vec::new();
     }
     if !index_output {
-        Ok(PyList::new(py, output).into())
+        Ok(PyList::new_bound(py, output).into())
     } else {
-        Ok(PyList::new(py, output_indices).into())
+        Ok(PyList::new_bound(py, output_indices).into())
     }
 }
 
@@ -445,7 +445,7 @@ pub fn lexicographical_topological_sort(
         }
         out_list.push(&dag.graph[node])
     }
-    Ok(PyList::new(py, out_list).into())
+    Ok(PyList::new_bound(py, out_list).into())
 }
 
 /// Return the topological generations of a DAG

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -1619,7 +1619,7 @@ pub fn directed_complete_graph(
 }
 
 #[pymodule]
-pub fn generators(_py: Python, m: &PyModule) -> PyResult<()> {
+pub fn generators(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(cycle_graph))?;
     m.add_wrapped(wrap_pyfunction!(directed_cycle_graph))?;
     m.add_wrapped(wrap_pyfunction!(path_graph))?;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -216,9 +216,9 @@ impl PyGraph {
             edges.push(edge);
         }
 
-        let out_dict = PyDict::new(py);
-        let nodes_lst: PyObject = PyList::new(py, nodes).into();
-        let edges_lst: PyObject = PyList::new(py, edges).into();
+        let out_dict = PyDict::new_bound(py);
+        let nodes_lst: PyObject = PyList::new_bound(py, nodes).into();
+        let edges_lst: PyObject = PyList::new_bound(py, edges).into();
         out_dict.set_item("nodes", nodes_lst)?;
         out_dict.set_item("edges", edges_lst)?;
         out_dict.set_item("nodes_removed", self.node_removed)?;
@@ -228,15 +228,11 @@ impl PyGraph {
     }
 
     fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
-        let dict_state = state.downcast::<PyDict>(py)?;
-        let nodes_lst = dict_state
-            .get_item("nodes")?
-            .unwrap()
-            .downcast::<PyList>()?;
-        let edges_lst = dict_state
-            .get_item("edges")?
-            .unwrap()
-            .downcast::<PyList>()?;
+        let dict_state = state.downcast_bound::<PyDict>(py)?;
+        let binding = dict_state.get_item("nodes")?.unwrap();
+        let nodes_lst = binding.downcast::<PyList>()?;
+        let binding = dict_state.get_item("edges")?.unwrap();
+        let edges_lst = binding.downcast::<PyList>()?;
 
         self.graph = StablePyGraph::<Undirected>::default();
         self.multigraph = dict_state
@@ -271,11 +267,8 @@ impl PyGraph {
             }
         } else if nodes_lst.len() == 1 {
             // graph has only one node, handle logic here to save one if in the loop later
-            let item = nodes_lst
-                .get_item(0)
-                .unwrap()
-                .downcast::<PyTuple>()
-                .unwrap();
+            let binding = nodes_lst.get_item(0).unwrap();
+            let item = binding.downcast::<PyTuple>().unwrap();
             let node_idx: usize = item.get_item(0).unwrap().extract().unwrap();
             let node_w = item.get_item(1).unwrap().extract().unwrap();
 
@@ -287,11 +280,8 @@ impl PyGraph {
                 self.graph.remove_node(NodeIndex::new(i));
             }
         } else {
-            let last_item = nodes_lst
-                .get_item(nodes_lst.len() - 1)
-                .unwrap()
-                .downcast::<PyTuple>()
-                .unwrap();
+            let binding = nodes_lst.get_item(nodes_lst.len() - 1).unwrap();
+            let last_item = binding.downcast::<PyTuple>().unwrap();
 
             // list of temporary nodes that will be removed later to re-create holes
             let node_bound_1: usize = last_item.get_item(0).unwrap().extract().unwrap();
@@ -1259,7 +1249,7 @@ impl PyGraph {
                 let mut file = Vec::<u8>::new();
                 build_dot(py, &self.graph, &mut file, graph_attr, node_attr, edge_attr)?;
                 Ok(Some(
-                    PyString::new(py, str::from_utf8(&file)?).to_object(py),
+                    PyString::new_bound(py, str::from_utf8(&file)?).to_object(py),
                 ))
             }
         }
@@ -1372,7 +1362,7 @@ impl PyGraph {
                     Some(del) => pieces[2..].join(del),
                     None => pieces[2..].join(&' '.to_string()),
                 };
-                PyString::new(py, &weight_str).into()
+                PyString::new_bound(py, &weight_str).into()
             } else {
                 py.None()
             };
@@ -1626,7 +1616,7 @@ impl PyGraph {
                 weight.clone_ref(py),
             );
         }
-        let out_dict = PyDict::new(py);
+        let out_dict = PyDict::new_bound(py);
         for (orig_node, new_node) in new_node_map.iter() {
             out_dict.set_item(orig_node.index(), new_node.index())?;
         }

--- a/src/isomorphism/vf2.rs
+++ b/src/isomorphism/vf2.rs
@@ -22,7 +22,6 @@ use std::marker;
 use hashbrown::HashMap;
 use rustworkx_core::dictmap::*;
 
-use pyo3::class::iter::IterNextOutput;
 use pyo3::gc::PyVisit;
 use pyo3::prelude::*;
 use pyo3::PyTraverseError;
@@ -413,7 +412,7 @@ impl SemanticMatcher<PyObject> for Option<PyObject> {
     #[inline]
     fn eq(&self, py: Python, a: &PyObject, b: &PyObject) -> PyResult<bool> {
         let res = self.as_ref().unwrap().call1(py, (a, b))?;
-        res.is_true(py)
+        res.is_truthy(py)
     }
 }
 
@@ -1007,12 +1006,10 @@ macro_rules! vf2_mapping_impl {
                 slf.into()
             }
 
-            fn __next__(
-                mut slf: PyRefMut<Self>,
-            ) -> PyResult<IterNextOutput<NodeMap, &'static str>> {
+            fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<NodeMap>> {
                 Python::with_gil(|py| match slf.vf2.next(py)? {
-                    Some(mapping) => Ok(IterNextOutput::Yield(mapping)),
-                    None => Ok(IterNextOutput::Return("Ended")),
+                    Some(mapping) => Ok(Some(mapping)),
+                    None => Ok(None),
                 })
             }
 

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -47,7 +47,6 @@ use rustworkx_core::dictmap::*;
 
 use ndarray::prelude::*;
 use numpy::{IntoPyArray, PyArrayDescr};
-use pyo3::class::iter::IterNextOutput;
 use pyo3::exceptions::{PyIndexError, PyKeyError, PyNotImplementedError};
 use pyo3::gc::PyVisit;
 use pyo3::prelude::*;
@@ -67,7 +66,7 @@ trait PyHash {
 impl PyHash for PyObject {
     #[inline]
     fn hash<H: Hasher>(&self, py: Python, state: &mut H) -> PyResult<()> {
-        state.write_isize(self.as_ref(py).hash()?);
+        state.write_isize(self.bind(py).hash()?);
         Ok(())
     }
 }
@@ -186,7 +185,7 @@ trait PyEq<Rhs: ?Sized = Self> {
 impl PyEq for PyObject {
     #[inline]
     fn eq(&self, other: &Self, py: Python) -> PyResult<bool> {
-        Ok(self.as_ref(py).compare(other)? == std::cmp::Ordering::Equal)
+        Ok(self.bind(py).compare(other)? == std::cmp::Ordering::Equal)
     }
 }
 
@@ -283,31 +282,31 @@ where
     }
 }
 
-impl<T> PyEq<PyAny> for T
+impl<'py, T> PyEq<Bound<'py, PyAny>> for T
 where
     for<'p> T: PyEq<T> + Clone + FromPyObject<'p>,
 {
     #[inline]
-    fn eq(&self, other: &PyAny, py: Python) -> PyResult<bool> {
+    fn eq(&self, other: &Bound<PyAny>, py: Python) -> PyResult<bool> {
         let other_value: T = other.extract()?;
         PyEq::eq(self, &other_value, py)
     }
 }
 
-impl<K, V> PyEq<PyAny> for DictMap<K, V>
+impl<'py, K, V> PyEq<Bound<'py, PyAny>> for DictMap<K, V>
 where
     for<'p> K: PyEq<K> + Clone + pyo3::ToPyObject,
-    for<'p> V: PyEq<PyAny>,
+    for<'p> V: PyEq<Bound<'py, PyAny>>,
 {
     #[inline]
-    fn eq(&self, other: &PyAny, py: Python) -> PyResult<bool> {
+    fn eq(&self, other: &Bound<'py, PyAny>, py: Python) -> PyResult<bool> {
         if other.len()? != self.len() {
             return Ok(false);
         }
         for (key, value) in self {
             match other.get_item(key) {
                 Ok(other_raw) => {
-                    if !PyEq::eq(value, other_raw, py)? {
+                    if !PyEq::eq(value, &other_raw, py)? {
                         return Ok(false);
                     }
                 }
@@ -327,7 +326,7 @@ trait PyDisplay {
 
 impl PyDisplay for PyObject {
     fn str(&self, py: Python) -> PyResult<String> {
-        Ok(format!("{}", self.as_ref(py).str()?))
+        Ok(format!("{}", self.bind(py).str()?))
     }
 }
 
@@ -424,7 +423,7 @@ macro_rules! py_convert_to_py_array_impl {
     ($($t:ty)*) => ($(
         impl PyConvertToPyArray for Vec<$t> {
             fn convert_to_pyarray(&self, py: Python) -> PyResult<PyObject> {
-                Ok(self.clone().into_pyarray(py).into())
+                Ok(self.clone().into_pyarray_bound(py).into())
             }
         }
     )*)
@@ -435,7 +434,7 @@ macro_rules! py_convert_to_py_array_obj_impl {
         impl PyConvertToPyArray for Vec<$t> {
             fn convert_to_pyarray(&self, py: Python) -> PyResult<PyObject> {
                 let pyobj_vec: Vec<PyObject> = self.iter().map(|x| x.clone().into_py(py)).collect();
-                Ok(pyobj_vec.into_pyarray(py).into())
+                Ok(pyobj_vec.into_pyarray_bound(py).into())
             }
         }
     };
@@ -455,7 +454,7 @@ impl PyConvertToPyArray for Vec<(usize, usize)> {
             mat[[index, 1]] = element.1;
         }
 
-        Ok(mat.into_pyarray(py).into())
+        Ok(mat.into_pyarray_bound(py).into())
     }
 }
 
@@ -469,7 +468,7 @@ impl PyConvertToPyArray for Vec<(usize, usize, PyObject)> {
             mat[[index, 2]] = element.2.clone();
         }
 
-        Ok(mat.into_pyarray(py).into())
+        Ok(mat.into_pyarray_bound(py).into())
     }
 }
 
@@ -497,8 +496,12 @@ macro_rules! custom_vec_iter_impl {
                 self.$data = state;
             }
 
-            fn __richcmp__(&self, other: &PyAny, op: pyo3::basic::CompareOp) -> PyResult<bool> {
-                let compare = |other: &PyAny| -> PyResult<bool> {
+            fn __richcmp__(
+                &self,
+                other: &Bound<PyAny>,
+                op: pyo3::basic::CompareOp,
+            ) -> PyResult<bool> {
+                let compare = |other: &Bound<PyAny>| -> PyResult<bool> {
                     Python::with_gil(|py| {
                         if other.len()? as usize != self.$data.len() {
                             return Ok(false);
@@ -506,7 +509,7 @@ macro_rules! custom_vec_iter_impl {
 
                         for (i, item) in self.$data.iter().enumerate() {
                             let other_raw = other.get_item(i)?;
-                            if !PyEq::eq(item, other_raw, py)? {
+                            if !PyEq::eq(item, &other_raw, py)? {
                                 return Ok(false);
                             }
                         }
@@ -595,7 +598,11 @@ macro_rules! custom_vec_iter_impl {
                 }
             }
 
-            fn __array__(&self, py: Python, _dt: Option<&PyArrayDescr>) -> PyResult<PyObject> {
+            fn __array__(
+                &self,
+                py: Python,
+                _dt: Option<&Bound<PyArrayDescr>>,
+            ) -> PyResult<PyObject> {
                 // Note: we accept the dtype argument on the signature but
                 // effictively do nothing with it to let Numpy handle the conversion itself
                 self.$data.convert_to_pyarray(py)
@@ -988,9 +995,9 @@ impl PyHash for EdgeList {
     }
 }
 
-impl PyEq<PyAny> for EdgeList {
+impl<'py> PyEq<Bound<'py, PyAny>> for EdgeList {
     #[inline]
-    fn eq(&self, other: &PyAny, py: Python) -> PyResult<bool> {
+    fn eq(&self, other: &Bound<PyAny>, py: Python) -> PyResult<bool> {
         PyEq::eq(&self.edges, other, py)
     }
 }
@@ -1048,13 +1055,13 @@ macro_rules! py_iter_protocol_impl {
             fn __iter__(slf: PyRef<Self>) -> Py<$name> {
                 slf.into()
             }
-            fn __next__(mut slf: PyRefMut<Self>) -> IterNextOutput<$T, &'static str> {
+            fn __next__(mut slf: PyRefMut<Self>) -> Option<$T> {
                 if slf.iter_pos < slf.$data.len() {
-                    let res = IterNextOutput::Yield(slf.$data[slf.iter_pos].clone());
+                    let res = Some(slf.$data[slf.iter_pos].clone());
                     slf.iter_pos += 1;
                     res
                 } else {
-                    IterNextOutput::Return("Ended")
+                    None
                 }
             }
         }
@@ -1114,8 +1121,12 @@ macro_rules! custom_hash_map_iter_impl {
                 }
             }
 
-            fn __richcmp__(&self, other: &PyAny, op: pyo3::basic::CompareOp) -> PyResult<bool> {
-                let compare = |other: &PyAny| -> PyResult<bool> {
+            fn __richcmp__(
+                &self,
+                other: &Bound<PyAny>,
+                op: pyo3::basic::CompareOp,
+            ) -> PyResult<bool> {
+                let compare = |other: &Bound<PyAny>| -> PyResult<bool> {
                     Python::with_gil(|py| PyEq::eq(&self.$data, other, py))
                 };
                 match op {
@@ -1319,8 +1330,8 @@ impl PathMapping {
         }
     }
 
-    fn __richcmp__(&self, other: &PyAny, op: pyo3::basic::CompareOp) -> PyResult<bool> {
-        let compare = |other: &PyAny| -> PyResult<bool> {
+    fn __richcmp__(&self, other: &Bound<PyAny>, op: pyo3::basic::CompareOp) -> PyResult<bool> {
+        let compare = |other: &Bound<PyAny>| -> PyResult<bool> {
             Python::with_gil(|py| PyEq::eq(&self.paths, other, py))
         };
         match op {
@@ -1386,9 +1397,9 @@ impl PyHash for PathMapping {
     }
 }
 
-impl PyEq<PyAny> for PathMapping {
+impl<'py> PyEq<Bound<'py, PyAny>> for PathMapping {
     #[inline]
-    fn eq(&self, other: &PyAny, py: Python) -> PyResult<bool> {
+    fn eq(&self, other: &Bound<PyAny>, py: Python) -> PyResult<bool> {
         PyEq::eq(&self.paths, other, py)
     }
 }
@@ -1477,8 +1488,8 @@ impl MultiplePathMapping {
         }
     }
 
-    fn __richcmp__(&self, other: &PyAny, op: pyo3::basic::CompareOp) -> PyResult<bool> {
-        let compare = |other: &PyAny| -> PyResult<bool> {
+    fn __richcmp__(&self, other: &Bound<PyAny>, op: pyo3::basic::CompareOp) -> PyResult<bool> {
+        let compare = |other: &Bound<PyAny>| -> PyResult<bool> {
             Python::with_gil(|py| PyEq::eq(&self.paths, other, py))
         };
         match op {
@@ -1550,9 +1561,9 @@ impl PyHash for MultiplePathMapping {
     }
 }
 
-impl PyEq<PyAny> for MultiplePathMapping {
+impl<'py> PyEq<Bound<'py, PyAny>> for MultiplePathMapping {
     #[inline]
-    fn eq(&self, other: &PyAny, py: Python) -> PyResult<bool> {
+    fn eq(&self, other: &Bound<PyAny>, py: Python) -> PyResult<bool> {
         PyEq::eq(&self.paths, other, py)
     }
 }
@@ -1614,9 +1625,9 @@ impl PyHash for PathLengthMapping {
     }
 }
 
-impl PyEq<PyAny> for PathLengthMapping {
+impl<'py> PyEq<Bound<'py, PyAny>> for PathLengthMapping {
     #[inline]
-    fn eq(&self, other: &PyAny, py: Python) -> PyResult<bool> {
+    fn eq(&self, other: &Bound<PyAny>, py: Python) -> PyResult<bool> {
         PyEq::eq(&self.path_lengths, other, py)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,7 @@ where
 {
     match weight_fn {
         Some(weight_fn) => {
-            let res = weight_fn.as_ref(py).call1((weight,))?;
+            let res = weight_fn.bind(py).call1((weight,))?;
             res.extract()
         }
         None => Ok(default),
@@ -278,9 +278,9 @@ fn find_node_by_weight<Ty: EdgeType>(
     for node in graph.node_indices() {
         let weight = graph.node_weight(node).unwrap();
         if obj
-            .as_ref(py)
+            .bind(py)
             .rich_compare(weight, pyo3::basic::CompareOp::Eq)?
-            .is_true()?
+            .is_truthy()?
         {
             index = Some(node);
             break;
@@ -338,23 +338,32 @@ create_exception!(rustworkx, FailedToConverge, PyException);
 create_exception!(rustworkx, GraphNotBipartite, PyException);
 
 #[pymodule]
-fn rustworkx(py: Python<'_>, m: &PyModule) -> PyResult<()> {
+fn rustworkx(py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
-    m.add("InvalidNode", py.get_type::<InvalidNode>())?;
-    m.add("DAGWouldCycle", py.get_type::<DAGWouldCycle>())?;
-    m.add("NoEdgeBetweenNodes", py.get_type::<NoEdgeBetweenNodes>())?;
-    m.add("DAGHasCycle", py.get_type::<DAGHasCycle>())?;
-    m.add("NoSuitableNeighbors", py.get_type::<NoSuitableNeighbors>())?;
-    m.add("NoPathFound", py.get_type::<NoPathFound>())?;
-    m.add("InvalidMapping", py.get_type::<InvalidMapping>())?;
-    m.add("NullGraph", py.get_type::<NullGraph>())?;
-    m.add("NegativeCycle", py.get_type::<NegativeCycle>())?;
+    m.add("InvalidNode", py.get_type_bound::<InvalidNode>())?;
+    m.add("DAGWouldCycle", py.get_type_bound::<DAGWouldCycle>())?;
+    m.add(
+        "NoEdgeBetweenNodes",
+        py.get_type_bound::<NoEdgeBetweenNodes>(),
+    )?;
+    m.add("DAGHasCycle", py.get_type_bound::<DAGHasCycle>())?;
+    m.add(
+        "NoSuitableNeighbors",
+        py.get_type_bound::<NoSuitableNeighbors>(),
+    )?;
+    m.add("NoPathFound", py.get_type_bound::<NoPathFound>())?;
+    m.add("InvalidMapping", py.get_type_bound::<InvalidMapping>())?;
+    m.add("NullGraph", py.get_type_bound::<NullGraph>())?;
+    m.add("NegativeCycle", py.get_type_bound::<NegativeCycle>())?;
     m.add(
         "JSONSerializationError",
-        py.get_type::<JSONSerializationError>(),
+        py.get_type_bound::<JSONSerializationError>(),
     )?;
-    m.add("FailedToConverge", py.get_type::<FailedToConverge>())?;
-    m.add("GraphNotBipartite", py.get_type::<GraphNotBipartite>())?;
+    m.add("FailedToConverge", py.get_type_bound::<FailedToConverge>())?;
+    m.add(
+        "GraphNotBipartite",
+        py.get_type_bound::<GraphNotBipartite>(),
+    )?;
     m.add_wrapped(wrap_pyfunction!(bfs_successors))?;
     m.add_wrapped(wrap_pyfunction!(bfs_predecessors))?;
     m.add_wrapped(wrap_pyfunction!(graph_bfs_search))?;

--- a/src/random_graph.rs
+++ b/src/random_graph.rs
@@ -357,7 +357,7 @@ pub fn random_geometric_graph(
     }
 
     for pval in pos.iter() {
-        let pos_dict = PyDict::new(py);
+        let pos_dict = PyDict::new_bound(py);
         pos_dict.set_item("pos", pval.to_object(py))?;
 
         inner_graph.add_node(pos_dict.into());

--- a/src/shortest_path/mod.rs
+++ b/src/shortest_path/mod.rs
@@ -1083,7 +1083,7 @@ pub fn graph_floyd_warshall_numpy(
         false,
         parallel_threshold,
     )?;
-    Ok(matrix.into_pyarray(py).into())
+    Ok(matrix.into_pyarray_bound(py).into())
 }
 
 /// Find all-pairs shortest path lengths using Floyd's algorithm
@@ -1157,8 +1157,8 @@ pub fn graph_floyd_warshall_successor_and_distance(
         parallel_threshold,
     )?;
     Ok((
-        matrix.into_pyarray(py).into(),
-        next.unwrap().into_pyarray(py).into(),
+        matrix.into_pyarray_bound(py).into(),
+        next.unwrap().into_pyarray_bound(py).into(),
     ))
 }
 
@@ -1219,7 +1219,7 @@ pub fn digraph_floyd_warshall_numpy(
         false,
         parallel_threshold,
     )?;
-    Ok(matrix.into_pyarray(py).into())
+    Ok(matrix.into_pyarray_bound(py).into())
 }
 
 /// Find all-pairs shortest path lengths using Floyd's algorithm
@@ -1296,8 +1296,8 @@ pub fn digraph_floyd_warshall_successor_and_distance(
         parallel_threshold,
     )?;
     Ok((
-        matrix.into_pyarray(py).into(),
-        next.unwrap().into_pyarray(py).into(),
+        matrix.into_pyarray_bound(py).into(),
+        next.unwrap().into_pyarray_bound(py).into(),
     ))
 }
 
@@ -1383,7 +1383,7 @@ pub fn digraph_distance_matrix(
         as_undirected,
         null_value,
     );
-    matrix.into_pyarray(py).into()
+    matrix.into_pyarray_bound(py).into()
 }
 
 /// Get the distance matrix for an undirected graph
@@ -1424,7 +1424,7 @@ pub fn graph_distance_matrix(
         true,
         null_value,
     );
-    matrix.into_pyarray(py).into()
+    matrix.into_pyarray_bound(py).into()
 }
 
 /// Return the average shortest path length for a :class:`~rustworkx.PyDiGraph`

--- a/src/union.rs
+++ b/src/union.rs
@@ -58,9 +58,9 @@ fn union<Ty: EdgeType>(
     }
 
     let weights_equal = |a: &PyObject, b: &PyObject| -> PyResult<bool> {
-        a.as_ref(py)
+        a.bind(py)
             .rich_compare(b, pyo3::basic::CompareOp::Eq)?
-            .is_true()
+            .is_truthy()
     };
 
     for edge in second.edge_references() {


### PR DESCRIPTION
This commit updates rustworkx to the latest release 0.21.0 and updates the API usage for the new Bound api. [1] Luckily in rustworkx the usage of py references was minimal so the migration effort wasn't too complex, it's mostly the iterators.rs module's custom traits that needed to updated to handle the new API.

Fixes #1150

[1] https://pyo3.rs/v0.21.0/migration#from-020-to-021

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
