### PR TITLE
Pin lxml in constraints

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,4 @@
 decorator==4.4.2
 importlib-metadata==4.13.0;python_version<'3.8'
 pillow<10.0.0
+lxml==5.1.1


### PR DESCRIPTION
The recent lxml 5.2.0 release is raising an exception about a packaging change that moved a submodule into a different location during the docs build. We don't actually directly use lxml in rustworkx (or the docs), but it gets pulled in via a dependency of jupyter-sphinx (it's deeper in the dependency tree than jupyter-sphinx's immediate dependencies). To workaround this until things are updated to take this into account this commit pins the lxml version in the constraints.txt file so we don't pull in the latest release.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
