### PR TITLE
Added general form of transitive closure

### DIFF
--- a/releasenotes/notes/general-transitive-closure-2b6bee50af59cf8a.yaml
+++ b/releasenotes/notes/general-transitive-closure-2b6bee50af59cf8a.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Added a new function ``transitive_closure`` to rustworkx which returns the 
+    transitive closure of a graph. The transitive closure of G = (V,E) is a graph 
+    G+ = (V,E+) such that for all v, w in V there is an edge (v, w) in E+ if and 
+    only if there is a path from v to w in G.

--- a/rustworkx/__init__.pyi
+++ b/rustworkx/__init__.pyi
@@ -214,6 +214,7 @@ from .rustworkx import graph_tensor_product as graph_tensor_product
 from .rustworkx import graph_token_swapper as graph_token_swapper
 from .rustworkx import digraph_transitivity as digraph_transitivity
 from .rustworkx import graph_transitivity as graph_transitivity
+from .rustworkx import transitive_closure as transitive_closure
 from .rustworkx import digraph_bfs_search as digraph_bfs_search
 from .rustworkx import graph_bfs_search as graph_bfs_search
 from .rustworkx import digraph_dfs_search as digraph_dfs_search

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -542,6 +542,7 @@ fn rustworkx(py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(minimum_spanning_edges))?;
     m.add_wrapped(wrap_pyfunction!(minimum_spanning_tree))?;
     m.add_wrapped(wrap_pyfunction!(graph_transitivity))?;
+    m.add_wrapped(wrap_pyfunction!(transitive_closure))?;
     m.add_wrapped(wrap_pyfunction!(digraph_transitivity))?;
     m.add_wrapped(wrap_pyfunction!(graph_token_swapper))?;
     m.add_wrapped(wrap_pyfunction!(graph_core_number))?;

--- a/tests/graph/test_transitive_closure.py
+++ b/tests/graph/test_transitive_closure.py
@@ -1,0 +1,70 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import rustworkx
+
+
+class TestTransitive(unittest.TestCase):
+    def test_transitive_closure(self):
+
+        graph = rustworkx.PyDiGraph()
+        graph.add_nodes_from(list(range(4)))
+        graph.add_edge(0, 1, ())
+        graph.add_edge(1, 2, ())
+        graph.add_edge(2, 0, ())
+        graph.add_edge(2, 3, ())
+
+        closure_graph = rustworkx.transitive_closure(graph)
+        self.expected_edges = [
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (1, 0),
+            (1, 2),
+            (1, 3),
+            (2, 0),
+            (2, 1),
+            (2, 3),
+        ]
+
+        self.assertEqualEdgeList(self.expected_edges, closure_graph.edge_list())
+
+    def test_transitive_closure_single_node(self):
+        graph = rustworkx.PyDiGraph()
+        graph.add_node(())
+        closure_graph = rustworkx.transitive_closure(graph)
+        expected_edges = []
+        self.assertEqualEdgeList(expected_edges, closure_graph.edge_list())
+
+    def test_transitive_closure_no_edges(self):
+        graph = rustworkx.PyDiGraph()
+        graph.add_nodes_from(list(range(4)))
+        closure_graph = rustworkx.transitive_closure(graph)
+        expected_edges = []
+        self.assertEqualEdgeList(expected_edges, closure_graph.edge_list())
+
+    def test_transitive_closure_complete_graph(self):
+        graph = rustworkx.PyDiGraph()
+        graph.add_nodes_from(list(range(4)))
+        for i in range(4):
+            for j in range(4):
+                if i != j:
+                    graph.add_edge(i, j, ())
+        closure_graph = rustworkx.transitive_closure(graph)
+        expected_edges = [(i, j) for i in range(4) for j in range(4) if i != j]
+        self.assertEqualEdgeList(expected_edges, closure_graph.edge_list())
+
+    def assertEqualEdgeList(self, expected, actual):
+        for edge in actual:
+            self.assertTrue(edge in expected)


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Bulids on PR #707 to implement the general form of the transitive closure of a graph. Implemented function by following structure from @IvanIsCoding.

- Condense the graph into strongly connect components (which we already implement)
- Apply the DAG algorithm and get the transitive closure for the intermediate graph
- Map the answer from the intermediate graph to the original graph
