### PR TITLE
Add Python 3.13 to CI and to release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         rust: [stable]
-        python-version: [3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
         platform: [
           { os: "macOS-13", python-architecture: "x64", rust-target: "x86_64-apple-darwin" },
           { os: "macOS-14", python-architecture: "arm64", rust-target: "aarch64-apple-darwin" },
@@ -73,7 +73,7 @@ jobs:
             msrv: "MSRV"
           # Test future versions of Rust and Python
           - rust: beta
-            python-version: "3.13-dev"
+            python-version: "3.13" # upgrade to 3.14-dev when the release candidate is available
             platform: { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" }
             msrv: "Beta"
         # Exclude python 3.9 on arm64 until actions/setup-python#808 is resolved
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.17.0
+          python -m pip install cibuildwheel==2.21.2
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -105,7 +105,7 @@ jobs:
           platforms: all
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.17.0
+          python -m pip install cibuildwheel==2.21.2
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -143,7 +143,7 @@ jobs:
           platforms: all
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.17.0
+          python -m pip install cibuildwheel==2.21.2
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -182,7 +182,7 @@ jobs:
           platforms: all
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.17.0
+          python -m pip install cibuildwheel==2.21.2
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -220,7 +220,7 @@ jobs:
           platforms: all
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.17.0
+          python -m pip install cibuildwheel==2.21.2
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -253,7 +253,7 @@ jobs:
         run: rustup default stable-i686-pc-windows-msvc
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.17.0
+          python -m pip install cibuildwheel==2.21.2
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,2 @@
-decorator==4.4.2
-pillow<10.0.0;python_version<'3.13'
+pillow>=10.1
 lxml==5.1.1

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,7 @@ stubs_deps = [
 
 def install_rustworkx(session):
     session.install(*deps)
-    session.install(".", "-c", "constraints.txt")
+    session.install(".[all]", "-c", "constraints.txt")
 
 # We define a common base such that -e test triggers a test with the current
 # Python version of the interpreter and -e test_with_version launches


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

This adds Python 3.13 to CI and bumps `cibuildwheel` to the latest version.

I will test the wheel build on my personal repository before merging.