### PR TITLE
Fix bug where edge colors are randomly shuffled in `mpl_draw`

### DIFF
--- a/releasenotes/notes/correct-edge-colors-e082e1761e1c060b.yaml
+++ b/releasenotes/notes/correct-edge-colors-e082e1761e1c060b.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a bug introduced in version 0.15 where the edge colors specified as
+    a list in calls to :func:`~rustworkx.visualization.mpl_draw` were not
+    having their order respected. Instead, the order of the colors was
+    being shuffled. This has been restored and now the behavior should
+    match that of 0.14.

--- a/rustworkx/visualization/matplotlib.py
+++ b/rustworkx/visualization/matplotlib.py
@@ -639,7 +639,7 @@ def draw_edges(
     edge_pos_keys = dict()
     for e in edge_list:
         edge_pos_keys[(tuple(pos[e[0]]), tuple(pos[e[1]]))] = None
-    edge_pos = edge_pos.keys()
+    edge_pos = edge_pos_keys.keys()
 
     # Check if edge_color is an array of floats and map to edge_cmap.
     # This is the only case handled differently from matplotlib

--- a/rustworkx/visualization/matplotlib.py
+++ b/rustworkx/visualization/matplotlib.py
@@ -636,9 +636,10 @@ def draw_edges(
         edge_color = "k"
 
     # set edge positions
-    edge_pos = set()
+    edge_pos_keys = dict()
     for e in edge_list:
-        edge_pos.add((tuple(pos[e[0]]), tuple(pos[e[1]])))
+        edge_pos_keys[(tuple(pos[e[0]]), tuple(pos[e[1]]))] = None
+    edge_pos = edge_pos.keys()
 
     # Check if edge_color is an array of floats and map to edge_cmap.
     # This is the only case handled differently from matplotlib


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Closes #1308. A bit embarrasing but we let that slip through in #1204.

The solution is a bit hacky but reusing Python dictionaries was the easiest way to get a set-like object that preservers iteration order.
