### PR TITLE
Decrease graphviz visualization test size to speed up tests

### DIFF
--- a/tests/visualization/test_graphviz.py
+++ b/tests/visualization/test_graphviz.py
@@ -118,7 +118,7 @@ class TestGraphvizDraw(unittest.TestCase):
         _save_image(image, "test_graphviz_draw_graph_attr.png")
 
     def test_image_type(self):
-        graph = rustworkx.directed_gnp_random_graph(50, 0.8)
+        graph = rustworkx.directed_gnp_random_graph(10, 0.8)
         image = graphviz_draw(graph, image_type="jpg")
         self.assertIsInstance(image, PIL.Image.Image)
         _save_image(image, "test_graphviz_draw_image_type.jpg")
@@ -129,7 +129,7 @@ class TestGraphvizDraw(unittest.TestCase):
             graphviz_draw(graph, image_type="raw")
 
     def test_method(self):
-        graph = rustworkx.directed_gnp_random_graph(50, 0.8)
+        graph = rustworkx.directed_gnp_random_graph(10, 0.8)
         image = graphviz_draw(graph, method="sfdp")
         self.assertIsInstance(image, PIL.Image.Image)
         _save_image(image, "test_graphviz_method.png")


### PR DESCRIPTION
With recent graphviz releases the graphviz_draw() visualization tests for 50 node random graphs were taking an inordinate amount of time. This didn't seem to be an issue in CI but on my local system with graphviz 10.0.1 the time for graphviz to generate a visualization for the 50 node random graph was orders of magnitude slower than the rest of the tests in the rustworkx python tests. This commit decreases the graph size to only be 10 nodes, which reduces the runtime of these tests to be inline with expectations.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
