### PR TITLE
Bump version strings post release

### DIFF
--- a/.github/.mergify.yml
+++ b/.github/.mergify.yml
@@ -5,4 +5,4 @@ pull_request_rules:
     actions:
       backport:
         branches:
-          - stable/0.15
+          - stable/0.16

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustworkx"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ahash",
  "fixedbitset",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "rustworkx-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ahash",
  "fixedbitset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Matthew Treinish <mtreinish@kortar.org>"]
@@ -59,7 +59,7 @@ rayon.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = { version = "1.0", features = ["union"] }
-rustworkx-core = { path = "rustworkx-core", version = "=0.16.0" }
+rustworkx-core = { path = "rustworkx-core", version = "=0.17.0" }
 flate2 = "1.0.35"
 
 [dependencies.pyo3]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,9 +24,9 @@ copyright = '2021, rustworkx Contributors'
 docs_url_prefix = ""
 
 # The short X.Y version.
-version = '0.16'
+version = '0.17'
 # The full version, including alpha/beta/rc tags.
-release = '0.16.0'
+release = '0.17.0'
 
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.autosummary',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ mpl_extras = ["matplotlib>=3.0"]
 graphviz_extras = ["pillow>=5.4"]
 
 PKG_NAME = os.getenv("RUSTWORKX_PKG_NAME", "rustworkx")
-PKG_VERSION = "0.16.0"
+PKG_VERSION = "0.17.0"
 PKG_PACKAGES = ["rustworkx", "rustworkx.visualization"]
 PKG_INSTALL_REQUIRES = ["numpy>=1.16.0,<3"]
 RUST_EXTENSIONS = [RustExtension("rustworkx.rustworkx", "Cargo.toml",


### PR DESCRIPTION
Now that rustworkx 0.16.0 has been released this commit bumps all the version strings for the rustworkx and rustworkx-core to be 0.17.0. This now indicates the development version on the main branch is 0.17.0 and differentiates it from the released 0.16.0.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
