### PR TITLE
Fix Clippy warnings on stable/0.15 branch

### DIFF
--- a/rustworkx-core/src/dag_algo.rs
+++ b/rustworkx-core/src/dag_algo.rs
@@ -249,8 +249,8 @@ type LongestPathResult<G, T, E> = Result<Option<(Vec<NodeId<G>>, T)>, E>;
 /// # Arguments
 /// * `graph`: Reference to a directed graph.
 /// * `weight_fn` - An input callable that will be passed the `EdgeRef` for each edge in the graph.
-///  The callable should return the weight of the edge as `Result<T, E>`. The weight must be a type that implements
-/// `Num`, `Zero`, `PartialOrd`, and `Copy`.
+///   The callable should return the weight of the edge as `Result<T, E>`. The weight must be a type that implements
+///   `Num`, `Zero`, `PartialOrd`, and `Copy`.
 ///
 /// # Type Parameters
 /// * `G`: Type of the graph. Must be a directed graph.

--- a/rustworkx-core/src/steiner_tree.rs
+++ b/rustworkx-core/src/steiner_tree.rs
@@ -302,7 +302,7 @@ where
 ///   - there is an edge `(u, v)` in the graph and path pass through this edge.
 ///   - node `s` is the closest node to  `u` among all `terminal_nodes`
 ///   - node `t` is the closest node to `v` among all `terminal_nodes`
-/// and wraps the result inside a `MetricClosureEdge`
+///     and wraps the result inside a `MetricClosureEdge`
 ///
 /// For example, if all vertices are terminals, it returns the original edges of the graph.
 fn fast_metric_edges<G, F, E>(


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

This is to unblock CI for the future backports of #1246 and #1247. The lints were super simple this time, we only changed docstrings not code.