### PR TITLE
Add one-off Arm64 build workflow to 0.16 musl

### DIFF
--- a/.github/workflows/wheels_aarch64.yml
+++ b/.github/workflows/wheels_aarch64.yml
@@ -5,39 +5,6 @@ on:
     branches:
       - 'stable/**'
 jobs:
-  build_wheels_aarch64:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    environment: release
-    permissions:
-      id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04-arm]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        name: Install Python
-        with:
-          python-version: '3.10'
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel==2.21.3
-      - name: Build wheels
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_SKIP: cp36-* cp37-* pp* *musl*
-      - uses: actions/upload-artifact@v4
-        with:
-          path: ./wheelhouse/*.whl
-          name: wheel-builds-aarch64
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: wheelhouse/
   build_wheels_musl_aarch64:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/wheels_aarch64.yml
+++ b/.github/workflows/wheels_aarch64.yml
@@ -1,0 +1,66 @@
+---
+name: Wheels for Aarch64 (Ad-Hoc)
+on:
+  push:
+    branches:
+      - 'stable/**'
+jobs:
+  build_wheels_aarch64:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    environment: release
+    permissions:
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04-arm]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: '3.10'
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel==2.21.3
+      - name: Build wheels
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_SKIP: cp36-* cp37-* pp* *musl*
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: wheel-builds-aarch64
+  build_wheels_musl_aarch64:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    environment: release
+    permissions:
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04-arm]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: '3.10'
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel==2.21.3
+      - name: Build wheels
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_SKIP: cp36-* cp37-* cp38-* *many*
+          CIBW_TEST_SKIP: cp39-* cp310-* cp311-* cp312-* *many*
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: wheel-builds-musl-aarch64

--- a/.github/workflows/wheels_aarch64.yml
+++ b/.github/workflows/wheels_aarch64.yml
@@ -34,6 +34,10 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
           name: wheel-builds-aarch64
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheelhouse/
   build_wheels_musl_aarch64:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -64,3 +68,7 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
           name: wheel-builds-musl-aarch64
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheelhouse/


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Related to #1372 

In short this PR will trigger an Arm64 for musllinux build on push, it will succeed and then we'll delete it in a follow up PR

