### PR TITLE
Hexagonal lattice followup

### DIFF
--- a/releasenotes/notes/hexagonal-lattice-graph-fixes-1cd4aa88f1591701.yaml
+++ b/releasenotes/notes/hexagonal-lattice-graph-fixes-1cd4aa88f1591701.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed two bugs in the node position calculation done by the generator functions
+    :func:`.hexagonal_lattice_graph` and :func:`.directed_hexagonal_lattice_graph` when 
+    ``with_positions = True``:
+
+      * Corrected a scale factor that made all the hexagons in the lattice irregular
+      * Corrected an indexing bug that positioned the nodes in the last column of
+        the lattice incorrectly when ``periodic = False`` and ``cols`` is odd

--- a/rustworkx-core/src/generators/hexagonal_lattice_graph.rs
+++ b/rustworkx-core/src/generators/hexagonal_lattice_graph.rs
@@ -600,7 +600,10 @@ mod tests {
             hexagonal_lattice_graph_weighted(2, 2, |u, v| (u, v), || (), false, true).unwrap();
         assert_eq!(g_weighted.node_count(), 8);
         check_expected_edges_directed(&g_weighted, &expected_edges);
+    }
 
+    #[test]
+    fn test_hexagonal_lattice_graph_node_weights() {
         let g: petgraph::graph::UnGraph<(usize, usize), ()> =
             hexagonal_lattice_graph_weighted(2, 2, |u, v| (u, v), || (), false, false).unwrap();
         let expected_node_weights = vec![

--- a/rustworkx-core/src/generators/hexagonal_lattice_graph.rs
+++ b/rustworkx-core/src/generators/hexagonal_lattice_graph.rs
@@ -113,7 +113,7 @@ impl HexagonalLatticeBuilder {
                     let k = n - (self.rowlen - 1);
                     let u = k / self.rowlen + 1;
                     let v = k % self.rowlen;
-                    if u == self.collen - 1 {
+                    if u == self.collen - 1 && u % 2 == 0 {
                         (u, v + 1)
                     } else {
                         (u, v)

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -1105,8 +1105,8 @@ pub fn full_rary_tree(
 
 fn _hexagonal_lattice_node_position(u: usize, v: usize) -> (f64, f64) {
     let [i, j, a, b, c] = [u, v, u / 2, v % 2, u % 2].map(|val| val as f64);
-    const SQRT3: f64 = 1.732_050_807_568_877_2_f64;
-    (0.5 + i + a + b * (c - 0.5), SQRT3 * j)
+    const HALFSQRT3: f64 = 0.866_025_403_784_438_6_f64;
+    (0.5 + i + a + b * (c - 0.5), HALFSQRT3 * j)
 }
 
 /// Generate an undirected hexagonal lattice graph.
@@ -1122,7 +1122,7 @@ fn _hexagonal_lattice_node_position(u: usize, v: usize) -> (f64, f64) {
 ///     ``rows > 1``, and ``cols > 1``.
 /// :param bool with_positions: When set to ``True`` each node will be assigned
 ///     a pair of coordinates ``(x, y)`` as a weight. This embeds the nodes in
-///     the plane so that each hexagon is regular (with side length 2).
+///     the plane so that each hexagon is regular (with side length 1).
 ///
 /// :returns: The generated hexagonal lattice graph.
 ///
@@ -1198,7 +1198,7 @@ pub fn hexagonal_lattice_graph(
 ///     ``rows > 1``, and ``cols > 1``.
 /// :param bool with_positions: When set to ``True`` each node will be assigned
 ///     a pair of coordinates ``(x, y)`` as a payload. This embeds the nodes in
-///     the plane so that each hexagon is regular (with side length 2).
+///     the plane so that each hexagon is regular (with side length 1).
 ///
 /// :returns: The generated directed hexagonal lattice graph.
 ///

--- a/tests/generators/test_hexagonal.py
+++ b/tests/generators/test_hexagonal.py
@@ -438,9 +438,12 @@ class TestHexagonalLatticeGraph(unittest.TestCase):
         degree 3 (idea copied from the networkx test suite)."""
         for nRows in range(2, 8):
             for nCols in range(2, 8, 2):
-                graph = rustworkx.generators.hexagonal_lattice_graph(nRows, nCols, periodic=True)
-                for n in range(graph.num_nodes()):
-                    self.assertEqual(graph.degree(n), 3)
+                with self.subTest(nRows=nRows, nCols=nCols):
+                    graph = rustworkx.generators.hexagonal_lattice_graph(
+                        nRows, nCols, periodic=True
+                    )
+                    for n in range(graph.num_nodes()):
+                        self.assertEqual(graph.degree(n), 3)
 
     def test_hexagonal_graph_periodic_3_4(self):
         graph = rustworkx.generators.hexagonal_lattice_graph(3, 4, periodic=True)
@@ -564,13 +567,16 @@ class TestHexagonalLatticeGraph(unittest.TestCase):
         networkx are isomorphic for a few cases."""
         for nRows in range(2, 8):
             for nCols in range(2, 8, 2):
-                graph = rustworkx.generators.hexagonal_lattice_graph(nRows, nCols, periodic=True)
+                with self.subTest(nRows=nRows, nCols=nCols):
+                    graph = rustworkx.generators.hexagonal_lattice_graph(
+                        nRows, nCols, periodic=True
+                    )
 
-                nx_graph = rustworkx.networkx_converter(
-                    networkx.hexagonal_lattice_graph(nRows, nCols, periodic=True)
-                )
+                    nx_graph = rustworkx.networkx_converter(
+                        networkx.hexagonal_lattice_graph(nRows, nCols, periodic=True)
+                    )
 
-                self.assertTrue(rustworkx.is_isomorphic(graph, nx_graph))
+                    self.assertTrue(rustworkx.is_isomorphic(graph, nx_graph))
 
     def test_hexagonal_graph_periodic_odd_columns(self):
         with self.assertRaises(ValueError):

--- a/tests/generators/test_hexagonal.py
+++ b/tests/generators/test_hexagonal.py
@@ -608,3 +608,29 @@ class TestHexagonalLatticeGraph(unittest.TestCase):
                 self.assertAlmostEqual(
                     np.dot(vectors[ii], vectors[(ii + 1) % 6]), np.cos(np.pi / 3), 12
                 )
+
+    def test_hexagonal_graph_with_positions_odd_number_of_columns(self):
+        graph = rustworkx.generators.hexagonal_lattice_graph(2, 3, with_positions=True)
+        positions = graph.nodes()
+        hexagons = [
+            [0, 1, 2, 7, 6, 5],
+            [2, 3, 4, 9, 8, 7],
+            [6, 7, 8, 14, 13, 12],
+            [8, 9, 10, 16, 15, 14],
+            [11, 12, 13, 19, 18, 17],
+            [13, 14, 15, 21, 20, 19],
+        ]
+        C6 = rustworkx.generators.cycle_graph(6)
+        for h in hexagons:
+            self.assertTrue(rustworkx.is_isomorphic(graph.subgraph(h), C6))
+            coordinates = np.array([positions[node] for node in h])
+            vectors = [coordinates[(ii + 1) % 6] - coordinates[ii] for ii in range(6)]
+
+            for v in vectors:
+                # Check that each side of the hexagon has length 1
+                self.assertAlmostEqual(np.linalg.norm(v), 1.0, 12)
+            for ii in range(6):
+                # Check that the angle between each consecutive pair of sides is pi/3
+                self.assertAlmostEqual(
+                    np.dot(vectors[ii], vectors[(ii + 1) % 6]), np.cos(np.pi / 3), 12
+                )

--- a/tests/generators/test_hexagonal.py
+++ b/tests/generators/test_hexagonal.py
@@ -13,6 +13,9 @@
 import unittest
 import rustworkx
 import networkx
+import numpy as np
+
+import rustworkx.generators
 
 
 class TestHexagonalLatticeGraph(unittest.TestCase):
@@ -581,3 +584,20 @@ class TestHexagonalLatticeGraph(unittest.TestCase):
     def test_hexagonal_graph_periodic_odd_columns(self):
         with self.assertRaises(ValueError):
             rustworkx.generators.hexagonal_lattice_graph(4, 5, periodic=True)
+    
+    def test_hexagonal_graph_with_positions(self):
+        graph = rustworkx.generators.hexagonal_lattice_graph(2, 2, with_positions=True)
+        positions = graph.nodes()
+        hexagons = [[0, 1, 2, 7, 6, 5], [2, 3, 4, 7, 8, 9]]
+        C6 = rustworkx.generators.cycle_graph(6)
+        for h in hexagons:
+            self.assertTrue(rustworkx.is_isomorphic(graph.subgraph(h), C6))
+            coordinates = np.array([positions[node] for node in h])
+            vectors = [ coordinates[(ii+1)%6] - coordinates[ii] for ii in range(6) ]
+
+            for v in vectors:
+                # Check that each side of the hexagon has length 2
+                self.assertAlmostEqual(np.linalg.norm(v), 2.0, 12)
+            for ii in range(6):
+                # Check that the angle between each consecutive pair of sides is pi/3
+                self.assertAlmostEqual(np.dot(vectors[ii], vectors[(ii+1)%6]), 2 * 2 * np.cos(np.pi/3), 12)

--- a/tests/generators/test_hexagonal.py
+++ b/tests/generators/test_hexagonal.py
@@ -584,20 +584,27 @@ class TestHexagonalLatticeGraph(unittest.TestCase):
     def test_hexagonal_graph_periodic_odd_columns(self):
         with self.assertRaises(ValueError):
             rustworkx.generators.hexagonal_lattice_graph(4, 5, periodic=True)
-    
+
     def test_hexagonal_graph_with_positions(self):
         graph = rustworkx.generators.hexagonal_lattice_graph(2, 2, with_positions=True)
         positions = graph.nodes()
-        hexagons = [[0, 1, 2, 7, 6, 5], [2, 3, 4, 7, 8, 9]]
+        hexagons = [
+            [0, 1, 2, 7, 6, 5],
+            [2, 3, 4, 9, 8, 7],
+            [6, 7, 8, 13, 12, 11],
+            [8, 9, 10, 15, 14, 13],
+        ]
         C6 = rustworkx.generators.cycle_graph(6)
         for h in hexagons:
             self.assertTrue(rustworkx.is_isomorphic(graph.subgraph(h), C6))
             coordinates = np.array([positions[node] for node in h])
-            vectors = [ coordinates[(ii+1)%6] - coordinates[ii] for ii in range(6) ]
+            vectors = [coordinates[(ii + 1) % 6] - coordinates[ii] for ii in range(6)]
 
             for v in vectors:
-                # Check that each side of the hexagon has length 2
-                self.assertAlmostEqual(np.linalg.norm(v), 2.0, 12)
+                # Check that each side of the hexagon has length 1
+                self.assertAlmostEqual(np.linalg.norm(v), 1.0, 12)
             for ii in range(6):
                 # Check that the angle between each consecutive pair of sides is pi/3
-                self.assertAlmostEqual(np.dot(vectors[ii], vectors[(ii+1)%6]), 2 * 2 * np.cos(np.pi/3), 12)
+                self.assertAlmostEqual(
+                    np.dot(vectors[ii], vectors[(ii + 1) % 6]), np.cos(np.pi / 3), 12
+                )


### PR DESCRIPTION
Follow-up to #1213.

* Addressed comments on the previous PR
    * Split tests with a lot of sub-cases into subtests
    * Removed unnecessary module

* We now pre-compute the number of edges in each graph, so that we can call `G::with_capacity(self.num_nodes, self.num_edges)` to create the graph where before we had `G::with_capacity(self.num_nodes, self.num_nodes)`
 
* Fixed two bugs in the position calculation
   * In my initial implementation I missed a factor of two, so the hexagons were not actually regular
   * For lattices with an odd number of columns, the node index arithmetic had an error that led to configurations like this:
![hexlattice_bug](https://github.com/Qiskit/rustworkx/assets/20975024/91085deb-1aff-4e48-9cbd-36fbf898c66e)
Probably the reason I missed this is that I mostly wrote tests for cases with an even number of columns (required when `periodic = True`). We now get the expected result:
![hexlattice_fixed](https://github.com/Qiskit/rustworkx/assets/20975024/e86d83c2-0cd1-4bf9-991a-5e682e35a471)

