### PR TITLE
Fix typos detected by the typos tool

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - run: pip install -U ruff==0.6.8 black~=24.8 typos~=1.27
+      - run: pip install -U ruff==0.6.8 black~=24.8 typos~=1.28
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - run: pip install -U ruff==0.6.8 black~=24.8
+      - run: pip install -U ruff==0.6.8 black~=24.8 typos~=1.27
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -42,6 +42,8 @@ jobs:
         run: ruff check rustworkx retworkx setup.py tests
       - name: Check stray release notes
         run: python tools/find_stray_release_notes.py
+      - name: Spell check
+        run: typos --exclude releasenotes/ && typos --no-check-filenames releasenotes/
       - name: rustworkx-core Rust Tests
         run: pushd rustworkx-core && cargo test && popd
       - name: rustworkx-core Docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,9 @@ jobs:
         with:
           python-version: "3.10"
       - run: pip install -U ruff==0.6.8 black~=24.8 typos~=1.28
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.82
         with:
-          components: rustfmt
+          components: rustfmt, clippy
       - name: Test Build
         run: cargo build
       - name: Rust Format

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           python-version: "3.10"
       - run: pip install -U ruff==0.6.8 black~=24.8
-      - uses: dtolnay/rust-toolchain@1.82
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
       - name: Test Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - run: pip install -U ruff==0.6.8 black~=24.8 typos~=1.28
+      - run: pip install -U ruff==0.6.8 black~=24.8
       - uses: dtolnay/rust-toolchain@1.82
         with:
           components: rustfmt, clippy
@@ -42,8 +42,6 @@ jobs:
         run: ruff check rustworkx retworkx setup.py tests
       - name: Check stray release notes
         run: python tools/find_stray_release_notes.py
-      - name: Spell check
-        run: typos --exclude releasenotes/ && typos --no-check-filenames releasenotes/
       - name: rustworkx-core Rust Tests
         run: pushd rustworkx-core && cargo test && popd
       - name: rustworkx-core Docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,7 +284,7 @@ cargo doc --open
 ### Type Annotations
 
 If you have added new methods, functions, or classes, and/or changed any
