### PR TITLE
Fix `coveralls` by changing the extension to `.lcov`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,17 +150,16 @@ jobs:
         run: |
           set -e
           mv tests/retworkx*profraw .
-          ./grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o ./coveralls.info
+          ./grcov . --binary-path ./target/debug/ -s . -t coveralls --branch --ignore-not-existing --ignore "/*" -o ./coveralls.json
       - uses: actions/upload-artifact@v4
         with:
           name: coverage
-          path: coveralls.info
+          path: coveralls.json
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          format: lcov
-          file: ./coveralls.info
+          file: ./coveralls.json
   docs:
     if: github.repository_owner == 'Qiskit'
     needs: [tests]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,16 +150,17 @@ jobs:
         run: |
           set -e
           mv tests/retworkx*profraw .
-          ./grcov . --binary-path ./target/debug/ -s . -t coveralls --branch --ignore-not-existing --ignore "/*" -o ./coveralls.json
+          ./grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o ./coveralls.lcov
       - uses: actions/upload-artifact@v4
         with:
           name: coverage
-          path: coveralls.json
+          path: coveralls.lcov
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./coveralls.json
+          format: lcov
+          file: ./coveralls.lcov
   docs:
     if: github.repository_owner == 'Qiskit'
     needs: [tests]


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

I have no idea why but our Coveralls integration started complaining about `lcov` files with `.info`, so I switched to `.lcov`
