### PR TITLE
Add lexicographical_topological_sort function to rustworkx-core

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,17 +150,17 @@ jobs:
         run: |
           set -e
           mv tests/retworkx*profraw .
-          ./grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o ./coveralls.info
+          ./grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o ./coveralls.lcov
       - uses: actions/upload-artifact@v4
         with:
           name: coverage
-          path: coveralls.info
+          path: coveralls.lcov
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           format: lcov
-          file: ./coveralls.info
+          file: ./coveralls.lcov
   docs:
     if: github.repository_owner == 'Qiskit'
     needs: [tests]

--- a/releasenotes/notes/lexicographical-topo-sort-core-e85fba409d612600.yaml
+++ b/releasenotes/notes/lexicographical-topo-sort-core-e85fba409d612600.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Added a new function ``lexicographical_topological_sort`` to the
+    ``rustworkx_core::dag_algo`` module. That is a gneric Rust implementation
+    for the core rust library that provides the
+    :func:`.lexicographical_topological_sort` function to Rust users.

--- a/rustworkx-core/src/dag_algo.rs
+++ b/rustworkx-core/src/dag_algo.rs
@@ -19,7 +19,7 @@ use hashbrown::HashMap;
 use petgraph::algo;
 use petgraph::visit::{
     EdgeRef, GraphBase, GraphProp, IntoEdgesDirected, IntoNeighborsDirected, IntoNodeIdentifiers,
-    IntoNodeReferences, NodeCount, Visitable,
+    NodeCount, Visitable,
 };
 use petgraph::Directed;
 
@@ -131,9 +131,7 @@ where
         + IntoNodeIdentifiers
         + IntoNeighborsDirected
         + IntoEdgesDirected
-        + IntoNodeReferences
-        + NodeCount
-        + Visitable,
+        + NodeCount,
     <G as GraphBase>::NodeId: Hash + Eq + Ord,
     F: FnMut(G::NodeId) -> Result<String, E>,
 {


### PR DESCRIPTION
This commit adds a rust generic implementation of the lexicographical topological sort function that was previously only exposed via the python interface to rustworkx-core. This new function is used internally by rustworkx and replaces the python specific implementation that used to be there. But it now exposes an interface to use it to rust.

Fixes: #1165

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