-signatures, type anotations for Python are required to be included in a pull
+signatures, type annotations for Python are required to be included in a pull
 request. Type annotations are added using type
 [stub files](https://typing.readthedocs.io/en/latest/source/stubs.html) which
 provide type annotations to python tooling which use type annotations. The stub
@@ -523,7 +523,7 @@ primary exception to this is adding support for new python versions. If a new
 python version is released backporting that feature change with that new support
 is an acceptable backport.
 
-In rustworkx at least until the 1.0 release we only maintaing a single stable
+In rustworkx at least until the 1.0 release we only maintain a single stable
 branch at a time for the most recent minor version release.
 
 #### Backporting procedure

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ it just as it would if there was a prebuilt binary available.
 > [!NOTE]  
 > To build from source you will need to ensure you have pip >=19.0.0
 installed, which supports PEP-517, or that you have manually installed
-`setuptools-rust` prior to running `pip install rustworkx`. If you recieve an
+`setuptools-rust` prior to running `pip install rustworkx`. If you receive an
 error about `setuptools-rust` not being found you should upgrade pip with
 `pip install -U pip` or manually install `setuptools-rust` with
 `pip install setuptools-rust` and try again.

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -2,7 +2,7 @@
 Rustworkx Comparison Benchmarks With Other Libraries
 ****************************************************
 
-rustworkx is competitive against other popular graph libraries for Python. We compared rustworkx to the igraph, graph-tools and NetworkIt libraries `in a benchmark consisting of four tasks available on Github for reproducibility <https://github.com/mtreinish/retworkx-comparison-benchmarks>`__. We report the results from a machine with an Intel(R) i9-9900K CPU at 3.60GHz with eight cores, 16 theads, and 32GB of RAM avaialble. 
+rustworkx is competitive against other popular graph libraries for Python. We compared rustworkx to the igraph, graph-tools and NetworkIt libraries `in a benchmark consisting of four tasks available on Github for reproducibility <https://github.com/mtreinish/retworkx-comparison-benchmarks>`__. We report the results from a machine with an Intel(R) i9-9900K CPU at 3.60GHz with eight cores, 16 threads, and 32GB of RAM available.
 
 Graph Creation
 ==============

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -44,12 +44,12 @@ just as it would if there was a prebuilt binary available.
 
     To build from source you will need to ensure you have pip >=19.0.0
     installed, which supports PEP-517, or that you have manually installed
-    setuptools-rust prior to running pip install rustworkx. If you recieve an
+    setuptools-rust prior to running pip install rustworkx. If you receive an
     error about ``setuptools-rust`` not being found you should upgrade pip with
     ``pip install -U pip`` or manually install ``setuptools-rust`` with:
     ``pip install setuptools-rust`` and try again.
 
-.. _platform-suppport:
+.. _platform-support:
 
 Platform Support
 ================

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -266,7 +266,7 @@ New Features
 
 - A new method, :meth:`~rustworkx.PyDiGraph.remove_node_retain_edges`, has been
   added to the :class:`~rustworkx.PyDiGraph` class. This method can be used to
-  remove a node and add edges from its predecesors to its successors.
+  remove a node and add edges from its predecessors to its successors.
 - Two new methods, :meth:`~rustworkx.PyGraph.edge_list` and
   :meth:`~rustworkx.PyGraph.weighted_edge_list`, for getting a list of tuples
   with the edge source and target (with or without edge weights) have been
@@ -285,7 +285,7 @@ New Features
   edge list file and will read that file and generate a new object from the
   contents.
 - Two new methods, :meth:`~rustworkx.PyGraph.extend_from_edge_list` and
-  :meth:`~rustworkx.PyGraoh.extend_from_weighted_edge_list` has been added
+  :meth:`~rustworkx.PyGraph.extend_from_weighted_edge_list` has been added
   to :class:`~rustworkx.PyGraph` and :class:`~rustworkx.PyDiGraph`
   (:meth:`~rustworkx.PyDiGraph.extend_from_edge_list` and
   :meth:`~rustworkx.PyDiGraph.extend_from_weighted_edge_list`). This method

--- a/docs/source/tutorial/betweenness_centrality.rst
+++ b/docs/source/tutorial/betweenness_centrality.rst
@@ -37,7 +37,7 @@ To start we need to generate a graph:
     mpl_draw(graph)
 
 
-Calculate the Betweeness Centrality
+Calculate the Betweenness Centrality
 -----------------------------------
 
 The :func:`~rustworkx.betweenness_centrality` function can be used to calculate

--- a/docs/source/tutorial/betweenness_centrality.rst
+++ b/docs/source/tutorial/betweenness_centrality.rst
@@ -38,7 +38,7 @@ To start we need to generate a graph:
 
 
 Calculate the Betweenness Centrality
------------------------------------
+------------------------------------
 
 The :func:`~rustworkx.betweenness_centrality` function can be used to calculate
 the betweenness centrality for each node in the graph.

--- a/docs/source/tutorial/dags.rst
+++ b/docs/source/tutorial/dags.rst
@@ -113,7 +113,7 @@ jobs. For example:
 Above we define a DAG with 6 jobs and dependency relationship between these
 jobs. Now if we run the :func:`~rustworkx.topological_sort` function on the
 graph it will return a linear order to execute the jobs that will respect
-the dependency releationship.
+the dependency relationship.
 
 .. jupyter-execute::
 
@@ -151,7 +151,7 @@ computation. A quantum circuit is represented graphically like:
 
 The specifics of this circuit aren't important here beyond the fact that
 we have 2 qubits, ``q_0`` and ``q_1``, 2 classical bits, ``c_0`` and ``c_1``,
-and a series of operations on those qubits with a depedency ordering. The last
+and a series of operations on those qubits with a dependency ordering. The last
 operation on each qubit is a measurement on ``q_0`` that is stored in ``c_0``
 and ``q_1`` that is stored in ``c_1``.
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,7 @@ lint_deps = [
     "black~=24.8",
     "ruff~=0.6",
     "setuptools-rust",
-    "typos~=1.27",
+    "typos~=1.28",
 ]
 
 stubs_deps = [

--- a/noxfile.py
+++ b/noxfile.py
@@ -51,6 +51,7 @@ def lint(session):
     session.run("cargo", "fmt", "--all", "--", "--check", external=True)
     session.run("python", "tools/find_stray_release_notes.py")
     session.run("typos", "--exclude", "releasenotes")
+    session.run("typos", "--no-check-filenames", "releasenotes")
 
 @nox.session(python=["3"])
 def docs(session):

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,6 +15,7 @@ lint_deps = [
     "black~=24.8",
     "ruff~=0.6",
     "setuptools-rust",
+    "typos~=1.27",
 ]
 
 stubs_deps = [
@@ -49,6 +50,7 @@ def lint(session):
     session.run("ruff", "check", "rustworkx", "retworkx", "setup.py")
     session.run("cargo", "fmt", "--all", "--", "--check", external=True)
     session.run("python", "tools/find_stray_release_notes.py")
+    session.run("typos", "--exclude", "releasenotes")
 
 @nox.session(python=["3"])
 def docs(session):

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,12 +46,11 @@ def test_with_version(session):
 @nox.session(python=["3"])
 def lint(session):
     black(session)
+    typos(session)
     session.install(*lint_deps)
     session.run("ruff", "check", "rustworkx", "retworkx", "setup.py")
     session.run("cargo", "fmt", "--all", "--", "--check", external=True)
     session.run("python", "tools/find_stray_release_notes.py")
-    session.run("typos", "--exclude", "releasenotes")
-    session.run("typos", "--no-check-filenames", "releasenotes")
 
 @nox.session(python=["3"])
 def docs(session):
@@ -71,6 +70,12 @@ def docs_clean(session):
 def black(session):
     session.install(*[d for d in lint_deps if "black" in d])
     session.run("black", "rustworkx", "tests", "retworkx", *session.posargs)
+
+@nox.session(python=["3"])
+def typos(session):
+    session.install(*[d for d in lint_deps if "typos" in d])
+    session.run("typos", "--exclude", "releasenotes")
+    session.run("typos", "--no-check-filenames", "releasenotes")
 
 @nox.session(python=["3"])
 def stubs(session):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,11 @@ extend-exclude = ["doc"]
 "rustworkx/__init__.py" = ["F405", "F403"]
 "*.pyi" = ["F403", "F405", "PYI001", "PYI002"]
 
+[tool.typos.default]
+extend-ignore-words-re = [
+  "[Ss]toer",
+]
+
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"

--- a/releasenotes/notes/0.11/edge-index-methods-427f7301c720f565.yaml
+++ b/releasenotes/notes/0.11/edge-index-methods-427f7301c720f565.yaml
@@ -8,7 +8,7 @@ features:
     Added a new method, :meth:`~rustworkx.PyGraph.incident_edge_index_map`, to the
     :class:`~rustworkx.PyGraph` and :class:`~rustworkx.PyDiGraph` class. This
     method returns a mapping of edge indices for edges incident to a provided node
-    to the endoint and weight tuple for that edge index. For example:
+    to the endpoint and weight tuple for that edge index. For example:
 
     .. jupyter-execute::
 

--- a/releasenotes/notes/0.11/fix-dispatch-3596ef110cc68338.yaml
+++ b/releasenotes/notes/0.11/fix-dispatch-3596ef110cc68338.yaml
@@ -8,4 +8,4 @@ fixes:
   - |
     Fixed an oversight in the :func:`~rustworkx.union` function where
     user-defined values for the ``merge_nodes`` and ``merge_edges`` arguments
-    were being ingored.
+    were being ignored.

--- a/releasenotes/notes/0.11/prepare-0.11-af688e532712c830.yaml
+++ b/releasenotes/notes/0.11/prepare-0.11-af688e532712c830.yaml
@@ -56,7 +56,7 @@ features:
         g = nx.Graph()
         g.add_nodes_from([
           ("A", {"color": "turquoise", "size": "extra large"}),
-          ("B", {"color": "fuschia", "size": "tiny"}),
+          ("B", {"color": "fuchsia", "size": "tiny"}),
         ])
         g.add_edge("A", "B")
         rx_graph = rx.networkx_converter(g, keep_attributes=True)
@@ -65,7 +65,7 @@ features:
 
     will output::
 
-        [{'color': 'turquoise', 'size': 'extra large', '__networkx_node__': 'A'}, {'color': 'fuschia', 'size': 'tiny', '__networkx_node__': 'B'}]
+        [{'color': 'turquoise', 'size': 'extra large', '__networkx_node__': 'A'}, {'color': 'fuchsia', 'size': 'tiny', '__networkx_node__': 'B'}]
         WeightedEdgeList[(0, 1, {})]
 
 fixes:

--- a/releasenotes/notes/0.13/fix-sequence-protocol-e95246e864cc850a.yaml
+++ b/releasenotes/notes/0.13/fix-sequence-protocol-e95246e864cc850a.yaml
@@ -4,7 +4,7 @@ fixes:
     Fixed an issue with the custom sequence return types,
     :class:`~.BFSSuccessors`, :class:`~.NodeIndices`, :class:`~.EdgeList`,
     :class:`~.WeightedEdgeList`, :class:`~.EdgeIndices`, and :class:`~.Chains`
-    where they previosuly were missing certain attributes that prevented them
+    where they previously were missing certain attributes that prevented them
     being used as a sequence for certain built-in functions such as
     ``reversed()``.
     Fixed `#696 <https://github.com/Qiskit/rustworkx/issues/696>`__.

--- a/releasenotes/notes/0.13/prepare-0.13.0-5e579fb3ab1e3b60.yaml
+++ b/releasenotes/notes/0.13/prepare-0.13.0-5e579fb3ab1e3b60.yaml
@@ -13,5 +13,5 @@ prelude: |
 
   This is also the final rustworkx release that supports running with Python
   3.7. Starting in the 0.14.0 release Python >= 3.8 will be required to use
-  rustworkx. This release also increased the minimum suported Rust version for
+  rustworkx. This release also increased the minimum supported Rust version for
   compiling rustworkx and rustworkx-core from source to 1.56.1.

--- a/releasenotes/notes/0.14/handle-invalid-mapping-token_swapper-55d5b045b0b55345.yaml
+++ b/releasenotes/notes/0.14/handle-invalid-mapping-token_swapper-55d5b045b0b55345.yaml
@@ -31,4 +31,4 @@ upgrade:
           token_swapper(&g, mapping, Some(10), Some(4), Some(50));
 
     will now return ``Err(MapNotPossible)`` instead of panicking. If you were using this
-    funciton before you'll need to handle the result type.
+    function before you'll need to handle the result type.

--- a/releasenotes/notes/0.14/platform-updates-e9b296144e633c95.yaml
+++ b/releasenotes/notes/0.14/platform-updates-e9b296144e633c95.yaml
@@ -6,7 +6,7 @@ features:
 upgrade:
   - |
     Support for the Linux ppc64le pllatform has changed from tier 3 to tier 4
-    (as documented in :ref:`platform-suppport`). This is a result of no longer
+    (as documented in :ref:`platform-support`). This is a result of no longer
     being able to run tests during the pre-compiled wheel publishing jobs due
     to constraints in the available CI infrastructure. There hopefully
     shouldn't be any meaningful impact resulting from this change, but as there

--- a/releasenotes/notes/0.14/s390x-tier-4-1701a0f044759cd1.yaml
+++ b/releasenotes/notes/0.14/s390x-tier-4-1701a0f044759cd1.yaml
@@ -2,7 +2,7 @@
 upgrade:
   - |
     Support for the Linux s390x platform has changed from tier 3 to tier 4 (as
-    documented in :ref:`platform-suppport`). This is a result of no longer being
+    documented in :ref:`platform-support`). This is a result of no longer being
     able to run tests during the pre-compiled wheel publishing jobs due to
     constraints in the available CI infrastructure. There hopefully shouldn't 
     be any meaningful impact resulting from this change, but as there are no longer tests being

--- a/releasenotes/notes/0.14/transitive-reduction-6db2b80351c15887.yaml
+++ b/releasenotes/notes/0.14/transitive-reduction-6db2b80351c15887.yaml
@@ -1,7 +1,7 @@
 ---
 features:
   - |
-    Added a new function, :func:`~.transitive_reduction` which returns the transtive reduction
+    Added a new function, :func:`~.transitive_reduction` which returns the transitive reduction
     of a given :class:`~rustworkx.PyDiGraph` and a dictionary with the mapping of indices from the given graph to the returned graph.
     The given graph must be a Directed Acyclic Graph (DAG).
     For example:

--- a/releasenotes/notes/0.15/custom-iterators-dce8557a8f87e8c0.yaml
+++ b/releasenotes/notes/0.15/custom-iterators-dce8557a8f87e8c0.yaml
@@ -7,4 +7,4 @@ features:
     of approximately 40% for iterating through the custom iterables.
 
     These types are not directly nameable or constructable from Python space, and other than the
-    performance improvement, the behavior should largely not be noticable from Python space.
+    performance improvement, the behavior should largely not be noticeable from Python space.

--- a/releasenotes/notes/0.15/fix-mpl-draw-digraph-plots-aecf86738ab9b0db.yaml
+++ b/releasenotes/notes/0.15/fix-mpl-draw-digraph-plots-aecf86738ab9b0db.yaml
@@ -4,7 +4,7 @@ fixes:
     Fixed the plots of multigraphs using :func:`.mpl_draw`. Previously, parallel edges of 
     multigraphs were plotted on top of each other, with overlapping arrows and labels. 
     The radius of parallel edges of the multigraph was fixed to be `0.25` for 
-    `connectionstyle` supporting this argument in :func:`.draw_edges`. The edge lables 
+    `connectionstyle` supporting this argument in :func:`.draw_edges`. The edge labels 
     were offset to `0.25` in :func:`.draw_edge_labels` to align with their respective 
     edges. This fix can be tested using the following code: 
 

--- a/releasenotes/notes/0.15/lexicographical-topo-sort-core-e85fba409d612600.yaml
+++ b/releasenotes/notes/0.15/lexicographical-topo-sort-core-e85fba409d612600.yaml
@@ -2,6 +2,6 @@
 features:
   - |
     Added a new function ``lexicographical_topological_sort`` to the
-    ``rustworkx_core::dag_algo`` module. That is a gneric Rust implementation
+    ``rustworkx_core::dag_algo`` module. That is a generic Rust implementation
     for the core rust library that provides the
     :func:`.lexicographical_topological_sort` function to Rust users.

--- a/releasenotes/notes/0.15/maximum-bisimulation-942a9d0dc9b46ee4.yaml
+++ b/releasenotes/notes/0.15/maximum-bisimulation-942a9d0dc9b46ee4.yaml
@@ -4,7 +4,7 @@ features:
     compute the maximum bisimulation or relational coarsest partition of a
     graph. This function is based on the algorithm described in the publication
     "Three partition refinement algorithms" by Paige and Tarjan. This function
-    recieves a graph and returns a
+    receives a graph and returns a
     :class:`~rustworkx.RelationalCoarsestPartition`.
   - |
     Added a new class :class:`~rustworkx.RelationalCoarsestPartition` to output

--- a/releasenotes/notes/0.15/swap-nox-tox-dea2bb14c400641c.yaml
+++ b/releasenotes/notes/0.15/swap-nox-tox-dea2bb14c400641c.yaml
@@ -1,7 +1,7 @@
 ---
 other:
   - |
-    For developement of rustworkx the automated testing environment
+    For development of rustworkx the automated testing environment
     tooling used has switched from Tox to instead
     `Nox <https://nox.thea.codes/en/stable/>`__. This is has no impact for
     end users and is only relevant if you contribute code to rustworkx.

--- a/releasenotes/notes/0.9.0/add-nx-converter-1feffc8d5aa13365.yaml
+++ b/releasenotes/notes/0.9.0/add-nx-converter-1feffc8d5aa13365.yaml
@@ -4,7 +4,7 @@ features:
     A new function :func:`rustworkx.networkx_converter` has been added. This
     function takes in a networkx ``Graph`` object and will generate an
     equivalent :class:`~rustworkx.PyGraph` or :class:`~rustworkx.PyDiGraph`
-    object. While this function is provided as a convience for users of
+    object. While this function is provided as a convenience for users of
     both rustworkx and networkx, networkx will **not** be added as a dependency
     of rustworkx (which precludes a rustworkx->networkx converter, see
     :ref:`networkx_converter` for example code on how to build this yourself).

--- a/releasenotes/notes/fix-typos-8f68ff3d0680b924.yaml
+++ b/releasenotes/notes/fix-typos-8f68ff3d0680b924.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix typos detected by `typos <https://github.com/crate-ci/typos>`_.
+    Add spell checker invocations to the Nox ``lint`` session.

--- a/rustworkx-core/src/bipartite_coloring.rs
+++ b/rustworkx-core/src/bipartite_coloring.rs
@@ -538,7 +538,7 @@ where
     }
 
     // Reconstruct coloring of the original graph by iterating over the edges, finding the
-    // correponding edge (endpoints) in the multigraph, and selecting the last (not yet
+    // corresponding edge (endpoints) in the multigraph, and selecting the last (not yet
     // assigned) color of that edge
     let mut edge_coloring: DictMap<G::EdgeId, usize> = DictMap::with_capacity(graph.edge_count());
     for edge in graph.edge_references() {

--- a/rustworkx-core/src/coloring.rs
+++ b/rustworkx-core/src/coloring.rs
@@ -401,7 +401,7 @@ where
 /// Arguments:
 ///
 /// * `graph` - The graph object to run the algorithm on
-/// * `preset_color_fn` - A callback function that will recieve the node identifier
+/// * `preset_color_fn` - A callback function that will receive the node identifier
 ///     for each node in the graph and is expected to return an `Option<usize>`
 ///     (wrapped in a `Result`) that is `None` if the node has no preset and
 ///     the usize represents the preset color.

--- a/rustworkx-core/src/connectivity/all_simple_paths.rs
+++ b/rustworkx-core/src/connectivity/all_simple_paths.rs
@@ -80,8 +80,8 @@ where
 
     // list of visited nodes
     let mut visited: IndexSet<G::NodeId> = IndexSet::from_iter(Some(from));
-    // list of childs of currently exploring path nodes,
-    // last elem is list of childs of last visited node
+    // list of children of currently exploring path nodes,
+    // last elem is list of children of last visited node
     let mut stack = vec![graph.neighbors_directed(from, Outgoing)];
 
     let mut output: DictMap<G::NodeId, Vec<Vec<G::NodeId>>> = DictMap::with_capacity(to.len());
@@ -174,8 +174,8 @@ where
 {
     // list of visited nodes
     let mut visited: IndexSet<G::NodeId> = IndexSet::from_iter(Some(from));
-    // list of childs of currently exploring path nodes,
-    // last elem is list of childs of last visited node
+    // list of children of currently exploring path nodes,
+    // last elem is list of children of last visited node
     let mut stack = vec![graph.neighbors_directed(from, Outgoing)];
 
     let mut output_path: Option<Vec<G::NodeId>> = None;

--- a/rustworkx-core/src/connectivity/biconnected.rs
+++ b/rustworkx-core/src/connectivity/biconnected.rs
@@ -336,7 +336,7 @@ mod tests {
 
     #[test]
     fn test_biconnected_components1() {
-        // exmaple from https://web.archive.org/web/20121229123447/http://www.ibluemojo.com/school/articul_algorithm.html
+        // example from https://web.archive.org/web/20121229123447/http://www.ibluemojo.com/school/articul_algorithm.html
         let graph = UnGraph::<(), ()>::from_edges([
             (0, 1),
             (0, 5),

--- a/rustworkx-core/src/connectivity/chain.rs
+++ b/rustworkx-core/src/connectivity/chain.rs
@@ -61,7 +61,7 @@ where
 /// The graph should be undirected. If `source` is specified only the chain
 /// decomposition for the connected component containing this node will be returned.
 /// This node indicates the root of the depth-first search tree. If it's not
-/// specified, a source will be chosen arbitrarly and repeated until all components
+/// specified, a source will be chosen arbitrarily and repeated until all components
 /// of the graph are searched.
 ///
 /// Returns a list of list of edges where each inner list is a chain.

--- a/rustworkx-core/src/connectivity/cycle_basis.rs
+++ b/rustworkx-core/src/connectivity/cycle_basis.rs
@@ -92,10 +92,10 @@ where
                     cycles.push(cycle);
                 // A cycle was found:
                 } else if !used.get(&z).unwrap().contains(&neighbor) {
-                    let pn = used.get(&neighbor).unwrap();
+                    let prev_n = used.get(&neighbor).unwrap();
                     let mut cycle: Vec<G::NodeId> = vec![neighbor, z];
                     let mut p = pred.get(&z).unwrap();
-                    while !pn.contains(p) {
+                    while !prev_n.contains(p) {
                         cycle.push(*p);
                         p = pred.get(p).unwrap();
                     }

--- a/rustworkx-core/src/dag_algo.rs
+++ b/rustworkx-core/src/dag_algo.rs
@@ -33,7 +33,7 @@ use num_traits::{Num, Zero};
 use crate::err::LayersError;
 
 /// Return a pair of [`petgraph::Direction`] values corresponding to the "forwards" and "backwards"
-/// direction of graph traversal, based on whether the graph is being traved forwards (following
+/// direction of graph traversal, based on whether the graph is being traversed forwards (following
 /// the edges) or backward (reversing along edges).  The order of returns is (forwards, backwards).
 #[inline(always)]
 pub fn traversal_directions(reverse: bool) -> (petgraph::Direction, petgraph::Direction) {
@@ -719,7 +719,7 @@ where
     Some(runs)
 }
 
-/// Auxiliary struct to make the output of [`collect_runs`] iteratable
+/// Auxiliary struct to make the output of [`collect_runs`] iterable
 ///
 /// If the filtering function passed to [`collect_runs`] returns an error, it is propagated
 /// through `next` as `Err`. In this case the run in which the error occurred will be skipped

--- a/rustworkx-core/src/generators/complete_graph.rs
+++ b/rustworkx-core/src/generators/complete_graph.rs
@@ -22,7 +22,7 @@ use super::InvalidInputError;
 ///
 /// * `num_nodes` - The number of nodes to create a complete graph for. Either this or
 ///     `weights` must be specified. If both this and `weights` are specified, `weights`
-///     will take priorty and this argument will be ignored
+///     will take priority and this argument will be ignored
 /// * `weights` - A `Vec` of node weight objects.
 /// * `default_node_weight` - A callable that will return the weight to use
 ///     for newly created nodes. This is ignored if `weights` is specified.

--- a/rustworkx-core/src/generators/cycle_graph.rs
+++ b/rustworkx-core/src/generators/cycle_graph.rs
@@ -22,7 +22,7 @@ use super::InvalidInputError;
 ///
 /// * `num_nodes` - The number of nodes to create a cycle graph for. Either this or
 ///     `weights` must be specified. If both this and `weights` are specified, `weights`
-///     will take priorty and this argument will be ignored.
+///     will take priority and this argument will be ignored.
 /// * `weights` - A `Vec` of node weight objects.
 /// * `default_node_weight` - A callable that will return the weight to use
 ///     for newly created nodes. This is ignored if `weights` is specified.

--- a/rustworkx-core/src/generators/karate_club.rs
+++ b/rustworkx-core/src/generators/karate_club.rs
@@ -23,9 +23,9 @@ use petgraph::visit::{Data, NodeIndexable};
 ///
 /// * `default_node_weight` - A callable that will receive a boolean, indicating
 ///     if a node is part of Mr Hi's faction (True) or the Officer's faction (false).
-///     It shoudl return the node weight according to the desired type.
+///     It should return the node weight according to the desired type.
 /// * `default_edge_weight` - A callable that will receive the integer representing
-///     the strenght of the relation between two nodes. It should return the edge
+///     the strength of the relation between two nodes. It should return the edge
 ///      weight according to the desired type.
 ///
 pub fn karate_club_graph<G, T, F, H, M>(mut default_node_weight: F, mut default_edge_weight: H) -> G

--- a/rustworkx-core/src/generators/path_graph.rs
+++ b/rustworkx-core/src/generators/path_graph.rs
@@ -22,7 +22,7 @@ use super::InvalidInputError;
 ///
 /// * `num_nodes` - The number of nodes to create a path graph for. Either this or
 ///     `weights` must be specified. If both this and `weights` are specified, `weights`
-///     will take priorty and this argument will be ignored
+///     will take priority and this argument will be ignored
 /// * `weights` - A `Vec` of node weight objects.
 /// * `default_node_weight` - A callable that will return the weight to use
 ///     for newly created nodes. This is ignored if `weights` is specified.

--- a/rustworkx-core/src/generators/star_graph.rs
+++ b/rustworkx-core/src/generators/star_graph.rs
@@ -22,7 +22,7 @@ use super::InvalidInputError;
 ///
 /// * `num_nodes` - The number of nodes to create a star graph for. Either this or
 ///     `weights` must be specified. If both this and `weights` are specified, weights
-///     will take priorty and this argument will be ignored
+///     will take priority and this argument will be ignored
 /// * `weights` - A `Vec` of node weight objects.
 /// * `default_node_weight` - A callable that will return the weight to use
 ///     for newly created nodes. This is ignored if `weights` is specified.

--- a/rustworkx-core/src/max_weight_matching.rs
+++ b/rustworkx-core/src/max_weight_matching.rs
@@ -11,7 +11,7 @@
 // under the License.
 
 // Needed to pass shared state between functions
-// closures don't work because of recurssion
+// closures don't work because of recursion
 #![allow(clippy::too_many_arguments)]
 // Allow single character names to match naming convention from
 // paper
@@ -87,7 +87,7 @@ fn assign_label<E>(
     best_edge[w] = None;
     best_edge[b] = None;
     if t == 1 {
-        // b became an S-vertex/blossom; add it(s verticies) to the queue
+        // b became an S-vertex/blossom; add it(s vertices) to the queue
         queue.append(&mut blossom_leaves(b, num_nodes, blossom_children)?);
     } else if t == 2 {
         // b became a T-vertex/blossom; assign label S to its mate.
@@ -142,7 +142,7 @@ fn scan_blossom(
         assert!(labels[blossom] == Some(1));
         path.push(blossom);
         labels[blossom] = Some(5);
-        // Trace one step bacl.
+        // Trace one step back.
         assert!(label_ends[blossom] == mate.get(&blossom_base[blossom].unwrap()).copied());
         if label_ends[blossom].is_none() {
             // The base of blossom is single; stop tracing this path
@@ -160,7 +160,7 @@ fn scan_blossom(
             mem::swap(&mut v, &mut w);
         }
     }
-    // Remvoe breadcrumbs.
+    // Remove breadcrumbs.
     for blossom in path {
         labels[blossom] = Some(1);
     }
@@ -371,7 +371,7 @@ fn expand_blossom<E>(
         // base.
         assert!(label_ends[blossom].is_some());
         let entry_child = in_blossoms[endpoints[label_ends[blossom].unwrap() ^ 1]];
-        // Decied in which direction we will go around the blossom.
+        // Decide in which direction we will go around the blossom.
         let i = blossom_children[blossom]
             .iter()
             .position(|x| *x == entry_child)
@@ -809,7 +809,7 @@ fn verify_optimum(
 /// Based on networkx implementation
 /// <https://github.com/networkx/networkx/blob/3351206a3ce5b3a39bb2fc451e93ef545b96c95b/networkx/algorithms/matching.py>
 ///
-/// With reference to the standalone protoype implementation from:
+/// With reference to the standalone prototype implementation from:
 /// <http://jorisvr.nl/article/maximum-matching>
 ///
 /// <http://jorisvr.nl/files/graphmatching/20130407/mwmatching.py>
@@ -884,9 +884,9 @@ where
     if num_edges == 0 {
         return Ok(HashSet::new());
     }
-    // Node indicies in the PyGraph may not be contiguous however the
+    // Node indices in the PyGraph may not be contiguous however the
     // algorithm operates on contiguous indices 0..num_nodes. node_map maps
-    // the PyGraph's NodeIndex to the contingous usize used inside the
+    // the PyGraph's NodeIndex to the contiguous usize used inside the
     // algorithm
     let node_map: HashMap<G::NodeId, usize> = graph
         .node_identifiers()
@@ -1018,7 +1018,7 @@ where
         best_edge = vec![None; 2 * num_nodes];
         blossom_best_edges.splice(num_nodes.., (0..num_nodes).map(|_| Vec::new()));
         // Loss of labeling means that we can not be sure that currently
-        // allowable edges remain allowable througout this stage.
+        // allowable edges remain allowable throughout this stage.
         allowed_edge = vec![false; num_edges];
         // Make queue empty
         queue.clear();
@@ -1248,7 +1248,7 @@ where
             if delta_type == -1 {
                 // No further improvement possible; max-cardinality optimum
                 // reached. Do a final delta update to make the optimum
-                // verifyable
+                // verifiable
                 assert!(max_cardinality);
                 delta_type = 1;
                 delta = Some(max(0, *dual_var[..num_nodes].iter().min().unwrap()));
@@ -1275,7 +1275,7 @@ where
                     }
                 }
             }
-            // Take action at the point where minimum delta occured.
+            // Take action at the point where minimum delta occurred.
             if delta_type == 1 {
                 // No further improvement possible; optimum reached
                 break;

--- a/rustworkx-core/src/planar/lr_planar.rs
+++ b/rustworkx-core/src/planar/lr_planar.rs
@@ -211,7 +211,7 @@ where
     graph: G,
     /// roots of the DFS forest.
     roots: Vec<G::NodeId>,
-    /// distnace from root.
+    /// distance from root.
     height: HashMap<G::NodeId, usize>,
     /// parent edge.
     eparent: HashMap<G::NodeId, Edge<G>>,

--- a/rustworkx-core/src/steiner_tree.rs
+++ b/rustworkx-core/src/steiner_tree.rs
@@ -446,7 +446,7 @@ pub struct SteinerTreeResult {
 ///
 /// The minimum tree of ``graph`` with regard to a set of ``terminal_nodes``
 /// is a tree within ``graph`` that spans those nodes and has a minimum size
-/// (measured as the sum of edge weights) amoung all such trees.
+/// (measured as the sum of edge weights) among all such trees.
 ///
 /// The minimum steiner tree can be approximated by computing the minimum
 /// spanning tree of the subgraph of the metric closure of ``graph`` induced

--- a/rustworkx/__init__.py
+++ b/rustworkx/__init__.py
@@ -24,7 +24,7 @@ class PyDAG(PyDiGraph):
     """A class for creating direct acyclic graphs.
 
     PyDAG is just an alias of the PyDiGraph class and behaves identically to
-    the :class:`~rustworkx.PyDiGraph` class and can be used interchangably
+    the :class:`~rustworkx.PyDiGraph` class and can be used interchangeably
     with ``PyDiGraph``. It currently exists solely as a backwards
     compatibility alias for users of rustworkx from prior to the
     0.4.0 release when there was no PyDiGraph class.
@@ -641,7 +641,7 @@ def dfs_edges(graph, source=None):
     :param int source: An optional node index to use as the starting node
         for the depth-first search. The edge list will only return edges in
         the components reachable from this index. If this is not specified
-        then a source will be chosen arbitrarly and repeated until all
+        then a source will be chosen arbitrarily and repeated until all
         components of the graph are searched.
 
     :returns: A list of edges as a tuple of the form ``(source, target)`` in
@@ -1003,7 +1003,7 @@ def bipartite_layout(
     :param graph: The graph to generate the layout for. Can either be a
         :class:`~rustworkx.PyGraph` or :class:`~rustworkx.PyDiGraph`
     :param set first_nodes: The set of node indices on the left (or top if
-        horitontal is true)
+        horizontal is true)
     :param bool horizontal: An optional bool specifying the orientation of the
         layout
     :param float scale: An optional scaling factor to scale positions
@@ -1344,7 +1344,7 @@ def vf2_mapping(
     """
     Return an iterator over all vf2 mappings between two graphs.
 
-    This funcion will run the vf2 algorithm used from
+    This function will run the vf2 algorithm used from
     :func:`~rustworkx.is_isomorphic` and :func:`~rustworkx.is_subgraph_isomorphic`
     but instead of returning a boolean it will return an iterator over all possible
     mapping of node ids found from ``first`` to ``second``. If the graphs are not
@@ -1381,7 +1381,7 @@ def vf2_mapping(
         algorithm visits while searching for a solution. If it exceeds this limit,
         the algorithm will stop. Default: ``None``.
 
-    :returns: An iterator over dicitonaries of node indices from ``first`` to node
+    :returns: An iterator over dictionaries of node indices from ``first`` to node
         indices in ``second`` representing the mapping found.
     :rtype: Iterable[NodeMap]
     """
@@ -1555,7 +1555,7 @@ def bfs_search(graph, source, visitor):
         or a :class:`~rustworkx.PyDiGraph`
     :param List[int] source: An optional list of node indices to use as the starting
         nodes for the breadth-first search. If this is not specified then a source
-        will be chosen arbitrarly and repeated until all components of the
+        will be chosen arbitrarily and repeated until all components of the
         graph are searched.
     :param visitor: A visitor object that is invoked at the event points inside the
         algorithm. This should be a subclass of :class:`~rustworkx.visit.BFSVisitor`.
@@ -1625,7 +1625,7 @@ def dfs_search(graph, source, visitor):
     :param PyGraph graph: The graph to be used.
     :param List[int] source: An optional list of node indices to use as the starting
         nodes for the depth-first search. If this is not specified then a source
-        will be chosen arbitrarly and repeated until all components of the
+        will be chosen arbitrarily and repeated until all components of the
         graph are searched.
     :param visitor: A visitor object that is invoked at the event points inside the
         algorithm. This should be a subclass of :class:`~rustworkx.visit.DFSVisitor`.
@@ -1678,7 +1678,7 @@ def dijkstra_search(graph, source, weight_fn, visitor):
         or a :class:`~rustworkx.PyDiGraph`.
     :param List[int] source: An optional list of node indices to use as the starting nodes
         for the dijkstra search. If this is not specified then a source
-        will be chosen arbitrarly and repeated until all components of the
+        will be chosen arbitrarily and repeated until all components of the
         graph are searched.
     :param weight_fn: An optional weight function for an edge. It will accept
         a single argument, the edge's weight object and will return a float which

--- a/rustworkx/visualization/matplotlib.py
+++ b/rustworkx/visualization/matplotlib.py
@@ -581,7 +581,7 @@ def draw_edges(
         Label for legend
 
     min_source_margin : int (default=0)
-        The minimum margin (gap) at the begining of the edge at the source.
+        The minimum margin (gap) at the beginning of the edge at the source.
 
     min_target_margin : int (default=0)
         The minimum margin (gap) at the end of the edge at the target.
@@ -978,7 +978,7 @@ def draw_edge_labels(
     ax : Matplotlib Axes object, optional
         Draw the graph in the specified Matplotlib axes.
 
-    rotate : bool (deafult=True)
+    rotate : bool (default=True)
         Rotate edge labels to lie parallel to edges
 
     clip_on : bool (default=True)

--- a/src/bisimulation.rs
+++ b/src/bisimulation.rs
@@ -309,11 +309,11 @@ fn maximum_bisimulation(graph: &StablePyGraph<Directed>) -> Option<Vec<Block>> {
         let mut counterimage = build_counterimage(graph, smaller_component);
 
         let counterimage_group = group_by_counterimage(counterimage.clone(), &node_to_block_vec);
-        let ((new_fine_blocks, removeable_fine_blocks), coarse_block_that_are_now_compound) =
+        let ((new_fine_blocks, removable_fine_blocks), coarse_block_that_are_now_compound) =
             split_blocks_with_grouped_counterimage(counterimage_group, &mut node_to_block_vec);
 
         all_fine_blocks.extend(new_fine_blocks);
-        all_fine_blocks.retain(|x| !removeable_fine_blocks.iter().any(|y| Rc::ptr_eq(x, y)));
+        all_fine_blocks.retain(|x| !removable_fine_blocks.iter().any(|y| Rc::ptr_eq(x, y)));
         queue.extend(coarse_block_that_are_now_compound);
 
         // counterimage = E^{-1}(B) - E^{-1}(S-B)
@@ -327,11 +327,11 @@ fn maximum_bisimulation(graph: &StablePyGraph<Directed>) -> Option<Vec<Block>> {
         }
 
         let counterimage_group = group_by_counterimage(counterimage, &node_to_block_vec);
-        let ((new_fine_blocks, removeable_fine_blocks), coarse_block_that_are_now_compound) =
+        let ((new_fine_blocks, removable_fine_blocks), coarse_block_that_are_now_compound) =
             split_blocks_with_grouped_counterimage(counterimage_group, &mut node_to_block_vec);
 
         all_fine_blocks.extend(new_fine_blocks);
-        all_fine_blocks.retain(|x| !removeable_fine_blocks.iter().any(|y| Rc::ptr_eq(x, y)));
+        all_fine_blocks.retain(|x| !removable_fine_blocks.iter().any(|y| Rc::ptr_eq(x, y)));
         queue.extend(coarse_block_that_are_now_compound);
     }
 

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -1073,7 +1073,7 @@ pub fn biconnected_components(graph: &graph::PyGraph) -> BiconnectedComponents {
 ///     only the chain decomposition for the connected component containing
 ///     this node will be returned. This node indicates the root of the depth-first
 ///     search tree. If this is not specified then a source will be chosen
-///     arbitrarly and repeated until all components of the graph are searched.
+///     arbitrarily and repeated until all components of the graph are searched.
 /// :returns: A list of list of edges where each inner list is a chain.
 /// :rtype: list of EdgeList
 ///

--- a/src/dag_algo/mod.rs
+++ b/src/dag_algo/mod.rs
@@ -81,7 +81,7 @@ where
 }
 
 /// Return a pair of [`petgraph::Direction`] values corresponding to the "forwards" and "backwards"
-/// direction of graph traversal, based on whether the graph is being traved forwards (following
+/// direction of graph traversal, based on whether the graph is being traversed forwards (following
 /// the edges) or backward (reversing along edges).  The order of returns is (forwards, backwards).
 #[inline(always)]
 pub fn traversal_directions(reverse: bool) -> (petgraph::Direction, petgraph::Direction) {

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -637,15 +637,15 @@ impl PyDiGraph {
         let children = self
             .graph
             .neighbors_directed(index, petgraph::Direction::Outgoing);
-        let mut succesors: Vec<&PyObject> = Vec::new();
+        let mut successors: Vec<&PyObject> = Vec::new();
         let mut used_indices: HashSet<NodeIndex> = HashSet::new();
         for succ in children {
             if !used_indices.contains(&succ) {
-                succesors.push(self.graph.node_weight(succ).unwrap());
+                successors.push(self.graph.node_weight(succ).unwrap());
                 used_indices.insert(succ);
             }
         }
-        succesors
+        successors
     }
 
     /// Return a list of all the node predecessor data.
@@ -692,7 +692,7 @@ impl PyDiGraph {
         filter_fn: PyObject,
     ) -> PyResult<Vec<&PyObject>> {
         let index = NodeIndex::new(node);
-        let mut succesors: Vec<&PyObject> = Vec::new();
+        let mut successors: Vec<&PyObject> = Vec::new();
         let mut used_indices: HashSet<NodeIndex> = HashSet::new();
 
         let filter_edge = |edge: &PyObject| -> PyResult<bool> {
@@ -710,11 +710,11 @@ impl PyDiGraph {
                 let edge_weight = edge.weight();
                 if filter_edge(edge_weight)? {
                     used_indices.insert(succ);
-                    succesors.push(self.graph.node_weight(succ).unwrap());
+                    successors.push(self.graph.node_weight(succ).unwrap());
                 }
             }
         }
-        Ok(succesors)
+        Ok(successors)
     }
 
     /// Return a filtered list of predecessor data such that each
@@ -1004,7 +1004,7 @@ impl PyDiGraph {
     /// :meth:`remove_node_retain_edges_by_id`.
     ///
     /// :param int node: The index of the node to remove. If the index is not
-    ///     present in the graph it will be ingored and this function willl have
+    ///     present in the graph it will be ignored and this function will have
     ///     no effect.
     /// :param bool use_outgoing: If set to true the weight/data from the
     ///     edge outgoing from ``node`` will be used in the retained edge
@@ -1754,12 +1754,12 @@ impl PyDiGraph {
 
     /// Get the successor indices of a node.
     ///
-    /// This will return a list of the node indicies for the succesors of
+    /// This will return a list of the node indices for the successors of
     /// a node
     ///
     /// :param int node: The index of the node to get the successors of
     ///
-    /// :returns: A list of the neighbor node indicies
+    /// :returns: A list of the neighbor node indices
     /// :rtype: NodeIndices
     #[pyo3(text_signature = "(self, node, /)")]
     pub fn successor_indices(&self, node: usize) -> NodeIndices {
@@ -1774,12 +1774,12 @@ impl PyDiGraph {
 
     /// Get the predecessor indices of a node.
     ///
-    /// This will return a list of the node indicies for the predecessors of
+    /// This will return a list of the node indices for the predecessors of
     /// a node
     ///
     /// :param int node: The index of the node to get the predecessors of
     ///
-    /// :returns: A list of the neighbor node indicies
+    /// :returns: A list of the neighbor node indices
     /// :rtype: NodeIndices
     #[pyo3(text_signature = "(self, node, /)")]
     pub fn predecessor_indices(&self, node: usize) -> NodeIndices {
@@ -2162,8 +2162,8 @@ impl PyDiGraph {
     /// Read an edge list file and create a new PyDiGraph object from the
     /// contents
     ///
-    /// The expected format for the edge list file is a line seperated list
-    /// of deliminated node ids. If there are more than 3 elements on
+    /// The expected format for the edge list file is a line separated list
+    /// of delimited node ids. If there are more than 3 elements on
     /// a line the 3rd on will be treated as a string weight for the edge
     ///
     /// :param str path: The path of the file to open

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -989,7 +989,7 @@ pub fn binomial_tree_graph(
 ///
 /// :returns: A directed binomial tree with 2^n vertices and 2^n - 1 edges.
 /// :rtype: PyDiGraph
-/// :raises IndexError: If the lenght of ``weights`` is greater that 2^n
+/// :raises IndexError: If the length of ``weights`` is greater that 2^n
 /// :raises OverflowError: If the input order exceeds the maximum value for the
 ///     current platform.
 ///
@@ -1059,7 +1059,7 @@ pub fn directed_binomial_tree_graph(
 ///
 /// :returns: A r-ary tree.
 /// :rtype: PyGraph
-/// :raises IndexError: If the lenght of ``weights`` is greater that n
+/// :raises IndexError: If the length of ``weights`` is greater that n
 ///
 /// .. jupyter-execute::
 ///

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1124,7 +1124,7 @@ impl PyGraph {
     ///
     /// :param int node: The index of the node to get the neighbors of
     ///
-    /// :returns: A list of the neighbor node indicies
+    /// :returns: A list of the neighbor node indices
     /// :rtype: NodeIndices
     #[pyo3(text_signature = "(self, node, /)")]
     pub fn neighbors(&self, node: usize) -> NodeIndices {
@@ -1284,8 +1284,8 @@ impl PyGraph {
     /// Read an edge list file and create a new PyGraph object from the
     /// contents
     ///
-    /// The expected format for the edge list file is a line seperated list
-    /// of deliminated node ids. If there are more than 3 elements on
+    /// The expected format for the edge list file is a line separated list
+    /// of delimited node ids. If there are more than 3 elements on
     /// a line the 3rd on will be treated as a string weight for the edge
     ///
     /// :param str path: The path of the file to open

--- a/src/isomorphism/mod.rs
+++ b/src/isomorphism/mod.rs
@@ -295,7 +295,7 @@ pub fn graph_is_subgraph_isomorphic(
 
 /// Return an iterator over all vf2 mappings between two :class:`~rustworkx.PyDiGraph` objects
 ///
-/// This funcion will run the vf2 algorithm used from
+/// This function will run the vf2 algorithm used from
 /// :func:`~rustworkx.is_isomorphic` and :func:`~rustworkx.is_subgraph_isomorphic`
 /// but instead of returning a boolean it will return an iterator over all possible
 /// mapping of node ids found from ``first`` to ``second``. If the graphs are not
@@ -333,7 +333,7 @@ pub fn graph_is_subgraph_isomorphic(
 ///     visits while searching for a solution. If it exceeds this limit, the algorithm
 ///     will stop.
 ///
-/// :returns: An iterator over dicitonaries of node indices from ``first`` to node
+/// :returns: An iterator over dictionaries of node indices from ``first`` to node
 ///     indices in ``second`` representing the mapping found.
 /// :rtype: Iterable[NodeMap]
 #[pyfunction]
@@ -374,7 +374,7 @@ pub fn digraph_vf2_mapping(
 
 /// Return an iterator over all vf2 mappings between two :class:`~rustworkx.PyGraph` objects
 ///
-/// This funcion will run the vf2 algorithm used from
+/// This function will run the vf2 algorithm used from
 /// :func:`~rustworkx.is_isomorphic` and :func:`~rustworkx.is_subgraph_isomorphic`
 /// but instead of returning a boolean it will return an iterator over all possible
 /// mapping of node ids found from ``first`` to ``second``. If the graphs are not
@@ -411,7 +411,7 @@ pub fn digraph_vf2_mapping(
 ///     visits while searching for a solution. If it exceeds this limit, the algorithm
 ///     will stop. Default: ``None``.
 ///
-/// :returns: An iterator over dicitonaries of node indices from ``first`` to node
+/// :returns: An iterator over dictionaries of node indices from ``first`` to node
 ///     indices in ``second`` representing the mapping found.
 /// :rtype: Iterable[NodeMap]
 #[pyfunction]

--- a/src/isomorphism/vf2.rs
+++ b/src/isomorphism/vf2.rs
@@ -168,7 +168,7 @@ where
     fn sort(&self, graph: &StablePyGraph<Ty>) -> Vec<NodeIndex> {
         let n = graph.node_bound();
 
-        let dout: Vec<usize> = (0..n)
+        let d_out: Vec<usize> = (0..n)
             .map(|idx| {
                 graph
                     .neighbors_directed(graph.from_index(idx), Outgoing)
@@ -176,9 +176,9 @@ where
             })
             .collect();
 
-        let mut din: Vec<usize> = vec![0; n];
+        let mut d_in: Vec<usize> = vec![0; n];
         if graph.is_directed() {
-            din = (0..n)
+            d_in = (0..n)
                 .map(|idx| {
                     graph
                         .neighbors_directed(graph.from_index(idx), Incoming)
@@ -202,9 +202,9 @@ where
                     .max_by_key(|&(_, &node)| {
                         (
                             conn_in[node],
-                            dout[node],
+                            d_out[node],
                             conn_out[node],
-                            din[node],
+                            d_in[node],
                             Reverse(node),
                         )
                     })
@@ -256,7 +256,7 @@ where
         };
 
         let mut sorted_nodes: Vec<usize> = graph.node_indices().map(|node| node.index()).collect();
-        sorted_nodes.par_sort_by_key(|&node| (dout[node], din[node], Reverse(node)));
+        sorted_nodes.par_sort_by_key(|&node| (d_out[node], d_in[node], Reverse(node)));
         sorted_nodes.reverse();
 
         for node in sorted_nodes {

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -34,7 +34,7 @@
 // don't store any python object, just use `impl PyGCProtocol for MyReadOnlyType {}`.
 //
 // Types `T, K, V` above should implement `PyHash`, `PyEq`, `PyDisplay` traits.
-// These are arleady implemented for many primitive rust types and `PyObject`.
+// These are already implemented for many primitive rust types and `PyObject`.
 
 #![allow(clippy::float_cmp, clippy::upper_case_acronyms)]
 
@@ -1088,7 +1088,7 @@ custom_vec_iter_impl!(
 
     The class is a read-only sequence of integers instances.
 
-    This class is a container class for the results of the digraph_maximum_bisimulation funtion.
+    This class is a container class for the results of the digraph_maximum_bisimulation function.
     It implements the Python sequence
     protocol. So you can treat the return as a read-only sequence/list
     that is integer indexed. If you want to use it as an iterator you
@@ -1144,7 +1144,7 @@ custom_vec_iter_impl!(
 
     The class is a read-only sequence of :class:`.NodeIndices` instances.
 
-    This class is a container class for the results of the digraph_maximum_bisimulation funtion.
+    This class is a container class for the results of the digraph_maximum_bisimulation function.
     It implements the Python sequence
     protocol. So you can treat the return as a read-only sequence/list
     that is integer indexed. If you want to use it as an iterator you

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -237,7 +237,7 @@ pub fn digraph_random_layout(
 ///
 /// :param PyGraph graph: The graph to generate the layout for
 /// :param set first_nodes: The set of node indices on the left (or top if
-///     horitontal is true)
+///     horizontal is true)
 /// :param bool horizontal: An optional bool specifying the orientation of the
 ///     layout
 /// :param float scale: An optional scaling factor to scale positions

--- a/src/layout/spring.rs
+++ b/src/layout/spring.rs
@@ -183,7 +183,7 @@ pub fn rescale(pos: &mut [Point], scale: Nt, indices: Vec<usize>) {
     mu[0] /= n as Nt;
     mu[1] /= n as Nt;
 
-    // substract mean and find max coordinate for all axes
+    // subtract mean and find max coordinate for all axes
     let mut lim = f64::NEG_INFINITY;
     for n in indices {
         let [px, py] = pos.get_mut(n).unwrap();

--- a/src/shortest_path/all_pairs_dijkstra.rs
+++ b/src/shortest_path/all_pairs_dijkstra.rs
@@ -76,10 +76,10 @@ pub fn all_pairs_dijkstra_path_lengths<Ty: EdgeType + Sync>(
     let out_map: DictMap<usize, PathLengthMapping> = node_indices
         .into_par_iter()
         .map(|x| {
-            let path_lenghts: PyResult<Vec<Option<f64>>> =
+            let path_lengths: PyResult<Vec<Option<f64>>> =
                 dijkstra(graph, x, None, |e| edge_cost(e.id()), None);
             let out_map = PathLengthMapping {
-                path_lengths: path_lenghts
+                path_lengths: path_lengths
                     .unwrap()
                     .into_iter()
                     .enumerate()

--- a/src/shortest_path/mod.rs
+++ b/src/shortest_path/mod.rs
@@ -1361,7 +1361,7 @@ pub fn graph_num_shortest_paths_unweighted(
 ///     output distance matrix.
 /// :param float null_value: An optional float that will treated as a null
 ///     value. This element will be the default in the matrix and represents
-///     the absense of a path in the graph. By default this is ``0.0``.
+///     the absence of a path in the graph. By default this is ``0.0``.
 ///
 /// :returns: The distance matrix
 /// :rtype: numpy.ndarray
@@ -1403,7 +1403,7 @@ pub fn digraph_distance_matrix(
 ///     be tuned
 /// :param float null_value: An optional float that will treated as a null
 ///     value. This element will be the default in the matrix and represents
-///     the absense of a path in the graph. By default this is ``0.0``.
+///     the absence of a path in the graph. By default this is ``0.0``.
 ///
 /// :returns: The distance matrix
 /// :rtype: numpy.ndarray

--- a/src/steiner_tree.rs
+++ b/src/steiner_tree.rs
@@ -79,7 +79,7 @@ pub fn metric_closure(
 ///
 /// The minimum tree of ``graph`` with regard to a set of ``terminal_nodes``
 /// is a tree within ``graph`` that spans those nodes and has a minimum size
-/// (measured as the sum of edge weights) amoung all such trees.
+/// (measured as the sum of edge weights) among all such trees.
 ///
 /// The minimum steiner tree can be approximated by computing the minimum
 /// spanning tree of the subgraph of the metric closure of ``graph`` induced

--- a/src/transitivity.rs
+++ b/src/transitivity.rs
@@ -127,14 +127,14 @@ fn _digraph_triangles(graph: &digraph::PyDiGraph, node: usize) -> (usize, usize)
             .sum::<usize>();
     }
 
-    let din: usize = in_neighbors.len();
-    let dout: usize = out_neighbors.len();
+    let d_in: usize = in_neighbors.len();
+    let d_out: usize = out_neighbors.len();
 
-    let dtot = dout + din;
-    let dbil: usize = out_neighbors.intersection(&in_neighbors).count();
-    let triples: usize = match dtot {
+    let d_tot = d_out + d_in;
+    let d_bil: usize = out_neighbors.intersection(&in_neighbors).count();
+    let triples: usize = match d_tot {
         0 => 0,
-        _ => dtot * (dtot - 1) - 2 * dbil,
+        _ => d_tot * (d_tot - 1) - 2 * d_bil,
     };
 
     (triangles / 2, triples)

--- a/src/traversal/mod.rs
+++ b/src/traversal/mod.rs
@@ -64,7 +64,7 @@ use crate::iterators::EdgeList;
 /// :param int source: An optional node index to use as the starting node
 ///     for the depth-first search. The edge list will only return edges in
 ///     the components reachable from this index. If this is not specified
-///     then a source will be chosen arbitrarly and repeated until all
+///     then a source will be chosen arbitrarily and repeated until all
 ///     components of the graph are searched.
 ///
 /// :returns: A list of edges as a tuple of the form ``(source, target)`` in
@@ -109,7 +109,7 @@ pub fn digraph_dfs_edges(graph: &digraph::PyDiGraph, source: Option<usize>) -> E
 /// :param int source: An optional node index to use as the starting node
 ///     for the depth-first search. The edge list will only return edges in
 ///     the components reachable from this index. If this is not specified
-///     then a source will be chosen arbitrarly and repeated until all
+///     then a source will be chosen arbitrarily and repeated until all
 ///     components of the graph are searched.
 ///
 /// :returns: A list of edges as a tuple of the form ``(source, target)`` in
@@ -310,7 +310,7 @@ pub fn descendants(graph: &digraph::PyDiGraph, node: usize) -> HashSet<usize> {
 /// :param PyDiGraph graph: The graph to be used.
 /// :param List[int] source: An optional list of node indices to use as the starting nodes
 ///     for the breadth-first search. If this is not specified then a source
-///     will be chosen arbitrarly and repeated until all components of the
+///     will be chosen arbitrarily and repeated until all components of the
 ///     graph are searched.
 /// :param visitor: A visitor object that is invoked at the event points inside the
 ///     algorithm. This should be a subclass of :class:`~rustworkx.visit.BFSVisitor`.
@@ -403,7 +403,7 @@ pub fn digraph_bfs_search(
 /// :param PyGraph graph: The graph to be used.
 /// :param List[int] source: An optional list of node indices to use as the starting nodes
 ///     for the breadth-first search. If this is not specified then a source
-///     will be chosen arbitrarly and repeated until all components of the
+///     will be chosen arbitrarily and repeated until all components of the
 ///     graph are searched.
 /// :param visitor: A visitor object that is invoked at the event points inside the
 ///     algorithm. This should be a subclass of :class:`~rustworkx.visit.BFSVisitor`.
@@ -494,7 +494,7 @@ pub fn graph_bfs_search(
 /// :param PyDiGraph graph: The graph to be used.
 /// :param List[int] source: An optional list of node indices to use as the starting nodes
 ///     for the depth-first search. If this is not specified then a source
-///     will be chosen arbitrarly and repeated until all components of the
+///     will be chosen arbitrarily and repeated until all components of the
 ///     graph are searched.
 /// :param visitor: A visitor object that is invoked at the event points inside the
 ///     algorithm. This should be a subclass of :class:`~rustworkx.visit.DFSVisitor`.
@@ -585,7 +585,7 @@ pub fn digraph_dfs_search(
 /// :param PyGraph graph: The graph to be used.
 /// :param List[int] source: An optional list of node indices to use as the starting nodes
 ///     for the depth-first search. If this is not specified then a source
-///     will be chosen arbitrarly and repeated until all components of the
+///     will be chosen arbitrarily and repeated until all components of the
 ///     graph are searched.
 /// :param visitor: A visitor object that is invoked at the event points inside the
 ///     algorithm. This should be a subclass of :class:`~rustworkx.visit.DFSVisitor`.
@@ -658,7 +658,7 @@ pub fn graph_dfs_search(
 /// :param PyDiGraph graph: The graph to be used.
 /// :param List[int] source: An optional list of node indices to use as the starting nodes
 ///     for the dijkstra search. If this is not specified then a source
-///     will be chosen arbitrarly and repeated until all components of the
+///     will be chosen arbitrarily and repeated until all components of the
 ///     graph are searched.
 /// :param weight_fn: An optional weight function for an edge. It will accept
 ///     a single argument, the edge's weight object and will return a float which
@@ -740,7 +740,7 @@ pub fn digraph_dijkstra_search(
 /// :param PyGraph graph: The graph to be used.
 /// :param List[int] source: An optional list of node indices to use as the starting nodes
 ///     for the dijkstra search. If this is not specified then a source
-///     will be chosen arbitrarly and repeated until all components of the
+///     will be chosen arbitrarily and repeated until all components of the
 ///     graph are searched.
 /// :param weight_fn: An optional weight function for an edge. It will accept
 ///     a single argument, the edge's weight object and will return a float which

--- a/tests/digraph/test_bellman_ford.py
+++ b/tests/digraph/test_bellman_ford.py
@@ -48,11 +48,11 @@ class TestBellmanFordDiGraph(unittest.TestCase):
         g = rustworkx.PyDiGraph()
         a = g.add_node("A")
         g.add_node("B")
-        path_lenghts = rustworkx.digraph_bellman_ford_shortest_path_lengths(
+        path_lengths = rustworkx.digraph_bellman_ford_shortest_path_lengths(
             g, a, edge_cost_fn=float
         )
         expected = {}
-        self.assertEqual(expected, path_lenghts)
+        self.assertEqual(expected, path_lengths)
 
     def test_bellman_ford_path(self):
         paths = rustworkx.digraph_bellman_ford_shortest_paths(self.graph, self.a)
@@ -136,13 +136,13 @@ class TestBellmanFordDiGraph(unittest.TestCase):
         g = rustworkx.PyDiGraph()
         a = g.add_node("A")
         b = g.add_node("B")
-        path_lenghts = rustworkx.digraph_bellman_ford_shortest_path_lengths(
+        path_lengths = rustworkx.digraph_bellman_ford_shortest_path_lengths(
             g, a, edge_cost_fn=float, goal=b
         )
         expected = rustworkx.digraph_dijkstra_shortest_path_lengths(
             g, a, edge_cost_fn=float, goal=b
         )
-        self.assertEqual(expected, path_lenghts)
+        self.assertEqual(expected, path_lengths)
 
     def test_bellman_ford_with_no_path(self):
         g = rustworkx.PyDiGraph()
@@ -212,7 +212,7 @@ class TestBellmanFordDiGraph(unittest.TestCase):
         with self.assertRaises(rustworkx.NegativeCycle):
             rustworkx.bellman_ford_shortest_paths(graph, 0, weight_fn=float)
 
-    def test_raises_negative_cycle_bellman_ford_path_lenghts(self):
+    def test_raises_negative_cycle_bellman_ford_path_lengths(self):
         graph = rustworkx.PyDiGraph()
         graph.add_nodes_from(list(range(4)))
         graph.add_edges_from(
@@ -428,7 +428,7 @@ class TestBellmanFordDiGraph(unittest.TestCase):
         with self.assertRaises(rustworkx.NegativeCycle):
             rustworkx.all_pairs_bellman_ford_shortest_paths(graph, float)
 
-    def test_raises_negative_cycle_all_pairs_bellman_ford_path_lenghts(self):
+    def test_raises_negative_cycle_all_pairs_bellman_ford_path_lengths(self):
         graph = rustworkx.PyDiGraph()
         graph.add_nodes_from(list(range(4)))
         graph.add_edges_from(
@@ -449,7 +449,7 @@ class TestBellmanFordDiGraph(unittest.TestCase):
                 self.graph, len(self.graph.node_indices()) + 1, weight_fn=lambda x: float(x)
             )
 
-    def test_raises_index_error_bellman_ford_path_lenghts(self):
+    def test_raises_index_error_bellman_ford_path_lengths(self):
         with self.assertRaises(IndexError):
             rustworkx.digraph_bellman_ford_shortest_path_lengths(
                 self.graph, len(self.graph.node_indices()) + 1, edge_cost_fn=lambda x: float(x)

--- a/tests/digraph/test_bisimulation.py
+++ b/tests/digraph/test_bisimulation.py
@@ -34,7 +34,7 @@ class TestBisimulation(unittest.TestCase):
         res = rustworkx.digraph_maximum_bisimulation(graph)
         self.assertEqual(res, [])
 
-    def test_multigraph_compatability(self):
+    def test_multigraph_compatibility(self):
         graph = rustworkx.PyDiGraph()
         graph.add_nodes_from(range(5))
         graph.add_edges_from_no_data([(0, 1), (1, 4), (1, 4), (1, 4), (1, 4), (2, 3), (3, 0)])

--- a/tests/digraph/test_dijkstra.py
+++ b/tests/digraph/test_dijkstra.py
@@ -48,11 +48,11 @@ class TestDijkstraDiGraph(unittest.TestCase):
         g = rustworkx.PyDiGraph()
         a = g.add_node("A")
         b = g.add_node("B")
-        path_lenghts = rustworkx.digraph_dijkstra_shortest_path_lengths(
+        path_lengths = rustworkx.digraph_dijkstra_shortest_path_lengths(
             g, a, edge_cost_fn=float, goal=b
         )
         expected = {}
-        self.assertEqual(expected, path_lenghts)
+        self.assertEqual(expected, path_lengths)
 
     def test_dijkstra_path(self):
         paths = rustworkx.digraph_dijkstra_shortest_paths(self.graph, self.a)
@@ -318,7 +318,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
                         graph, edge_cost_fn=lambda _: invalid_weight
                     )
 
-    def all_pairs_dijkstra_lenghts_with_invalid_weights(self):
+    def all_pairs_dijkstra_lengths_with_invalid_weights(self):
         graph = rustworkx.generators.directed_path_graph(2)
         for invalid_weight in [float("nan"), -1]:
             with self.subTest(invalid_weight=invalid_weight):

--- a/tests/digraph/test_hits.py
+++ b/tests/digraph/test_hits.py
@@ -46,7 +46,7 @@
 #   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-# These tests are adapated from the networkx test cases:
+# These tests are adapted from the networkx test cases:
 # https://github.com/networkx/networkx/blob/cea310f9066efc0d5ff76f63d33dbc3eefe61f6b/networkx/algorithms/link_analysis/tests/test_pagerank.py
 
 import unittest

--- a/tests/digraph/test_k_shortest_path.py
+++ b/tests/digraph/test_k_shortest_path.py
@@ -89,8 +89,8 @@ class TestKShortestpath(unittest.TestCase):
         g = rustworkx.PyDiGraph()
         a = g.add_node("A")
         b = g.add_node("B")
-        path_lenghts = rustworkx.digraph_k_shortest_path_lengths(
+        path_lengths = rustworkx.digraph_k_shortest_path_lengths(
             g, start=a, k=1, edge_cost=float, goal=b
         )
         expected = {}
-        self.assertEqual(expected, path_lenghts)
+        self.assertEqual(expected, path_lengths)

--- a/tests/digraph/test_nodes.py
+++ b/tests/digraph/test_nodes.py
@@ -211,7 +211,7 @@ class TestNodes(unittest.TestCase):
         for weight in weights:
             dag.add_edge(nodes[0], nodes[1], weight)
             dag.add_edge(nodes[1], nodes[2], weight)
-        # The middle node has three precessor edges and three successor edges, where each set has
+        # The middle node has three predecessor edges and three successor edges, where each set has
         # one edge each of three weights. Edges should be paired up in bijection during the removal.
         dag.remove_node_retain_edges_by_id(nodes[1])
         self.assertEqual(set(dag.node_indices()), {nodes[0], nodes[2]})

--- a/tests/digraph/test_pagerank.py
+++ b/tests/digraph/test_pagerank.py
@@ -46,7 +46,7 @@
 #   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-# These tests are adapated from the networkx test cases:
+# These tests are adapted from the networkx test cases:
 # https://github.com/networkx/networkx/blob/cea310f9066efc0d5ff76f63d33dbc3eefe61f6b/networkx/algorithms/link_analysis/tests/test_pagerank.py
 
 import unittest

--- a/tests/digraph/test_pred_succ.py
+++ b/tests/digraph/test_pred_succ.py
@@ -274,7 +274,7 @@ class TestBfsSuccessors(unittest.TestCase):
             res,
         )
 
-    def test_bfs_succesors(self):
+    def test_bfs_successors(self):
         dag = rustworkx.PyDAG()
         node_a = dag.add_node(0)
         node_b = dag.add_child(node_a, 1, {})

--- a/tests/graph/test_bellman_ford.py
+++ b/tests/graph/test_bellman_ford.py
@@ -81,19 +81,19 @@ class TestBellmanFordGraph(unittest.TestCase):
         g = rustworkx.PyGraph()
         a = g.add_node("A")
         b = g.add_node("B")
-        path_lenghts = rustworkx.graph_bellman_ford_shortest_path_lengths(
+        path_lengths = rustworkx.graph_bellman_ford_shortest_path_lengths(
             g, a, edge_cost_fn=float, goal=b
         )
         expected = rustworkx.graph_dijkstra_shortest_path_lengths(g, a, edge_cost_fn=float, goal=b)
-        self.assertEqual(expected, path_lenghts)
+        self.assertEqual(expected, path_lengths)
 
     def test_bellman_ford_length_with_no_path(self):
         g = rustworkx.PyGraph()
         a = g.add_node("A")
         g.add_node("B")
-        path_lenghts = rustworkx.graph_bellman_ford_shortest_path_lengths(g, a, edge_cost_fn=float)
+        path_lengths = rustworkx.graph_bellman_ford_shortest_path_lengths(g, a, edge_cost_fn=float)
         expected = {}
-        self.assertEqual(expected, path_lenghts)
+        self.assertEqual(expected, path_lengths)
 
     def test_bellman_ford_path_with_no_goal_set(self):
         path = rustworkx.graph_bellman_ford_shortest_paths(self.graph, self.a)
@@ -175,7 +175,7 @@ class TestBellmanFordGraph(unittest.TestCase):
         with self.assertRaises(rustworkx.NegativeCycle):
             rustworkx.bellman_ford_shortest_paths(graph, 0, weight_fn=float)
 
-    def test_raises_negative_cycle_bellman_ford_path_lenghts(self):
+    def test_raises_negative_cycle_bellman_ford_path_lengths(self):
         graph = rustworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
         graph.add_edges_from(
@@ -292,7 +292,7 @@ class TestBellmanFordGraph(unittest.TestCase):
         with self.assertRaises(rustworkx.NegativeCycle):
             rustworkx.all_pairs_bellman_ford_shortest_paths(graph, float)
 
-    def test_raises_negative_cycle_all_pairs_bellman_ford_path_lenghts(self):
+    def test_raises_negative_cycle_all_pairs_bellman_ford_path_lengths(self):
         graph = rustworkx.PyGraph()
         graph.add_nodes_from(list(range(4)))
         graph.add_edges_from(
@@ -313,7 +313,7 @@ class TestBellmanFordGraph(unittest.TestCase):
                 self.graph, len(self.graph.node_indices()) + 1, weight_fn=lambda x: float(x)
             )
 
-    def test_raises_index_error_bellman_ford_path_lenghts(self):
+    def test_raises_index_error_bellman_ford_path_lengths(self):
         with self.assertRaises(IndexError):
             rustworkx.graph_bellman_ford_shortest_path_lengths(
                 self.graph, len(self.graph.node_indices()) + 1, edge_cost_fn=lambda x: float(x)

--- a/tests/graph/test_dijkstra.py
+++ b/tests/graph/test_dijkstra.py
@@ -74,11 +74,11 @@ class TestDijkstraGraph(unittest.TestCase):
         g = rustworkx.PyGraph()
         a = g.add_node("A")
         b = g.add_node("B")
-        path_lenghts = rustworkx.graph_dijkstra_shortest_path_lengths(
+        path_lengths = rustworkx.graph_dijkstra_shortest_path_lengths(
             g, a, edge_cost_fn=float, goal=b
         )
         expected = {}
-        self.assertEqual(expected, path_lenghts)
+        self.assertEqual(expected, path_lengths)
 
     def test_dijkstra_path_with_no_goal_set(self):
         path = rustworkx.graph_dijkstra_shortest_paths(self.graph, self.a)
@@ -253,7 +253,7 @@ class TestDijkstraGraph(unittest.TestCase):
                         graph, edge_cost_fn=lambda _: invalid_weight
                     )
 
-    def all_pairs_dijkstra_lenghts_with_invalid_weights(self):
+    def all_pairs_dijkstra_lengths_with_invalid_weights(self):
         graph = rustworkx.generators.path_graph(2)
         for invalid_weight in [float("nan"), -1]:
             with self.subTest(invalid_weight=invalid_weight):

--- a/tests/graph/test_k_shortest_path.py
+++ b/tests/graph/test_k_shortest_path.py
@@ -68,8 +68,8 @@ class TestKShortestpath(unittest.TestCase):
         g = rustworkx.PyGraph()
         a = g.add_node("A")
         b = g.add_node("B")
-        path_lenghts = rustworkx.graph_k_shortest_path_lengths(
+        path_lengths = rustworkx.graph_k_shortest_path_lengths(
             g, start=a, k=1, edge_cost=float, goal=b
         )
         expected = {}
-        self.assertEqual(expected, path_lenghts)
+        self.assertEqual(expected, path_lengths)

--- a/tests/graph/test_max_weight_matching.py
+++ b/tests/graph/test_max_weight_matching.py
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-# These tests are adapated from the networkx test cases:
+# These tests are adapted from the networkx test cases:
 # https://github.com/networkx/networkx/blob/3351206a3ce5b3a39bb2fc451e93ef545b96c95b/networkx/algorithms/tests/test_matching.py
 
 import random

--- a/tests/test_custom_return_types.py
+++ b/tests/test_custom_return_types.py
@@ -1200,7 +1200,7 @@ class TestAllPairsPathLengthMapping(unittest.TestCase):
     def test_str(self):
         res = rustworkx.all_pairs_dijkstra_path_lengths(self.dag, lambda _: 3.14)
         # Since all_pairs_dijkstra_path_lengths() is parallel the order of the
-        # output is non-determinisitic
+        # output is non-deterministic
         valid_values = [
             "AllPairsPathLengthMapping{1: PathLengthMapping{}, " "0: PathLengthMapping{1: 3.14}}",
             "AllPairsPathLengthMapping{"

--- a/tests/test_token_swapper.py
+++ b/tests/test_token_swapper.py
@@ -57,7 +57,7 @@ class TestGeneral(unittest.TestCase):
         self.assertEqual({i: i for i in range(8)}, permutation)
 
     def test_bug1(self) -> None:
-        """Tests for a bug that occured in happy swap chains of length >2."""
+        """Tests for a bug that occurred in happy swap chains of length >2."""
         graph = rx.PyGraph()
         graph.extend_from_edge_list(
             [(0, 1), (0, 2), (0, 3), (0, 4), (1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4), (3, 6)]

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ passenv =
 changedir = {toxinidir}/tests
 commands =
   stestr run {posargs}
-  python -c "print('\nrustworkx no longer supports tox. Please run the equivalent comand with nox:\n\n\tnox -e test\n')"
+  python -c "print('\nrustworkx no longer supports tox. Please run the equivalent command with nox:\n\n\tnox -e test\n')"
 
 [testenv:lint]
 basepython = python3
@@ -41,7 +41,7 @@ commands =
   ruff check ../rustworkx ../retworkx . ../setup.py
   cargo fmt --all -- --check
   python {toxinidir}/tools/find_stray_release_notes.py
-  python -c "print('\nrustworkx no longer supports tox. Please run the equivalent comand with nox:\n\n\tnox -e lint\n')"
+  python -c "print('\nrustworkx no longer supports tox. Please run the equivalent command with nox:\n\n\tnox -e lint\n')"
 
 
 [testenv:docs]
@@ -61,7 +61,7 @@ commands =
   python -m ipykernel install --user
   jupyter kernelspec list
   sphinx-build -W -d {toxinidir}/docs/build/.doctrees -b html source build/html {posargs}
-  python -c "print('\nrustworkx no longer supports tox. Please run the equivalent comand with nox:\n\n\tnox -e docs\n')"
+  python -c "print('\nrustworkx no longer supports tox. Please run the equivalent command with nox:\n\n\tnox -e docs\n')"
 
 [testenv:docs-clean]
 skip_install = true
@@ -69,7 +69,7 @@ deps =
 allowlist_externals = rm
 commands =
   rm -rf {toxinidir}/docs/build {toxinidir}/docs/source/apiref
-  python -c "print('\nrustworkx no longer supports tox. Please run the equivalent comand with nox:\n\n\tnox -e docs_clean\n')"
+  python -c "print('\nrustworkx no longer supports tox. Please run the equivalent command with nox:\n\n\tnox -e docs_clean\n')"
 
 [testenv:black]
 basepython = python3
@@ -78,7 +78,7 @@ deps =
   black~=24.8
 commands =
   black {posargs} '../rustworkx' '../tests' '../retworkx'
-  python -c "print('\nrustworkx no longer supports tox. Please run the equivalent comand with nox:\n\tnox -e black\n')"
+  python -c "print('\nrustworkx no longer supports tox. Please run the equivalent command with nox:\n\tnox -e black\n')"
 
 [testenv:stubs]
 basepython = python3
@@ -90,4 +90,4 @@ extras =
   graphviz
 commands =
   python -m mypy.stubtest --concise rustworkx
-  python -c "print('\nrustworkx no longer supports tox. Please run the equivalent comand with nox:\n\n\tnox -e stubs\n')"
+  python -c "print('\nrustworkx no longer supports tox. Please run the equivalent command with nox:\n\n\tnox -e stubs\n')"

--- a/typos.toml
+++ b/typos.toml
@@ -1,4 +1,0 @@
-[default]
-extend-ignore-words-re = [
-  "[Ss]toer",
-]

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,4 @@
+[default]
+extend-ignore-words-re = [
+  "[Ss]toer",
+]


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

This is a proposal to add the [typos](https://github.com/crate-ci/typos) tool to the ``lint`` session.

The patch adds the tool to the Nox ``lint`` session and fixes the reported issues. Some issues require overriding the tools decision. To limit these cases, db4c4ef does some minor renaming, which hopefully also improves the code's readability.

Since file names in `releasenotes/notes/**/*.yaml` are automatically generated, they may contain false positives. This scenario is dealt with by suppressing filename spell-checking for files under `releasenotes/`.