### PR TITLE
Use stestr again for unittests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Download grcov
         run: curl -L https://github.com/mozilla/grcov/releases/download/v0.8.7/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
       - name: Install deps
-        run: pip install -U setuptools-rust networkx scipy testtools fixtures
+        run: pip install -U setuptools-rust networkx scipy testtools fixtures stestr
       - name: Build retworkx
         run: python setup.py develop
         env:
@@ -143,7 +143,7 @@ jobs:
           RUSTFLAGS: "-Cinstrument-coverage"
           LLVM_PROFILE_FILE: "retworkx-%p-%m.profraw"
       - name: Run tests
-        run: cd tests && python -m unittest discover . && cd ..
+        run: cd tests && stestr run && cd ..
         env:
           LLVM_PROFILE_FILE: "retworkx-%p-%m.profraw"
       - name: Run grcov

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,7 +33,7 @@ def install_rustworkx(session):
 def base_test(session):
     install_rustworkx(session)
     session.chdir("tests")
-    session.run("python", "-m", "unittest", "discover", *session.posargs)
+    session.run("stestr", "run", *session.posargs)
 
 @nox.session(python=["3"])
 def test(session):

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ passenv =
   RUSTWORKX_DEBUG
 changedir = {toxinidir}/tests
 commands =
-  python -m unittest discover {posargs}
+  stestr run {posargs}
   python -c "print('\nrustworkx no longer supports tox. Please run the equivalent comand with nox:\n\n\tnox -e test\n')"
 
 [testenv:lint]


### PR DESCRIPTION
With the release of Python 3.12.1 we stopped using stest in CI because 3.12.1 introduced a breaking API change to the unittest runner API that broke a dependency of stestr, testtools. This has been worked around with a new testtools release so we can restore using stestr in CI again which should improve test run throughput. This commit restores using stestr for the test CI jobs and local runs. The cibuildwheel config remains unchanged and uses the stdlib unittest runner still, just for simplicity so we don't need to install additional test dependencies.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
