### PR TITLE
Allow partial kwargs in mpl_draw

### DIFF
--- a/releasenotes/notes/fix-mpl-draw-kargs-typing-6cf7cfde0db072d5.yaml
+++ b/releasenotes/notes/fix-mpl-draw-kargs-typing-6cf7cfde0db072d5.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug in the type hint for the :func:`~rustworkx.visualization.mpl_draw`.
+    Previously, all `kwargs` were required when calling the method. The new annotation
+    accepts `kwargs` with partial arguments.

--- a/rustworkx/visualization/matplotlib.pyi
+++ b/rustworkx/visualization/matplotlib.pyi
@@ -20,7 +20,7 @@ if typing.TYPE_CHECKING:
 _S = typing.TypeVar("_S")
 _T = typing.TypeVar("_T")
 
-class _DrawKwargs(typing.TypedDict):
+class _DrawKwargs(typing.TypedDict, total=False):
     arrowstyle: str
     arrow_size: int
     node_list: list[int]


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Closes #1179 

We missed https://typing.readthedocs.io/en/latest/spec/typeddict.html#totality. Because `total=True` is the default, `mypy` and other type checkers expect all arguments which is not user-friendly.