### PR TITLE
Fix Clippy warnings due to 1.79

### DIFF
--- a/rustworkx-core/src/connectivity/biconnected.rs
+++ b/rustworkx-core/src/connectivity/biconnected.rs
@@ -23,7 +23,7 @@ use petgraph::{
 
 use crate::traversal::{depth_first_search, DfsEvent};
 
-const NULL: usize = std::usize::MAX;
+const NULL: usize = usize::MAX;
 
 type Edge<G> = (<G as GraphBase>::NodeId, <G as GraphBase>::NodeId);
 

--- a/rustworkx-core/src/connectivity/chain.rs
+++ b/rustworkx-core/src/connectivity/chain.rs
@@ -128,7 +128,7 @@ where
         None => graph.node_identifiers().collect(),
     };
 
-    let mut parent = vec![std::usize::MAX; graph.node_bound()];
+    let mut parent = vec![usize::MAX; graph.node_bound()];
     let mut back_edges: HashMap<G::NodeId, Vec<G::NodeId>> = HashMap::new();
 
     // depth-first-index (DFI) ordered nodes.

--- a/rustworkx-core/src/generators/random_graph.rs
+++ b/rustworkx-core/src/generators/random_graph.rs
@@ -108,7 +108,7 @@ where
     }
 
     if probability > 0.0 {
-        if (probability - 1.0).abs() < std::f64::EPSILON {
+        if (probability - 1.0).abs() < f64::EPSILON {
             for u in 0..num_nodes {
                 let start_node = if directed { 0 } else { u + 1 };
                 for v in start_node..num_nodes {
@@ -433,7 +433,7 @@ fn symmetric_array<T: std::cmp::PartialEq>(mat: &ArrayView2<T>) -> bool {
 
 #[inline]
 fn pnorm(x: f64, p: f64) -> f64 {
-    if p == 1.0 || p == std::f64::INFINITY {
+    if p == 1.0 || p == f64::INFINITY {
         x.abs()
     } else if p == 2.0 {
         x * x
@@ -445,7 +445,7 @@ fn pnorm(x: f64, p: f64) -> f64 {
 fn distance(x: &[f64], y: &[f64], p: f64) -> f64 {
     let it = x.iter().zip(y.iter()).map(|(xi, yi)| pnorm(xi - yi, p));
 
-    if p == std::f64::INFINITY {
+    if p == f64::INFINITY {
         it.fold(-1.0, |max, x| if x > max { x } else { max })
     } else {
         it.sum()

--- a/rustworkx-core/src/planar/lr_planar.rs
+++ b/rustworkx-core/src/planar/lr_planar.rs
@@ -186,7 +186,7 @@ where
             (Some(l_low), Some(r_low)) => lr_state.lowpt[l_low].min(lr_state.lowpt[r_low]),
             (Some(l_low), None) => lr_state.lowpt[l_low],
             (None, Some(r_low)) => lr_state.lowpt[r_low],
-            (None, None) => std::usize::MAX,
+            (None, None) => usize::MAX,
         }
     }
 }

--- a/rustworkx-core/src/steiner_tree.rs
+++ b/rustworkx-core/src/steiner_tree.rs
@@ -373,7 +373,7 @@ where
     distance.swap_remove(&dummy);
 
     // ``partition[u]`` holds the terminal node closest to node ``u``.
-    let mut partition: Vec<usize> = vec![std::usize::MAX; graph.node_bound()];
+    let mut partition: Vec<usize> = vec![usize::MAX; graph.node_bound()];
     for (u, path) in paths.iter() {
         let u = NodeIndexable::to_index(&in_graph, reverse_node_map[u]);
         partition[u] = NodeIndexable::to_index(&in_graph, reverse_node_map[&path[1]]);

--- a/src/connectivity/johnson_simple_cycles.rs
+++ b/src/connectivity/johnson_simple_cycles.rs
@@ -102,7 +102,7 @@ impl SimpleCycleIter {
             closed: HashSet::new(),
             block: HashMap::new(),
             stack: Vec::new(),
-            start_node: NodeIndex::new(std::u32::MAX as usize),
+            start_node: NodeIndex::new(u32::MAX as usize),
             node_map: HashMap::new(),
             reverse_node_map: HashMap::new(),
             subgraph: StableDiGraph::new(),

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -577,7 +577,7 @@ macro_rules! custom_vec_iter_impl {
                             Err(PyIndexError::new_err(format!("Invalid index, {}", idx)))
                         } else if idx < 0 {
                             let len = self.$data.len();
-                            Ok(self.$data[len - idx.abs() as usize].clone().into_py(py))
+                            Ok(self.$data[len - idx.unsigned_abs()].clone().into_py(py))
                         } else {
                             Ok(self.$data[idx as usize].clone().into_py(py))
                         }

--- a/src/layout/spring.rs
+++ b/src/layout/spring.rs
@@ -121,7 +121,7 @@ impl AdaptiveCoolingScheme {
         AdaptiveCoolingScheme {
             _step: step,
             _tau: 0.9,
-            _cost: std::f64::INFINITY,
+            _cost: f64::INFINITY,
             _progress: 0,
         }
     }
@@ -184,7 +184,7 @@ pub fn rescale(pos: &mut [Point], scale: Nt, indices: Vec<usize>) {
     mu[1] /= n as Nt;
 
     // substract mean and find max coordinate for all axes
-    let mut lim = std::f64::NEG_INFINITY;
+    let mut lim = f64::NEG_INFINITY;
     for n in indices {
         let [px, py] = pos.get_mut(n).unwrap();
         *px -= mu[0];
@@ -232,7 +232,7 @@ where
     Fr: Force,
     C: CoolingScheme,
 {
-    let mut step = cs.update_step(std::f64::INFINITY);
+    let mut step = cs.update_step(f64::INFINITY);
 
     for _ in 0..num_iter {
         let mut energy = 0.0;

--- a/src/random_graph.rs
+++ b/src/random_graph.rs
@@ -387,7 +387,7 @@ pub fn undirected_sbm_random_graph<'p>(
 
 #[inline]
 fn pnorm(x: f64, p: f64) -> f64 {
-    if p == 1.0 || p == std::f64::INFINITY {
+    if p == 1.0 || p == f64::INFINITY {
         x.abs()
     } else if p == 2.0 {
         x * x
@@ -399,7 +399,7 @@ fn pnorm(x: f64, p: f64) -> f64 {
 fn distance(x: &[f64], y: &[f64], p: f64) -> f64 {
     let it = x.iter().zip(y.iter()).map(|(xi, yi)| pnorm(xi - yi, p));
 
-    if p == std::f64::INFINITY {
+    if p == f64::INFINITY {
         it.fold(-1.0, |max, x| if x > max { x } else { max })
     } else {
         it.sum()

--- a/src/shortest_path/floyd_warshall.rs
+++ b/src/shortest_path/floyd_warshall.rs
@@ -153,7 +153,7 @@ pub fn floyd_warshall_numpy<Ty: EdgeType>(
 ) -> PyResult<(Array2<f64>, Option<Array2<usize>>)> {
     let n = graph.node_count();
     // Allocate empty matrix
-    let mut mat = Array2::<f64>::from_elem((n, n), std::f64::INFINITY);
+    let mut mat = Array2::<f64>::from_elem((n, n), f64::INFINITY);
     let mut next = if generate_successors {
         let mut next = Array2::<usize>::from_elem((n, n), 0);
 

--- a/src/shortest_path/mod.rs
+++ b/src/shortest_path/mod.rs
@@ -1476,7 +1476,7 @@ pub fn digraph_unweighted_average_shortest_path_length(
 ) -> f64 {
     let n = graph.node_count();
     if n <= 1 {
-        return std::f64::NAN;
+        return f64::NAN;
     }
 
     let (sum, conn_pairs) =
@@ -1484,11 +1484,11 @@ pub fn digraph_unweighted_average_shortest_path_length(
 
     let tot_pairs = n * (n - 1);
     if disconnected && conn_pairs == 0 {
-        return std::f64::NAN;
+        return f64::NAN;
     }
 
     if !disconnected && conn_pairs < tot_pairs {
-        return std::f64::INFINITY;
+        return f64::INFINITY;
     }
 
     (sum as f64) / (conn_pairs as f64)
@@ -1539,7 +1539,7 @@ pub fn graph_unweighted_average_shortest_path_length(
 ) -> f64 {
     let n = graph.node_count();
     if n <= 1 {
-        return std::f64::NAN;
+        return f64::NAN;
     }
 
     let (sum, conn_pairs) =
@@ -1547,11 +1547,11 @@ pub fn graph_unweighted_average_shortest_path_length(
 
     let tot_pairs = n * (n - 1);
     if disconnected && conn_pairs == 0 {
-        return std::f64::NAN;
+        return f64::NAN;
     }
 
     if !disconnected && conn_pairs < tot_pairs {
-        return std::f64::INFINITY;
+        return f64::INFINITY;
     }
 
     (sum as f64) / (conn_pairs as f64)


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Currently CI is broken because Clippy introduced new lints in the 1.79 update. This PR fixes that