### PR TITLE
Fix some typos in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ are no changes made to the rust code. To avoid this you can use the
 `--no-install` package if you'd like to rerun tests without recompiling.
 Note, you only want to use this flag if you recently ran Nox and there are no
 rust code (or packaged python code) changes to the repo since then. Otherwise
-the rustworkx package Nox installs in it's virtualenv will be out of date (or
+the rustworkx package Nox installs in its virtualenv will be out of date (or
 missing).
 
 Note, if you run tests outside of Nox that you can **not** run the tests from
@@ -194,8 +194,8 @@ the run finishes so you can inspect the output.
 
 #### rustworkx-core tests
 
-As rustworkx-core is a standalone rust crate with it's own public interface it
-needs it's own testing. These tests can be a combination of doc tests (embedded
+As rustworkx-core is a standalone rust crate with its own public interface it
+needs its own testing. These tests can be a combination of doc tests (embedded
 code examples in the docstrings in the rust code) or standalone tests. You
 can refer to the rust book on how to add tests:
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ environment.
 ### Installing on a platform without precompiled binaries
 
 If there are no precompiled binaries published for your system you'll have to
-build the package from source. However, to be able able to build the package
+build the package from source. However, to be able to build the package
 from the published source package you need to have Rust >= 1.70 installed (and
 also [cargo](https://doc.rust-lang.org/cargo/) which is normally included with
 rust) You can use [rustup](https://rustup.rs/) (a cross platform installer for
@@ -177,6 +177,6 @@ NetworkX usage (hence the original name).  The project was originally started
 to build a faster directed graph to use as the underlying data structure for
 the DAG at the center of
 [qiskit](https://github.com/Qiskit/qiskit/)'s transpiler. However,
-since it's initial introduction the project has grown substantially and now
+since its initial introduction the project has grown substantially and now
 covers all applications that need to work with graphs which includes
 Qiskit.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -25,7 +25,7 @@ Installing on a platform without precompiled binaries
 -----------------------------------------------------
 
 If there are no precompiled binaries published for your system you'll have to
-build the package from source. However, to be able able to build the package from
+build the package from source. However, to be able to build the package from
 the published source package you need to have Rust >= 1.64 installed (and also
 cargo which is normally included with rust) You can use
 `rustup <https://rustup.rs/>`_ (a cross platform installer for rust) to make this

--- a/docs/source/networkx.rst
+++ b/docs/source/networkx.rst
@@ -327,7 +327,7 @@ graph and matrices in other libraries. This includes ``to_numpy_matrix()``,
 adjacency matrix).
 
 However, in rustworkx there is **only** a :meth:`~rustworkx.adjacency_matrix`
-function (and it's per type variants :meth:`~rustworkx.digraph_adjacency_matrix`
+function (and its per type variants :meth:`~rustworkx.digraph_adjacency_matrix`
 and :meth:`~rustworkx.graph_adjacency_matrix`) which will return a numpy array
 of the adjacency matrix (**not** a scipy csr sparse matrix like networkx's
 function). This function is equivalent to networkx's ``to_numpy_array()``

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -185,7 +185,7 @@ New Features
   :meth:`~rustworkx.PyDiGraph.insert_node_on_in_edges_multiple`, and
   :meth:`~rustworkx.PyDiGraph.insert_node_on_out_edges_multiple` were added to
   :class:`~rustworkx.PyDiGraph`. These functions are used to insert an existing
-  node in between an reference node(s) and all it's predecessors or successors.
+  node in between an reference node(s) and all its predecessors or successors.
 - Two new functions, :func:`~rustworkx.graph_dfs_edges` and
   :func:`~rustworkx.digraph_dfs_edges`, were added to get an edge list in depth
   first order from a :class:`~rustworkx.PyGraph` and
@@ -356,7 +356,7 @@ Upgrade Notes
 -------------
 
 - The :class:`~rustworkx.PyDAG` class was renamed :class:`~rustworkx.PyDiGraph`
-  to better reflect it's functionality. For backwards compatibility
+  to better reflect its functionality. For backwards compatibility
   :class:`~rustworkx.PyDAG` still exists as a Python subclass of
   :class:`~rustworkx.PyDiGraph`. No changes should be required for existing
   users.

--- a/docs/source/tutorial/dags.rst
+++ b/docs/source/tutorial/dags.rst
@@ -205,7 +205,7 @@ performed is:
 
     # Equivalency matrix
     translation_matrix = {"h": ["rz(pi/2)", "sx", "rz(pi/2)"]}
-    # Insructions natively supported on target QPU
+    # Instructions natively supported on target QPU
     hardware_instructions = {"measure", "cx", "sx", "rz", "x"}
 
     # Iterate over instructions in order and replace gates outside of native

--- a/docs/source/tutorial/introduction.rst
+++ b/docs/source/tutorial/introduction.rst
@@ -97,7 +97,7 @@ In the above cases, we were adding nodes with a data payload of type integer (e.
 However, rustworkx doesn't place constraints on what the node data payload can
 be, so you can use more involved objects including types which are not
 `hashable <https://docs.python.org/3/glossary.html#term-hashable>`__. For
-example, we can add a node with a data payload that's a a
+example, we can add a node with a data payload that's a
 `dict <https://docs.python.org/3/library/stdtypes.html#dict>`__:
 
 .. jupyter-execute::
@@ -219,7 +219,7 @@ Modifying elements of a graph
 
 The graph classes in rustworkx also allow for in place mutation of the payloads
 for elements in the graph. For nodes you can simply use the mapping protocol to
-change the payload via it's node index. For example:
+change the payload via its node index. For example:
 
 .. jupyter-execute::
 

--- a/rustworkx-core/README.md
+++ b/rustworkx-core/README.md
@@ -18,7 +18,7 @@ that offers a general purpose high performance graph library written in Rust,
 rustworkx-core is a pure rust library that offers a stable rust API for any
 downstream crate that need it.
 
-At it's core rustworkx is built on top of the
+At its core rustworkx is built on top of the
 [petgraph](https://github.com/petgraph/petgraph) library and wraps it in a
 Python layer. However, many of the algorithms (and to a lesser extent data
 structures) needed for rustworkx are not available in petgraph. For places

--- a/rustworkx/__init__.py
+++ b/rustworkx/__init__.py
@@ -125,7 +125,7 @@ class PyDAG(PyDiGraph):
         ``PyDAG`` has runtime cycle detection enabled.
     :param bool multgraph: When this is set to ``False`` the created
         ``PyDAG`` object will not be a multigraph. When ``False`` if a method
-        call is made that would add parallel edges the the weight/weight from
+        call is made that would add parallel edges the weight/weight from
         that method call will be used to update the existing edge in place.
     """
 
@@ -596,7 +596,7 @@ def k_shortest_path_lengths(graph, start, k, edge_cost, goal=None):
     :param int start: The node index to find the shortest paths from
     :param int k: The kth shortest path to find the lengths of
     :param edge_cost: A python callable that will receive an edge payload and
-        return a float for the cost of that eedge
+        return a float for the cost of that edge
     :param int goal: An optional goal node index, if specified the output
         dictionary
 
@@ -732,7 +732,7 @@ def is_isomorphic_node_match(first, second, matcher, id_order=True):
         It should be the same type as the first graph.
     :param callable matcher: A python callable object that takes 2 positional
         one for each node data object. If the return of this
-        function evaluates to True then the nodes passed to it are vieded
+        function evaluates to True then the nodes passed to it are viewed
         as matching.
     :param bool id_order: If set to ``False`` this function will use a
         heuristic matching order based on [VF2]_ paper. Otherwise it will
@@ -1144,7 +1144,7 @@ def closeness_centrality(graph, wf_improved=True):
 
     The closeness centrality of a node :math:`u` is defined as the
     reciprocal of the average shortest path distance to :math:`u` over all
-    :math:`n-1` reachable nodes in the graph. In it's general form this can
+    :math:`n-1` reachable nodes in the graph. In its general form this can
     be expressed as:
 
     .. math::

--- a/src/centrality.rs
+++ b/src/centrality.rs
@@ -265,7 +265,7 @@ pub fn out_degree_centrality(graph: &digraph::PyDiGraph) -> PyResult<CentralityM
 ///
 /// The closeness centrality of a node :math:`u` is defined as the
 /// reciprocal of the average shortest path distance to :math:`u` over all
-/// :math:`n-1` reachable nodes in the graph. In it's general form this can
+/// :math:`n-1` reachable nodes in the graph. In its general form this can
 /// be expressed as:
 ///
 /// .. math::
@@ -313,7 +313,7 @@ pub fn graph_closeness_centrality(graph: &graph::PyGraph, wf_improved: bool) -> 
 ///
 /// The closeness centrality of a node :math:`u` is defined as the
 /// reciprocal of the average shortest path distance to :math:`u` over all
-/// :math:`n-1` reachable nodes in the graph. In it's general form this can
+/// :math:`n-1` reachable nodes in the graph. In its general form this can
 /// be expressed as:
 ///
 /// .. math::

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -805,7 +805,7 @@ pub fn connected_subgraphs(graph: &PyGraph, k: usize) -> PyResult<Vec<Vec<usize>
 ///     of paths. By default includes all paths regardless of depth, setting to
 ///     0 will behave like default.
 ///
-/// :returns: A mapping of node indices to to a mapping of target node
+/// :returns: A mapping of node indices to a mapping of target node
 ///     indices to a list of paths between the source and target nodes.
 /// :rtype: AllPairsMultiplePathMapping
 ///
@@ -990,7 +990,7 @@ pub fn digraph_core_number(py: Python, graph: &digraph::PyDiGraph) -> PyResult<P
 /// :param PyGraph: The graph to be used
 /// :param Callable weight_fn:  An optional callable object (function, lambda, etc) which
 ///     will be passed the edge object and expected to return a ``float``.
-///     Edges with ``NaN`` weights will be ignored, i.e it's conidered to have zero weight.
+///     Edges with ``NaN`` weights will be ignored, i.e it's considered to have zero weight.
 ///     If ``weight_fn`` is not specified a default value of ``1.0`` will be used for all edges.
 ///
 /// :returns: A tuple with the minimum cut value and a list of all

--- a/src/dag_algo/mod.rs
+++ b/src/dag_algo/mod.rs
@@ -279,7 +279,7 @@ pub fn is_directed_acyclic_graph(graph: &digraph::PyDiGraph) -> bool {
 /// :param PyDiGraph graph: The DAG to get the layers from
 /// :param list first_layer: A list of node ids for the first layer. This
 ///     will be the first layer in the output
-/// :param bool index_output: When set to to ``True`` the output layers will be
+/// :param bool index_output: When set to ``True`` the output layers will be
 ///     a list of integer node indices.
 ///
 /// :returns: A list of layers, each layer is a list of node data, or if

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -171,7 +171,7 @@ use super::dag_algo::is_directed_acyclic_graph;
 ///     ``PyDiGraph`` has runtime cycle detection enabled.
 /// :param bool multigraph: When this is set to ``False`` the created
 ///     ``PyDiGraph`` object will not be a multigraph. When ``False`` if a
-///     method call is made that would add parallel edges the the weight/weight
+///     method call is made that would add parallel edges the weight/weight
 ///     from that method call will be used to update the existing edge in place.
 /// :param attrs: An optional attributes payload to assign to the
 ///     :attr:`~.PyDiGraph.attrs` attribute. This can be any Python object. If
@@ -2540,7 +2540,7 @@ impl PyDiGraph {
             DictMap::with_capacity(other.node_count());
 
         // TODO: Reimplement this without looping over the graphs
-        // Loop over other nodes add add to self graph
+        // Loop over other nodes add to self graph
         for node in other.graph.node_indices() {
             let new_index = self.graph.add_node(weight_transform_callable(
                 py,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -135,7 +135,7 @@ use petgraph::visit::{
 ///
 /// :param bool multigraph: When this is set to ``False`` the created PyGraph
 ///     object will not be a multigraph. When ``False`` if a method call is
-///     made that would add parallel edges the the weight/weight from that
+///     made that would add parallel edges the weight/weight from that
 ///     method call will be used to update the existing edge in place.
 /// :param attrs: An optional attributes payload to assign to the
 ///     :attr:`~.PyGraph.attrs` attribute. This can be any Python object. If
@@ -1665,7 +1665,7 @@ impl PyGraph {
             DictMap::with_capacity(other.node_count());
 
         // TODO: Reimplement this without looping over the graphs
-        // Loop over other nodes add add to self graph
+        // Loop over other nodes add to self graph
         for node in other.graph.node_indices() {
             let new_index = self.graph.add_node(weight_transform_callable(
                 py,

--- a/tests/graph/test_max_weight_matching.py
+++ b/tests/graph/test_max_weight_matching.py
@@ -30,7 +30,7 @@ class TestMaxWeightMatching(unittest.TestCase):
         for u, v in rx_match:
             if (u, v) not in expected_match and (v, u) not in expected_match:
                 self.fail(
-                    f"Element {(u, v)} and it's reverse {(v, u)} not found in "
+                    f"Element {(u, v)} and its reverse {(v, u)} not found in "
                     f"expected output.\nrustworkx output: {rx_match}\nexpected "
                     f"output: {expected_match}"
                 )

--- a/tests/graph/test_steiner_tree.py
+++ b/tests/graph/test_steiner_tree.py
@@ -73,7 +73,7 @@ class TestSteinerTree(unittest.TestCase):
                     found = True
             if not found:
                 self.fail(
-                    f"edge: {edge} nor it's reverse not found in metric "
+                    f"edge: {edge} nor its reverse not found in metric "
                     f"closure output:\n{pprint.pformat(edges)}"
                 )
 


### PR DESCRIPTION
Fix some repeated words, it's/its, and a few typos.
