### PR TITLE
Impl `__repr__` for custom vector

### DIFF
--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -546,6 +546,10 @@ macro_rules! custom_vec_iter_impl {
                 Python::with_gil(|py| Ok(format!("{}{}", stringify!($name), self.$data.str(py)?)))
             }
 
+            fn __repr__(&self) -> PyResult<String> {
+                self.__str__()
+            }
+
             fn __hash__(&self) -> PyResult<u64> {
                 let mut hasher = DefaultHasher::new();
                 Python::with_gil(|py| PyHash::hash(&self.$data, py, &mut hasher))?;


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
I found that rustworkx's custom vectors do not provide `__repr__` method, which I have to use `print(indices)`