### PR TITLE
Swap `ahash` with `foldhash`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -107,6 +106,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "getrandom"
@@ -617,8 +622,8 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 name = "rustworkx"
 version = "0.16.0"
 dependencies = [
- "ahash",
  "fixedbitset",
+ "foldhash",
  "hashbrown 0.14.5",
  "indexmap 2.6.0",
  "ndarray",
@@ -644,8 +649,8 @@ dependencies = [
 name = "rustworkx-core"
 version = "0.16.0"
 dependencies = [
- "ahash",
  "fixedbitset",
+ "foldhash",
  "hashbrown 0.14.5",
  "indexmap 2.6.0",
  "ndarray",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ repository = "https://github.com/Qiskit/rustworkx"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-ahash = "0.8.6"
+foldhash = "0.1.2"
 fixedbitset = "0.4.2"
 hashbrown = { version = ">=0.13, <0.15", features = ["rayon"] }
 indexmap = { version = ">=1.9, <3", features = ["rayon"] }
@@ -41,7 +41,7 @@ name = "rustworkx"
 crate-type = ["cdylib"]
 
 [dependencies]
-ahash.workspace = true
+foldhash.workspace = true
 fixedbitset.workspace = true
 hashbrown.workspace = true
 indexmap.workspace = true

--- a/rustworkx-core/Cargo.toml
+++ b/rustworkx-core/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-ahash.workspace = true
+foldhash.workspace = true
 fixedbitset.workspace = true
 hashbrown.workspace = true
 indexmap.workspace = true

--- a/rustworkx-core/src/coloring.rs
+++ b/rustworkx-core/src/coloring.rs
@@ -10,7 +10,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-use ahash::RandomState;
+use foldhash::fast::RandomState;
 use priority_queue::PriorityQueue;
 use std::cmp::Ordering;
 use std::cmp::Reverse;

--- a/rustworkx-core/src/connectivity/min_cut.rs
+++ b/rustworkx-core/src/connectivity/min_cut.rs
@@ -39,7 +39,7 @@ where
     F: FnMut(G::EdgeRef) -> K,
     K: Copy + Ord + Zero + AddAssign,
 {
-    let mut pq = PriorityQueue::<G::NodeId, K, ahash::RandomState>::from(
+    let mut pq = PriorityQueue::<G::NodeId, K, foldhash::fast::RandomState>::from(
         graph
             .node_identifiers()
             .map(|nx| (nx, K::zero()))

--- a/rustworkx-core/src/dictmap.rs
+++ b/rustworkx-core/src/dictmap.rs
@@ -11,21 +11,21 @@
 // under the License.
 
 //! This module contains the [`DictMap`] type alias which is a combination of
-//! [`IndexMap`] and [`AHash`].
+//! [`IndexMap`] and [`Foldhash`].
 //!
 //! It is used as a return type for rustworkx for compatibility
 //! with Python's dict which preserves insertion order.
 //!
-//! [`AHash`]: https://crates.io/crates/ahash
+//! [`Foldhash`]: https://crates.io/crates/foldhash
 
 use indexmap::IndexMap;
 
 /// Convenient alias to build an [`IndexMap`] using a custom hasher.
-/// For the moment, we use ahash which is the default hasher
+/// For the moment, we use foldhash which is the default hasher
 /// for [`HashMap`], another hashmap we use.
 ///
-/// [`HashMap`]: https://docs.rs/hashbrown/0.11.2/hashbrown/hash_map/struct.HashMap.html
-pub type DictMap<K, V> = IndexMap<K, V, ahash::RandomState>;
+/// [`HashMap`]: https://docs.rs/hashbrown/0.15.0/hashbrown/hash_map/struct.HashMap.html
+pub type DictMap<K, V> = IndexMap<K, V, foldhash::fast::RandomState>;
 
 pub trait InitWithHasher {
     fn new() -> Self
@@ -40,11 +40,11 @@ pub trait InitWithHasher {
 impl<K, V> InitWithHasher for DictMap<K, V> {
     #[inline]
     fn new() -> Self {
-        indexmap::IndexMap::with_capacity_and_hasher(0, ahash::RandomState::default())
+        indexmap::IndexMap::with_capacity_and_hasher(0, foldhash::fast::RandomState::default())
     }
 
     #[inline]
     fn with_capacity(n: usize) -> Self {
-        indexmap::IndexMap::with_capacity_and_hasher(n, ahash::RandomState::default())
+        indexmap::IndexMap::with_capacity_and_hasher(n, foldhash::fast::RandomState::default())
     }
 }

--- a/rustworkx-core/src/graph_ext/contraction.rs
+++ b/rustworkx-core/src/graph_ext/contraction.rs
@@ -471,7 +471,7 @@ where
 
 fn contract_stable<G, F, E: Error>(
     graph: &mut G,
-    mut nodes: IndexSet<G::NodeId, ahash::RandomState>,
+    mut nodes: IndexSet<G::NodeId, foldhash::fast::RandomState>,
     weight: G::NodeWeight,
     weight_combo_fn: Option<F>,
 ) -> Result<G::NodeId, E>
@@ -499,7 +499,7 @@ where
     Ok(node_index)
 }
 
-fn can_contract<G>(graph: G, nodes: &IndexSet<G::NodeId, ahash::RandomState>) -> bool
+fn can_contract<G>(graph: G, nodes: &IndexSet<G::NodeId, foldhash::fast::RandomState>) -> bool
 where
     G: Data + Visitable + IntoEdgesDirected,
     G::NodeId: Eq + Hash,
@@ -536,7 +536,7 @@ type NoCallback<E> = Option<fn(&E, &E) -> Result<E, Infallible>>;
 fn add_edges<G, F, E>(
     graph: &mut G,
     new_node: G::NodeId,
-    nodes: &IndexSet<G::NodeId, ahash::RandomState>,
+    nodes: &IndexSet<G::NodeId, foldhash::fast::RandomState>,
     mut weight_combo_fn: Option<F>,
 ) -> Result<(), E>
 where

--- a/rustworkx-core/src/shortest_path/all_shortest_paths.rs
+++ b/rustworkx-core/src/shortest_path/all_shortest_paths.rs
@@ -38,7 +38,7 @@ use crate::dictmap::*;
 /// use rustworkx_core::dictmap::DictMap;
 /// use rustworkx_core::shortest_path::all_shortest_paths;
 /// use rustworkx_core::Result;
-/// use ahash::HashSet;
+/// use foldhash::HashSet;
 ///
 /// let mut graph : Graph<(), (), Directed>= Graph::new();
 /// let a = graph.add_node(()); // node with no weight

--- a/rustworkx-core/tests/graph_ext/contraction.rs
+++ b/rustworkx-core/tests/graph_ext/contraction.rs
@@ -10,7 +10,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-use ahash::HashSet;
+use foldhash::HashSet;
 use hashbrown::HashMap;
 use petgraph::data::Build;
 use petgraph::visit::{

--- a/src/connectivity/johnson_simple_cycles.rs
+++ b/src/connectivity/johnson_simple_cycles.rs
@@ -10,7 +10,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-use ahash::RandomState;
+use foldhash::fast::RandomState;
 use hashbrown::{HashMap, HashSet};
 use indexmap::IndexSet;
 
@@ -141,7 +141,7 @@ fn unblock(
 #[allow(clippy::too_many_arguments)]
 fn process_stack(
     start_node: NodeIndex,
-    stack: &mut Vec<(NodeIndex, IndexSet<NodeIndex, ahash::RandomState>)>,
+    stack: &mut Vec<(NodeIndex, IndexSet<NodeIndex, foldhash::fast::RandomState>)>,
     path: &mut Vec<NodeIndex>,
     closed: &mut HashSet<NodeIndex>,
     blocked: &mut HashSet<NodeIndex>,
@@ -165,7 +165,7 @@ fn process_stack(
                     next_node,
                     subgraph
                         .neighbors(next_node)
-                        .collect::<IndexSet<NodeIndex, ahash::RandomState>>(),
+                        .collect::<IndexSet<NodeIndex, foldhash::fast::RandomState>>(),
                 ));
                 closed.remove(&next_node);
                 blocked.insert(next_node);
@@ -206,7 +206,7 @@ impl SimpleCycleIter {
             }));
         }
         // Restore previous state if it exists
-        let mut stack: Vec<(NodeIndex, IndexSet<NodeIndex, ahash::RandomState>)> =
+        let mut stack: Vec<(NodeIndex, IndexSet<NodeIndex, foldhash::fast::RandomState>)> =
             std::mem::take(&mut slf.stack);
         let mut path: Vec<NodeIndex> = std::mem::take(&mut slf.path);
         let mut closed: HashSet<NodeIndex> = std::mem::take(&mut slf.closed);
@@ -268,7 +268,7 @@ impl SimpleCycleIter {
                 slf.start_node,
                 subgraph
                     .neighbors(slf.start_node)
-                    .collect::<IndexSet<NodeIndex, ahash::RandomState>>(),
+                    .collect::<IndexSet<NodeIndex, foldhash::fast::RandomState>>(),
             )];
             if let Some(res) = process_stack(
                 slf.start_node,


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

This matches `hashbrown`'s 0.15 release that switches the default hasher. This is more to keep consistency with the internals.

I will put this on hold until #1293 is merged, we are still stuck with an older version of `hashbrown` until we update PyO3 anyway