### PR TITLE
add -x to graphviz to prune isolated nodes and peninsulas

### DIFF
--- a/rustworkx/visualization/graphviz.py
+++ b/rustworkx/visualization/graphviz.py
@@ -196,9 +196,13 @@ def graphviz_draw(
             )
         prog = method
 
+    extra_args = []
+    if prog == "neato":
+        extra_args.append("-x")
+
     if not filename:
         dot_result = subprocess.run(
-            [prog, "-x", "-T", output_format],
+            [prog, "-T", output_format] + extra_args,
             input=dot_str.encode("utf-8"),
             capture_output=True,
             encoding=None,
@@ -210,7 +214,7 @@ def graphviz_draw(
         return image
     else:
         subprocess.run(
-            [prog, "-x", "-T", output_format, "-o", filename],
+            [prog, "-x", "-T", output_format, "-o", filename] + extra_args,
             input=dot_str,
             check=True,
             encoding="utf8",

--- a/rustworkx/visualization/graphviz.py
+++ b/rustworkx/visualization/graphviz.py
@@ -198,7 +198,7 @@ def graphviz_draw(
 
     if not filename:
         dot_result = subprocess.run(
-            [prog, "-T", output_format],
+            [prog, "-x", "-T", output_format],
             input=dot_str.encode("utf-8"),
             capture_output=True,
             encoding=None,
@@ -210,7 +210,7 @@ def graphviz_draw(
         return image
     else:
         subprocess.run(
-            [prog, "-T", output_format, "-o", filename],
+            [prog, "-x", "-T", output_format, "-o", filename],
             input=dot_str,
             check=True,
             encoding="utf8",


### PR DESCRIPTION
On many nodes, `neato` seems to fold on its own.

![image](https://github.com/user-attachments/assets/45503383-ce89-43f9-a2f2-20d55dbaf493)

With the parameter `-x`, the problem seems fixed:

![image](https://github.com/user-attachments/assets/73554beb-2e41-433f-aba9-ab2e8696e1e6)
