### PR TITLE
rustworkx-core: fix docs build warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,8 @@ jobs:
         run: pushd rustworkx-core && cargo test && popd
       - name: rustworkx-core Docs
         run: pushd rustworkx-core && cargo doc && popd
+        env:
+          RUSTDOCFLAGS: '-D warnings'
       - uses: actions/upload-artifact@v4
         with:
           name: rustworkx_core_docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,9 @@ jobs:
         with:
           python-version: "3.10"
       - run: pip install -U ruff==0.6.8 black~=24.8
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.82
         with:
-          components: rustfmt
+          components: rustfmt, clippy
       - name: Test Build
         run: cargo build
       - name: Rust Format

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,9 @@ jobs:
         with:
           python-version: "3.10"
       - run: pip install -U ruff==0.6.8 black~=24.8
-      - uses: dtolnay/rust-toolchain@1.82
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
+          components: rustfmt
       - name: Test Build
         run: cargo build
       - name: Rust Format

--- a/rustworkx-core/src/centrality.rs
+++ b/rustworkx-core/src/centrality.rs
@@ -1073,18 +1073,21 @@ mod test_katz_centrality {
 /// In the case of a graphs with more than one connected component there is
 /// an alternative improved formula that calculates the closeness centrality
 /// as "a ratio of the fraction of actors in the group who are reachable, to
-/// the average distance" [^WF]. You can enable this by setting `wf_improved` to `true`.
+/// the average distance".[^WF]
+/// You can enable this by setting `wf_improved` to `true`.
 ///
-/// [^WF] Wasserman, S., & Faust, K. (1994). Social Network Analysis:
+/// [^WF]: Wasserman, S., & Faust, K. (1994). Social Network Analysis:
 ///     Methods and Applications (Structural Analysis in the Social Sciences).
-///     Cambridge: Cambridge University Press. doi:10.1017/CBO9780511815478
+///     Cambridge: Cambridge University Press.
+///     <https://doi.org/10.1017/CBO9780511815478>
 ///
-/// Arguments:
+/// # Arguments
 ///
 /// * `graph` - The graph object to run the algorithm on
 /// * `wf_improved` - If `true`, scale by the fraction of nodes reachable.
 ///
 /// # Example
+///
 /// ```rust
 /// use rustworkx_core::petgraph;
 /// use rustworkx_core::centrality::closeness_centrality;

--- a/rustworkx-core/src/generators/dorogovtsev_goltsev_mendes_graph.rs
+++ b/rustworkx-core/src/generators/dorogovtsev_goltsev_mendes_graph.rs
@@ -16,18 +16,19 @@ use super::InvalidInputError;
 
 /// Generate a Dorogovtsev-Goltsev-Mendes graph
 ///
-/// Generate a graph following the recursive procedure in [1].
+/// Generate a graph following the recursive procedure by Dorogovtsev, Goltsev,
+/// and Mendes[^DGM2002].
 /// Starting from the two-node, one-edge graph, iterating `n` times generates
-/// a graph with `(3**n + 3) // 2` nodes and `3**n` edges.
+/// a graph with `(3^n + 3) // 2` nodes and `3^n` edges.
 ///
+/// # Arguments
 ///
-/// Arguments:
-///
-/// * `n` - The number of iterations to perform. n=0 returns the two-node, one-edge graph.
+/// * `n` - The number of iterations to perform. `n = 0` returns the two-node, one-edge graph.
 /// * `default_node_weight` - A callable that will return the weight to use for newly created nodes.
 /// * `default_edge_weight` - A callable that will return the weight object to use for newly created edges.
 ///
 /// # Example
+///
 /// ```rust
 /// use rustworkx_core::petgraph;
 /// use rustworkx_core::generators::dorogovtsev_goltsev_mendes_graph;
@@ -43,10 +44,10 @@ use super::InvalidInputError;
 /// );
 /// ```
 ///
-/// .. [1] S. N. Dorogovtsev, A. V. Goltsev and J. F. F. Mendes
+/// [^DGM2002]: S. N. Dorogovtsev, A. V. Goltsev and J. F. F. Mendes
 ///    “Pseudofractal scale-free web”
-///    Physical Review E 65, 066122, 2002
-///    https://arxiv.org/abs/cond-mat/0112143
+///    Physical Review E 65, 066122 (2002)
+///    <https://arxiv.org/abs/cond-mat/0112143>
 ///
 pub fn dorogovtsev_goltsev_mendes_graph<G, T, F, H, M>(
     n: usize,

--- a/rustworkx-core/src/steiner_tree.rs
+++ b/rustworkx-core/src/steiner_tree.rs
@@ -437,6 +437,9 @@ where
     Ok(out_edges)
 }
 
+/// Solution to a minimum Steiner tree problem.
+///
+/// This `struct` is created by the [steiner_tree] function.
 pub struct SteinerTreeResult {
     pub used_node_indices: HashSet<usize>,
     pub used_edge_endpoints: HashSet<(usize, usize)>,
@@ -454,21 +457,25 @@ pub struct SteinerTreeResult {
 /// complete graph in which each edge is weighted by the shortest path distance
 /// between nodes in ``graph``.
 ///
-/// This algorithm [1]_ produces a tree whose weight is within a
-/// :math:`(2 - (2 / t))` factor of the weight of the optimal Steiner tree
-/// where :math:`t` is the number of terminal nodes. The algorithm implemented
-/// here is due to [2]_ . It avoids computing all pairs shortest paths but rather
-/// reduces the problem to a single source shortest path and a minimum spanning tree
-/// problem.
+/// This algorithm by Kou, Markowsky, and Berman[^KouMarkowskyBerman1981]
+/// produces a tree whose weight is within a `(2 - (2 / t))` factor of
+/// the weight of the optimal Steiner tree where `t` is the number of
+/// terminal nodes.
+/// The algorithm implemented here is due to Mehlhorn[^Mehlhorn1987]. It avoids
+/// computing all pairs shortest paths but rather reduces the problem to a
+/// single source shortest path and a minimum spanning tree problem.
 ///
-/// Arguments:
-///     `graph`: The input graph to compute the steiner tree of
-///     `terminal_nodes`: The terminal nodes of the steiner tree
-///     `weight_fn`: A callable weight function that will be passed an edge reference
-///         for each edge in the graph and it is expected to return a `Result<f64>`
-///         which if it doesn't error represents the weight of that edge.
+/// # Arguments
 ///
-/// Returns a custom struct that contains a set of nodes and edges and `None`
+/// - `graph` -  The input graph to compute the Steiner tree of
+/// - `terminal_nodes` - The terminal nodes of the Steiner tree
+/// - `weight_fn` - A callable weight function that will be passed an edge reference
+///   for each edge in the graph and it is expected to return a [`Result<f64>`]
+///   which if it doesn't error represents the weight of that edge.
+///
+/// # Returns
+///
+/// A custom struct that contains a set of nodes and edges and `None`
 /// if the graph is disconnected relative to the terminal nodes.
 ///
 /// # Example
@@ -509,13 +516,14 @@ pub struct SteinerTreeResult {
 /// let tree = steiner_tree(&input_graph, &terminal_nodes, weight_fn).unwrap().unwrap();
 /// ```
 ///
-/// .. [1] Kou, Markowsky & Berman,
+/// [^KouMarkowskyBerman1981]: Kou, Markowsky & Berman,
 ///    "A fast algorithm for Steiner trees"
-///    Acta Informatica 15, 141–145 (1981).
-///    https://link.springer.com/article/10.1007/BF00288961
-/// .. [2] Kurt Mehlhorn,
+///    Acta Informatica 15, 141–145 (1981)
+///    <https://link.springer.com/article/10.1007/BF00288961>
+/// [^Mehlhorn1987]: Kurt Mehlhorn,
 ///    "A faster approximation algorithm for the Steiner problem in graphs"
-///    https://doi.org/10.1016/0020-0190(88)90066-X
+///    Information Processing Letters 27(3), 125-128 (1987)
+///    <https://doi.org/10.1016/0020-0190(88)90066-X>
 pub fn steiner_tree<G, F, E>(
     graph: G,
     terminal_nodes: &[G::NodeId],


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

Fix the warnings during the `rustworkx-core` documentation build. See e.g. [this job](https://github.com/Qiskit/rustworkx/actions/runs/12091031005/job/33718904317#step:14:72):

```
warning: unresolved link to `1`
  --> rustworkx-core/src/generators/dorogovtsev_goltsev_mendes_graph.rs:19:60
   |
19 | /// Generate a graph following the recursive procedure in [1].
   |                                                            ^ no item named `1` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
   = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: unresolved link to `1`
  --> rustworkx-core/src/generators/dorogovtsev_goltsev_mendes_graph.rs:46:9
   |
46 | /// .. [1] S. N. Dorogovtsev, A. V. Goltsev and J. F. F. Mendes
   |         ^ no item named `1` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `1`
   --> rustworkx-core/src/steiner_tree.rs:457:21
    |
457 | /// This algorithm [1]_ produces a tree whose weight is within a
    |                     ^ no item named `1` in scope
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `2`
   --> rustworkx-core/src/steiner_tree.rs:460:21
    |
460 | /// here is due to [2]_ . It avoids computing all pairs shortest paths but rather
    |                     ^ no item named `2` in scope
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `1`
   --> rustworkx-core/src/steiner_tree.rs:512:9
    |
512 | /// .. [1] Kou, Markowsky & Berman,
    |         ^ no item named `1` in scope
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `2`
   --> rustworkx-core/src/steiner_tree.rs:516:9
    |
516 | /// .. [2] Kurt Mehlhorn,
    |         ^ no item named `2` in scope
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unportable markdown
    --> rustworkx-core/src/centrality.rs:1076:27
     |
1076 | /// the average distance" [^WF]. You can enable this by setting `wf_improved` to `true`.
     |                           -^^^^
     |                           |
     |                           help: if it should not be a footnote, escape it: `\`
     |
     = note: `#[warn(rustdoc::unportable_markdown)]` on by default

warning: unportable markdown
    --> rustworkx-core/src/centrality.rs:1078:5
     |
1078 | /// [^WF] Wasserman, S., & Faust, K. (1994). Social Network Analysis:
     |     -^^^^
     |     |
     |     help: if it should not be a footnote, escape it: `\`

warning: this URL is not a hyperlink
  --> rustworkx-core/src/generators/dorogovtsev_goltsev_mendes_graph.rs:49:8
   |
49 | ///    https://arxiv.org/abs/cond-mat/0112143
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: bare URLs are not automatically turned into clickable links
   = note: `#[warn(rustdoc::bare_urls)]` on by default
help: use an automatic link instead
   |
49 | ///    <https://arxiv.org/abs/cond-mat/0112143>
   |        +                                      +

warning: this URL is not a hyperlink
   --> rustworkx-core/src/steiner_tree.rs:515:8
    |
515 | ///    https://link.springer.com/article/10.1007/BF00288961
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
help: use an automatic link instead
    |
515 | ///    <https://link.springer.com/article/10.1007/BF00288961>
    |        +                                                    +

warning: this URL is not a hyperlink
   --> rustworkx-core/src/steiner_tree.rs:518:8
    |
518 | ///    https://doi.org/10.1016/0020-0190(88)90066-X
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: bare URLs are not automatically turned into clickable links
help: use an automatic link instead
    |
518 | ///    <https://doi.org/10.1016/0020-0190>(88)90066-X
    |        +                                 +
```

2a61e43  fails the `rustworkx-core` documentation build step to avoid regressions. The change could be reverted on similar ground to https://github.com/Qiskit/rustworkx/pull/1330#pullrequestreview-2456990762.