### PR TITLE
Bump GH Actions version to fix documentation publishing

### DIFF
--- a/.github/workflows/docs_dev.yml
+++ b/.github/workflows/docs_dev.yml
@@ -28,12 +28,12 @@ jobs:
       run: |
         tools/build_documentation_dev.sh
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
       with:
         name: html_docs
         path: docs/build/html
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages

--- a/.github/workflows/docs_release.yml
+++ b/.github/workflows/docs_release.yml
@@ -29,12 +29,12 @@ jobs:
       run: |
         tools/build_documentation_release.sh
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
       with:
         name: html_docs
         path: release_docs/
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

We ignored a warning and now the docs publishing job is broken: https://github.com/Qiskit/rustworkx/actions/runs/13105099930/job/36558547792

I think just bumping the version of the actions will fix
