### PR TITLE
Silence rust clippy lint enabled after the 1.84 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,12 @@ version = "^0.11"
 default-features = false
 features = ["multi_thread"]
 
+[features]
+default = []
+# TODO: remove this once PyO3 is updated to 0.23. Currently, this is a bug in PyO3 0.22
+# that leaks some of their features in a public macro. However, this was removed in 0.23.
+gil-refs = ["pyo3/gil-refs"]
+
 [profile.release]
 lto = 'fat'
 codegen-units = 1

--- a/rustworkx-core/src/dag_algo.rs
+++ b/rustworkx-core/src/dag_algo.rs
@@ -326,6 +326,7 @@ where
     let mut v = *first;
     let mut u: Option<G::NodeId> = None;
     // Backtrack from this node to find the path
+    #[allow(clippy::unnecessary_map_or)]
     while u.map_or(true, |u| u != v) {
         path.push(v);
         u = Some(v);


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

[In short the new clippy lint suggests us to replace `map_or` with `is_none_or`.](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or)

But `is_none_or` is only available for Rust 1.82 or newer (https://doc.rust-lang.org/std/option/enum.Option.html#method.is_none_or). So we can revisit this but at the time it is best to ignore