### PR TITLE
Always return a cycle in `digraph_find_cycle` if no node is specified and a cycle exists

### DIFF
--- a/releasenotes/notes/fix-digraph-find-cycle-141e302ff4a8fcd4.yaml
+++ b/releasenotes/notes/fix-digraph-find-cycle-141e302ff4a8fcd4.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed the behavior of :func:`~rustworkx.digraph_find_cycle` when
+    no source node was provided. Previously, the function would start looking
+    for a cycle at an arbitrary node which was not guaranteed to return a cycle.
+    Now, the function will smartly choose a source node to start the search from
+    such that if a cycle exists, it will be found.

--- a/releasenotes/notes/fix-digraph-find-cycle-141e302ff4a8fcd4.yaml
+++ b/releasenotes/notes/fix-digraph-find-cycle-141e302ff4a8fcd4.yaml
@@ -6,3 +6,7 @@ fixes:
     for a cycle at an arbitrary node which was not guaranteed to return a cycle.
     Now, the function will smartly choose a source node to start the search from
     such that if a cycle exists, it will be found.
+other:
+  - |
+    The `rustworkx-core` function `rustworkx_core::connectivity::find_cycle` now
+    requires the `petgraph::visit::Visitable` trait.

--- a/rustworkx-core/src/connectivity/find_cycle.rs
+++ b/rustworkx-core/src/connectivity/find_cycle.rs
@@ -157,6 +157,18 @@ mod tests {
     use crate::connectivity::find_cycle;
     use petgraph::prelude::*;
 
+    // Utility to assert cycles in the response
+    macro_rules! assert_cycle {
+        ($g: expr, $cycle: expr) => {{
+            for i in 0..$cycle.len() {
+                let (s, t) = $cycle[i];
+                assert!($g.contains_edge(s, t));
+                let (next_s, _) = $cycle[(i + 1) % $cycle.len()];
+                assert_eq!(t, next_s);
+            }
+        }};
+    }
+
     #[test]
     fn test_find_cycle_source() {
         let edge_list = vec![
@@ -209,10 +221,35 @@ mod tests {
         ];
         let mut graph = DiGraph::<i32, i32>::from_edges(edge_list);
         graph.add_edge(NodeIndex::new(1), NodeIndex::new(1), 0);
-        let res: Vec<(usize, usize)> = find_cycle(&graph, Some(NodeIndex::new(0)))
-            .iter()
-            .map(|(s, t)| (s.index(), t.index()))
-            .collect();
-        assert_eq!(res, [(1, 1)]);
+        let res = find_cycle(&graph, Some(NodeIndex::new(0)));
+        assert_eq!(res[0].0, NodeIndex::new(0));
+        assert_cycle!(graph, res);
+    }
+
+    #[test]
+    fn test_self_loop_no_source() {
+        let edge_list = vec![
+            (0, 1),
+            (1, 2),
+            (2, 3),
+            (2, 2),
+        ];
+        let graph = DiGraph::<i32, i32>::from_edges(edge_list);
+        let res = find_cycle(&graph, None);
+        assert_cycle!(graph, res);
+    }
+
+    #[test]
+    fn test_cycle_no_source() {
+        let edge_list = vec![
+            (0, 1),
+            (1, 2),
+            (2, 3),
+            (3, 4),
+            (4, 2)
+        ];
+        let graph = DiGraph::<i32, i32>::from_edges(edge_list);
+        let res = find_cycle(&graph, None);
+        assert_cycle!(graph, res);
     }
 }

--- a/rustworkx-core/src/connectivity/find_cycle.rs
+++ b/rustworkx-core/src/connectivity/find_cycle.rs
@@ -14,7 +14,7 @@ use hashbrown::{HashMap, HashSet};
 use petgraph::algo;
 use petgraph::visit::{
     EdgeCount, EdgeRef, GraphBase, IntoEdgeReferences, IntoNeighborsDirected, IntoNodeIdentifiers,
-    NodeCount, Visitable,
+    NodeCount, Visitable, NodeIndexable
 };
 use petgraph::Direction::Outgoing;
 use std::hash::Hash;
@@ -64,6 +64,7 @@ where
         + IntoNodeIdentifiers
         + IntoNeighborsDirected
         + Visitable
+        + NodeIndexable
         + IntoEdgeReferences,
     G::NodeId: Eq + Hash,
 {
@@ -134,10 +135,11 @@ where
         + IntoNodeIdentifiers
         + IntoNeighborsDirected
         + Visitable
-        + IntoEdgeReferences,
+        + IntoEdgeReferences
+        + NodeIndexable,
     G::NodeId: Eq + Hash,
 {
-    for scc in algo::kosaraju_scc(&graph) {
+    for scc in algo::tarjan_scc(&graph) {
         if scc.len() > 1 {
             return Some(scc[0]);
         }

--- a/rustworkx-core/src/connectivity/find_cycle.rs
+++ b/rustworkx-core/src/connectivity/find_cycle.rs
@@ -186,20 +186,13 @@ mod tests {
             (8, 9),
         ];
         let graph = DiGraph::<i32, i32>::from_edges(edge_list);
-        let mut res: Vec<(usize, usize)> = find_cycle(&graph, Some(NodeIndex::new(0)))
-            .iter()
-            .map(|(s, t)| (s.index(), t.index()))
-            .collect();
-        assert_eq!(res, [(0, 1), (1, 2), (2, 3), (3, 0)]);
-        res = find_cycle(&graph, Some(NodeIndex::new(1)))
-            .iter()
-            .map(|(s, t)| (s.index(), t.index()))
-            .collect();
-        assert_eq!(res, [(1, 2), (2, 3), (3, 0), (0, 1)]);
-        res = find_cycle(&graph, Some(NodeIndex::new(5)))
-            .iter()
-            .map(|(s, t)| (s.index(), t.index()))
-            .collect();
+        for i in [0, 1, 2, 3].iter() {
+            let idx = NodeIndex::new(*i);
+            let res = find_cycle(&graph, Some(idx));
+            assert_cycle!(graph, res);
+            assert_eq!(res[0].0, idx);
+        }
+        let res = find_cycle(&graph, Some(NodeIndex::new(5)));
         assert_eq!(res, []);
     }
 
@@ -222,7 +215,7 @@ mod tests {
         let mut graph = DiGraph::<i32, i32>::from_edges(edge_list);
         graph.add_edge(NodeIndex::new(1), NodeIndex::new(1), 0);
         let res = find_cycle(&graph, Some(NodeIndex::new(0)));
-        assert_eq!(res[0].0, NodeIndex::new(0));
+        assert_eq!(res[0].0, NodeIndex::new(1));
         assert_cycle!(graph, res);
     }
 

--- a/rustworkx-core/src/connectivity/find_cycle.rs
+++ b/rustworkx-core/src/connectivity/find_cycle.rs
@@ -13,7 +13,8 @@
 use hashbrown::{HashMap, HashSet};
 use petgraph::algo;
 use petgraph::visit::{
-    EdgeCount, GraphBase, IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount, Visitable,
+    EdgeCount, EdgeRef, GraphBase, IntoEdgeReferences, IntoNeighborsDirected, IntoNodeIdentifiers,
+    NodeCount, Visitable,
 };
 use petgraph::Direction::Outgoing;
 use std::hash::Hash;
@@ -59,8 +60,11 @@ where
     G: GraphBase,
     G: NodeCount,
     G: EdgeCount,
-    for<'b> &'b G:
-        GraphBase<NodeId = G::NodeId> + IntoNodeIdentifiers + IntoNeighborsDirected + Visitable,
+    for<'b> &'b G: GraphBase<NodeId = G::NodeId>
+        + IntoNodeIdentifiers
+        + IntoNeighborsDirected
+        + Visitable
+        + IntoEdgeReferences,
     G::NodeId: Eq + Hash,
 {
     // Find a cycle in the given graph and return it as a list of edges
@@ -126,17 +130,21 @@ where
     G: GraphBase,
     G: NodeCount,
     G: EdgeCount,
-    for<'b> &'b G:
-        GraphBase<NodeId = G::NodeId> + IntoNodeIdentifiers + IntoNeighborsDirected + Visitable,
+    for<'b> &'b G: GraphBase<NodeId = G::NodeId>
+        + IntoNodeIdentifiers
+        + IntoNeighborsDirected
+        + Visitable
+        + IntoEdgeReferences,
     G::NodeId: Eq + Hash,
 {
     for scc in algo::kosaraju_scc(&graph) {
         if scc.len() > 1 {
-            // TODO: build
-        } else {
-            // TODO: check
-            let node = scc[0];
-            return Some(node);
+            return Some(scc[0]);
+        }
+    }
+    for edge in graph.edge_references() {
+        if edge.source() == edge.target() {
+            return Some(edge.source());
         }
     }
     None

--- a/rustworkx-core/src/connectivity/find_cycle.rs
+++ b/rustworkx-core/src/connectivity/find_cycle.rs
@@ -234,4 +234,12 @@ mod tests {
         let res = find_cycle(&graph, None);
         assert_cycle!(graph, res);
     }
+
+    #[test]
+    fn test_no_cycle_no_source() {
+        let edge_list = vec![(0, 1), (1, 2), (2, 3)];
+        let graph = DiGraph::<i32, i32>::from_edges(edge_list);
+        let res = find_cycle(&graph, None);
+        assert_eq!(res, []);
+    }
 }

--- a/rustworkx-core/src/connectivity/find_cycle.rs
+++ b/rustworkx-core/src/connectivity/find_cycle.rs
@@ -13,8 +13,7 @@
 use hashbrown::{HashMap, HashSet};
 use petgraph::algo;
 use petgraph::visit::{
-    EdgeCount, EdgeRef, GraphBase, IntoEdgeReferences, IntoNeighborsDirected, IntoNodeIdentifiers,
-    NodeCount, NodeIndexable, Visitable,
+    EdgeCount, GraphBase, IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount, Visitable,
 };
 use petgraph::Direction::Outgoing;
 use std::hash::Hash;
@@ -59,12 +58,8 @@ where
     G: GraphBase,
     G: NodeCount,
     G: EdgeCount,
-    for<'b> &'b G: GraphBase<NodeId = G::NodeId>
-        + IntoNodeIdentifiers
-        + IntoNeighborsDirected
-        + Visitable
-        + NodeIndexable
-        + IntoEdgeReferences,
+    for<'b> &'b G:
+        GraphBase<NodeId = G::NodeId> + IntoNodeIdentifiers + IntoNeighborsDirected + Visitable,
     G::NodeId: Eq + Hash,
 {
     // Find a cycle in the given graph and return it as a list of edges
@@ -130,12 +125,8 @@ where
     G: GraphBase,
     G: NodeCount,
     G: EdgeCount,
-    for<'b> &'b G: GraphBase<NodeId = G::NodeId>
-        + IntoNodeIdentifiers
-        + IntoNeighborsDirected
-        + Visitable
-        + IntoEdgeReferences
-        + NodeIndexable,
+    for<'b> &'b G:
+        GraphBase<NodeId = G::NodeId> + IntoNodeIdentifiers + IntoNeighborsDirected + Visitable,
     G::NodeId: Eq + Hash,
 {
     for scc in algo::kosaraju_scc(&graph) {
@@ -143,9 +134,11 @@ where
             return Some(scc[0]);
         }
     }
-    for edge in graph.edge_references() {
-        if edge.source() == edge.target() {
-            return Some(edge.source());
+    for node in graph.node_identifiers() {
+        for neighbor in graph.neighbors_directed(node, Outgoing) {
+            if neighbor == node {
+                return Some(node);
+            }
         }
     }
     None

--- a/rustworkx-core/src/connectivity/find_cycle.rs
+++ b/rustworkx-core/src/connectivity/find_cycle.rs
@@ -14,7 +14,7 @@ use hashbrown::{HashMap, HashSet};
 use petgraph::algo;
 use petgraph::visit::{
     EdgeCount, EdgeRef, GraphBase, IntoEdgeReferences, IntoNeighborsDirected, IntoNodeIdentifiers,
-    NodeCount, Visitable, NodeIndexable
+    NodeCount, NodeIndexable, Visitable,
 };
 use petgraph::Direction::Outgoing;
 use std::hash::Hash;
@@ -221,12 +221,7 @@ mod tests {
 
     #[test]
     fn test_self_loop_no_source() {
-        let edge_list = vec![
-            (0, 1),
-            (1, 2),
-            (2, 3),
-            (2, 2),
-        ];
+        let edge_list = vec![(0, 1), (1, 2), (2, 3), (2, 2)];
         let graph = DiGraph::<i32, i32>::from_edges(edge_list);
         let res = find_cycle(&graph, None);
         assert_cycle!(graph, res);
@@ -234,13 +229,7 @@ mod tests {
 
     #[test]
     fn test_cycle_no_source() {
-        let edge_list = vec![
-            (0, 1),
-            (1, 2),
-            (2, 3),
-            (3, 4),
-            (4, 2)
-        ];
+        let edge_list = vec![(0, 1), (1, 2), (2, 3), (3, 4), (4, 2)];
         let graph = DiGraph::<i32, i32>::from_edges(edge_list);
         let res = find_cycle(&graph, None);
         assert_cycle!(graph, res);

--- a/rustworkx-core/src/connectivity/find_cycle.rs
+++ b/rustworkx-core/src/connectivity/find_cycle.rs
@@ -56,7 +56,6 @@ use std::hash::Hash;
 /// ```
 pub fn find_cycle<G>(graph: G, source: Option<G::NodeId>) -> Vec<(G::NodeId, G::NodeId)>
 where
-    G: Copy,
     G: GraphBase,
     G: NodeCount,
     G: EdgeCount,
@@ -74,7 +73,7 @@ where
     // otherwise return that there is no cycle
     let source_index = match source {
         Some(source_value) => source_value,
-        None => match find_node_in_arbitrary_cycle(graph) {
+        None => match find_node_in_arbitrary_cycle(&graph) {
             Some(node_in_cycle) => node_in_cycle,
             None => {
                 return Vec::new();
@@ -126,7 +125,7 @@ where
     cycle
 }
 
-fn find_node_in_arbitrary_cycle<G>(graph: G) -> Option<G::NodeId>
+fn find_node_in_arbitrary_cycle<G>(graph: &G) -> Option<G::NodeId>
 where
     G: GraphBase,
     G: NodeCount,
@@ -139,7 +138,7 @@ where
         + NodeIndexable,
     G::NodeId: Eq + Hash,
 {
-    for scc in algo::tarjan_scc(&graph) {
+    for scc in algo::kosaraju_scc(&graph) {
         if scc.len() > 1 {
             return Some(scc[0]);
         }

--- a/rustworkx-core/src/connectivity/find_cycle.rs
+++ b/rustworkx-core/src/connectivity/find_cycle.rs
@@ -61,17 +61,13 @@ where
     G::NodeId: Eq + Hash,
 {
     // Find a cycle in the given graph and return it as a list of edges
-    let mut graph_nodes: HashSet<G::NodeId> = graph.node_identifiers().collect();
     let mut cycle: Vec<(G::NodeId, G::NodeId)> = Vec::with_capacity(graph.edge_count());
-    let temp_value: G::NodeId;
     // If source is not set get an arbitrary node from the set of graph
     // nodes we've not "examined"
     let source_index = match source {
         Some(source_value) => source_value,
         None => {
-            temp_value = *graph_nodes.iter().next().unwrap();
-            graph_nodes.remove(&temp_value);
-            temp_value
+            return find_arbitrary_cycle(graph);
         }
     };
     // Stack (ie "pushdown list") of vertices already in the spanning tree
@@ -117,6 +113,18 @@ where
         }
     }
     cycle
+}
+
+fn find_arbitrary_cycle<G>(_graph: G) -> Vec<(G::NodeId, G::NodeId)>
+where
+    G: GraphBase,
+    G: NodeCount,
+    G: EdgeCount,
+    for<'b> &'b G: GraphBase<NodeId = G::NodeId> + IntoNodeIdentifiers + IntoNeighborsDirected,
+    G::NodeId: Eq + Hash,
+{
+    
+    Vec::new()
 }
 
 #[cfg(test)]

--- a/tests/digraph/test_find_cycle.py
+++ b/tests/digraph/test_find_cycle.py
@@ -36,6 +36,14 @@ class TestFindCycle(unittest.TestCase):
             ]
         )
 
+    def assertCycle(self, first_node, graph, res):
+        self.assertEqual(first_node, res[0][0])
+        for i in range(len(res)):
+            s, t = res[i]
+            self.assertTrue(graph.has_edge(s, t))
+            next_s, _ = res[(i + 1) % len(res)]
+            self.assertEqual(t, next_s)
+
     def test_find_cycle(self):
         graph = rustworkx.PyDiGraph()
         graph.add_nodes_from(list(range(6)))
@@ -43,13 +51,13 @@ class TestFindCycle(unittest.TestCase):
             [(0, 1), (0, 3), (0, 5), (1, 2), (2, 3), (3, 4), (4, 5), (4, 0)]
         )
         res = rustworkx.digraph_find_cycle(graph, 0)
-        self.assertEqual([(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)], res)
+        self.assertCycle(0, graph, res)
 
     def test_find_cycle_multiple_roots_same_cycles(self):
         res = rustworkx.digraph_find_cycle(self.graph, 0)
-        self.assertEqual(res, [(0, 1), (1, 2), (2, 3), (3, 0)])
+        self.assertCycle(0, self.graph, res)
         res = rustworkx.digraph_find_cycle(self.graph, 1)
-        self.assertEqual(res, [(1, 2), (2, 3), (3, 0), (0, 1)])
+        self.assertCycle(1, self.graph, res)
         res = rustworkx.digraph_find_cycle(self.graph, 5)
         self.assertEqual(res, [])
 
@@ -57,9 +65,9 @@ class TestFindCycle(unittest.TestCase):
         self.graph.add_nodes_from(["A", "B", "C"])
         self.graph.add_edges_from_no_data([(10, 11), (12, 10), (11, 12)])
         res = rustworkx.digraph_find_cycle(self.graph, 0)
-        self.assertEqual(res, [(0, 1), (1, 2), (2, 3), (3, 0)])
+        self.assertCycle(0, self.graph, res)
         res = rustworkx.digraph_find_cycle(self.graph, 10)
-        self.assertEqual(res, [(10, 11), (11, 12), (12, 10)])
+        self.assertCycle(10, self.graph, res)
 
     def test_invalid_types(self):
         graph = rustworkx.PyGraph()
@@ -69,4 +77,4 @@ class TestFindCycle(unittest.TestCase):
     def test_self_loop(self):
         self.graph.add_edge(1, 1, None)
         res = rustworkx.digraph_find_cycle(self.graph, 0)
-        self.assertEqual([(1, 1)], res)
+        self.assertCycle(1, self.graph, res)

--- a/tests/digraph/test_find_cycle.py
+++ b/tests/digraph/test_find_cycle.py
@@ -88,13 +88,12 @@ class TestFindCycle(unittest.TestCase):
     def test_cycle_no_source(self):
         g = rustworkx.generators.directed_path_graph(1000)
         a = g.add_node(1000)
-        b = g.node_indices()[-1]
+        b = g.node_indices()[-2]
         g.add_edge(b, a, None)
         g.add_edge(a, b, None)
         res = rustworkx.digraph_find_cycle(g)
         self.assertEqual(len(res), 2)
-        self.assertTrue(a in res[0] and b in res[0])
-        self.assertTrue(a in res[1] and b in res[1])
+        self.assertTrue(res[0] == res[1][::-1])
 
     def test_cycle_self_loop(self):
         g = rustworkx.generators.directed_path_graph(1000)

--- a/tests/digraph/test_find_cycle.py
+++ b/tests/digraph/test_find_cycle.py
@@ -95,3 +95,12 @@ class TestFindCycle(unittest.TestCase):
         self.assertEqual(len(res), 2)
         self.assertTrue(a in res[0] and b in res[0])
         self.assertTrue(a in res[1] and b in res[1])
+
+    def test_cycle_self_loop(self):
+        g = rustworkx.generators.directed_path_graph(1000)
+        a = g.add_node(1000)
+        b = g.node_indices()[-1]
+        g.add_edge(b, a, None)
+        g.add_edge(a, a, None)
+        res = rustworkx.digraph_find_cycle(g)
+        self.assertEqual(res, [(a, a)])

--- a/tests/digraph/test_find_cycle.py
+++ b/tests/digraph/test_find_cycle.py
@@ -13,6 +13,7 @@
 import unittest
 
 import rustworkx
+import rustworkx.generators
 
 
 class TestFindCycle(unittest.TestCase):
@@ -78,3 +79,19 @@ class TestFindCycle(unittest.TestCase):
         self.graph.add_edge(1, 1, None)
         res = rustworkx.digraph_find_cycle(self.graph, 0)
         self.assertCycle(1, self.graph, res)
+
+    def test_no_cycle_no_source(self):
+        g = rustworkx.generators.directed_grid_graph(10, 10)
+        res = rustworkx.digraph_find_cycle(g)
+        self.assertEqual(res, [])
+
+    def test_cycle_no_source(self):
+        g = rustworkx.generators.directed_path_graph(1000)
+        a = g.add_node(1000)
+        b = g.node_indices()[-1]
+        g.add_edge(b, a, None)
+        g.add_edge(a, b, None)
+        res = rustworkx.digraph_find_cycle(g)
+        self.assertEqual(len(res), 2)
+        self.assertTrue(a in res[0] and b in res[0])
+        self.assertTrue(a in res[1] and b in res[1])


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->
Closes #1171 

Instead of picking an arbitrary node if it is not provided, we find a smarter pick that is in a strongly-connected component with more than one node. It also handles the case of self-loops in case there is a SCC with a single node.