### PR TITLE
Consolidate Python docstrings in graph.rs

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -137,7 +137,7 @@ use petgraph::visit::{
 ///     object will not be a multigraph. When ``False`` if a method call is
 ///     made that would add parallel edges the weight/weight from that
 ///     method call will be used to update the existing edge in place.
-/// :param attrs: An optional attributes payload to assign to the
+/// :param Any attrs: An optional attributes payload to assign to the
 ///     :attr:`~.PyGraph.attrs` attribute. This can be any Python object. If
 ///     it is not specified :attr:`~.PyGraph.attrs` will be set to ``None``.
 /// :param int node_count_hint: An optional hint that will allocate enough capacity to store this
@@ -364,7 +364,7 @@ impl PyGraph {
 
     /// Detect if the graph has parallel edges or not
     ///
-    /// :returns: ``True`` if the graph has parallel edges, otherwise ``False``
+    /// :returns: ``True`` if the graph has parallel edges, ``False`` otherwise
     /// :rtype: bool
     #[pyo3(text_signature = "(self)")]
     fn has_parallel_edges(&self) -> bool {
@@ -402,7 +402,7 @@ impl PyGraph {
     /// Return a list of all edge data.
     ///
     /// :returns: A list of all the edge data objects in the graph
-    /// :rtype: list
+    /// :rtype: list[Any]
     #[pyo3(text_signature = "(self)")]
     pub fn edges(&self) -> Vec<&PyObject> {
         self.graph
@@ -424,6 +424,9 @@ impl PyGraph {
 
     /// Return a list of indices of all edges between specified nodes
     ///
+    /// :param int node_a: The index of the first node
+    /// :param int node_b: The index of the second node
+    ///
     /// :returns: A list of all the edge indices connecting the specified start and end node
     /// :rtype: EdgeIndices
     pub fn edge_indices_from_endpoints(&self, node_a: usize, node_b: usize) -> EdgeIndices {
@@ -443,7 +446,7 @@ impl PyGraph {
     /// Return a list of all node data.
     ///
     /// :returns: A list of all the node data objects in the graph
-    /// :rtype: list
+    /// :rtype: list[Any]
     #[pyo3(text_signature = "(self)")]
     pub fn nodes(&self) -> Vec<&PyObject> {
         self.graph
@@ -478,11 +481,11 @@ impl PyGraph {
         self.node_indices()
     }
 
-    /// Return True if there is a node.
+    /// Check if the node exists in the graph.
     ///
-    /// :param int node: The index for the node
+    /// :param int node: The index of the node
     ///
-    /// :returns: True if there is a node false if there is no node
+    /// :returns: ``True`` if the node exists, ``False`` otherwise
     /// :rtype: bool
     #[pyo3(text_signature = "(self, node, /)")]
     pub fn has_node(&self, node: usize) -> bool {
@@ -490,12 +493,12 @@ impl PyGraph {
         self.graph.contains_node(index)
     }
 
-    /// Return True if there is an edge between ``node_a`` and ``node_b``.
+    /// Check if there is a direct edge between ``node_a`` and ``node_b``.
     ///
-    /// :param int node_a: The index for the first node
-    /// :param int node_b: The index for the second node
+    /// :param int node_a: The index of the first node
+    /// :param int node_b: The index of the second node
     ///
-    /// :returns: True if there is an edge false if there is no edge
+    /// :returns: ``True`` if the edge exists, ``False`` otherwise
     /// :rtype: bool
     #[pyo3(text_signature = "(self, node_a, node_b, /)")]
     pub fn has_edge(&self, node_a: usize, node_b: usize) -> bool {
@@ -510,10 +513,11 @@ impl PyGraph {
     ///  returned. To get all edge data objects use
     ///  :meth:`~rustworkx.PyGraph.get_all_edge_data`
     ///
-    /// :param int node_a: The index for the first node
-    /// :param int node_b: The index for the second node
+    /// :param int node_a: The index of the first node
+    /// :param int node_b: The index of the second node
     ///
     /// :returns: The data object set for the edge
+    /// :rtype: Any
     /// :raises NoEdgeBetweenNodes: when there is no edge between the provided
     ///     nodes
     #[pyo3(text_signature = "(self, node_a, node_b, /)")]
@@ -682,6 +686,7 @@ impl PyGraph {
     /// :param int edge_index: The edge index to get the data for
     ///
     /// :returns: The data object for the edge
+    /// :rtype: Any
     /// :raises IndexError: when there is no edge present with the provided
     ///     index
     #[pyo3(text_signature = "(self, edge_index, /)")]
@@ -703,7 +708,7 @@ impl PyGraph {
     /// :param int edge_index: The edge index to get the endpoints for
     ///
     /// :returns: The endpoint tuple for the edge
-    /// :rtype: tuple
+    /// :rtype: tuple[int, int]
     /// :raises IndexError: when there is no edge present with the provided
     ///     index
     #[pyo3(text_signature = "(self, edge_index, /)")]
@@ -727,8 +732,8 @@ impl PyGraph {
     /// edges get updated you should use
     /// :meth:`~rustworkx.PyGraph.update_edge_by_index` instead.
     ///
-    /// :param int source: The index for the first node
-    /// :param int target: The index for the second node
+    /// :param int source: The index of the first node
+    /// :param int target: The index of the second node
     ///
     /// :raises NoEdgeBetweenNodes: When there is no edge between nodes
     #[pyo3(text_signature = "(self, source, target, edge, /)")]
@@ -746,8 +751,8 @@ impl PyGraph {
 
     /// Update an edge's weight/data payload in place by the edge index
     ///
-    /// :param int edge_index: The index for the edge
-    /// :param object edge: The data payload/weight to update the edge with
+    /// :param int edge_index: The index of the edge
+    /// :param Any edge: The python object to attach to the edge
     ///
     /// :raises IndexError: when there is no edge present with the provided
     ///     index
@@ -762,9 +767,10 @@ impl PyGraph {
 
     /// Return the node data for a given node index
     ///
-    /// :param int node: The index for the node
+    /// :param int node: The index of the node
     ///
     /// :returns: The data object set for that node
+    /// :rtype: Any
     /// :raises IndexError: when an invalid node index is provided
     #[pyo3(text_signature = "(self, node, /)")]
     pub fn get_node_data(&self, node: usize) -> PyResult<&PyObject> {
@@ -778,11 +784,11 @@ impl PyGraph {
 
     /// Return the edge data for all the edges between 2 nodes.
     ///
-    /// :param int node_a: The index for the first node
-    /// :param int node_b: The index for the second node
+    /// :param int node_a: The index of the first node
+    /// :param int node_b: The index of the second node
     ///
     /// :returns: A list with all the data objects for the edges between nodes
-    /// :rtype: list
+    /// :rtype: list[Any]
     /// :raises NoEdgeBetweenNodes: When there is no edge between nodes
     #[pyo3(text_signature = "(self, node_a, node_b, /)")]
     pub fn get_all_edge_data(&self, node_a: usize, node_b: usize) -> PyResult<Vec<&PyObject>> {
@@ -847,8 +853,7 @@ impl PyGraph {
     /// Get an edge index map
     ///
     /// Returns a read only mapping from edge indices to the weighted edge
-    /// tuple. The return is a mapping of the form:
-    /// ``{0: (0, 1, "weight"), 1: (2, 3, 2.3)}``
+    /// tuple in the form: ``{0: (0, 1, "weight"), 1: (2, 3, 2.3)}``
     ///
     /// :returns: An edge index map
     /// :rtype: EdgeIndexMap
@@ -891,12 +896,11 @@ impl PyGraph {
     /// exists between ``node_a`` and ``node_b`` the weight/payload of that
     /// existing edge will be updated to be ``edge``.
     ///
-    /// :param int node_a: Index of the parent node
-    /// :param int node_b: Index of the child node
-    /// :param edge: The object to set as the data for the edge. It can be any
-    ///     python object.
+    /// :param int node_a: The index of the parent node
+    /// :param int node_b: The index of the child node
+    /// :param Any edge: The python object to attach to the edge
     ///
-    /// :returns: The edge index for the newly created (or updated in the case
+    /// :returns: The index of the newly created (or updated in the case
     ///     of an existing edge with ``multigraph=False``) edge.
     /// :rtype: int
     #[pyo3(text_signature = "(self, node_a, node_b, edge, /)")]
@@ -913,7 +917,7 @@ impl PyGraph {
 
     /// Add new edges to the graph.
     ///
-    /// :param iterable obj_list: An iterable of tuples of the form
+    /// :param iterable[tuple[int, int, Any]] obj_list: An iterable of tuples of the form
     ///     ``(node_a, node_b, obj)`` to attach to the graph. ``node_a`` and
     ///     ``node_b`` are integer indices describing where an edge should be
     ///     added, and ``obj`` is the python object for the edge data.
@@ -924,8 +928,8 @@ impl PyGraph {
     /// from ``obj_list`` so if there are multiple parallel edges in ``obj_list``
     /// the last entry will be used.
     ///
-    /// :returns: A list of int indices of the newly created edges
-    /// :rtype: list
+    /// :returns: A list of indices of the newly created edges
+    /// :rtype: EdgeIndices
     #[pyo3(text_signature = "(self, obj_list, /)")]
     pub fn add_edges_from(&mut self, obj_list: Bound<'_, PyAny>) -> PyResult<EdgeIndices> {
         let mut out_list = Vec::new();
@@ -938,7 +942,7 @@ impl PyGraph {
 
     /// Add new edges to the graph without python data.
     ///
-    /// :param iterable obj_list: An iterable of tuples of the form
+    /// :param iterable[tuple[int, int]] obj_list: An iterable of tuples of the form
     ///     ``(parent, child)`` to attach to the graph. ``parent`` and
     ///     ``child`` are integer indices describing where an edge should be
     ///     added. Unlike :meth:`add_edges_from` there is no data payload and
@@ -948,8 +952,8 @@ impl PyGraph {
     /// exists between ``node_a`` and ``node_b`` the weight/payload of that
     /// existing edge will be updated to be ``None``.
     ///
-    /// :returns: A list of int indices of the newly created edges
-    /// :rtype: list
+    /// :returns: A list of indices of the newly created edges
+    /// :rtype: EdgeIndices
     #[pyo3(text_signature = "(self, obj_list, /)")]
     pub fn add_edges_from_no_data(
         &mut self,
@@ -973,8 +977,9 @@ impl PyGraph {
     /// exists between ``node_a`` and ``node_b`` the weight/payload of that
     /// existing edge will be updated to be ``None``.
     ///
-    /// :param iterable edge_list: An iterable of tuples of the form ``(source, target)``
-    ///     where source and target are integer node indices. If the node index
+    /// :param iterable[tuple[int, int]] edge_list: An iterable of tuples
+    ///     in the form ``(source, target)`` where ``source`` and ``target``
+    ///     are integer node indices. If the node index
     ///     is not present in the graph, nodes will be added (with a node
     ///     weight of ``None``) to that index.
     #[pyo3(text_signature = "(self, edge_list, /)")]
@@ -1007,7 +1012,7 @@ impl PyGraph {
     /// from ``obj_list`` so if there are multiple parallel edges in ``obj_list``
     /// the last entry will be used.
     ///
-    /// :param iterable edge_list: An iterable of tuples of the form
+    /// :param iterable[tuple[int, int, Any]] edge_list: An iterable of tuples in the form
     ///     ``(source, target, weight)`` where source and target are integer
     ///     node indices. If the node index is not present in the graph,
     ///     nodes will be added (with a node weight of ``None``) to that index.
@@ -1035,10 +1040,10 @@ impl PyGraph {
     /// Note if there are multiple edges between the specified nodes only one
     /// will be removed.
     ///
-    /// :param int parent: The index for the parent node.
-    /// :param int child: The index of the child node.
+    /// :param int parent: The index of the parent node
+    /// :param int child: The index of the child node
     ///
-    /// :raises NoEdgeBetweenNodes: If there are no edges between the nodes
+    /// :raises NoEdgeBetweenNodes: If there is no edge between the nodes
     ///     specified
     #[pyo3(text_signature = "(self, node_a, node_b, /)")]
     pub fn remove_edge(&mut self, node_a: usize, node_b: usize) -> PyResult<()> {
@@ -1067,8 +1072,8 @@ impl PyGraph {
     /// Note if there are multiple edges between the specified nodes only one
     /// will be removed.
     ///
-    /// :param iterable index_list: An iterable of node index pairs to remove from
-    ///     the graph
+    /// :param iterable[tuple[int, int]] index_list: An iterable of node index pairs
+    ///     to remove from the graph
     ///
     /// :raises NoEdgeBetweenNodes: If there are no edges between a specified
     ///     pair of nodes.
@@ -1088,7 +1093,7 @@ impl PyGraph {
 
     /// Add a new node to the graph.
     ///
-    /// :param obj: The python object to attach to the node
+    /// :param Any obj: The python object to attach to the node
     ///
     /// :returns: The index of the newly created node
     /// :rtype: int
@@ -1100,9 +1105,9 @@ impl PyGraph {
 
     /// Add new nodes to the graph.
     ///
-    /// :param iterable obj_list: An iterable of python object to attach to the graph.
+    /// :param iterable[Any] obj_list: An iterable of python object to attach to the graph
     ///
-    /// :returns indices: A list of int indices of the newly created nodes
+    /// :returns indices: A list of indices of the newly created nodes
     /// :rtype: NodeIndices
     #[pyo3(text_signature = "(self, obj_list, /)")]
     pub fn add_nodes_from(&mut self, obj_list: Bound<'_, PyAny>) -> PyResult<NodeIndices> {
@@ -1119,7 +1124,7 @@ impl PyGraph {
     /// If a node index in the list is not present in the graph it will be
     /// ignored.
     ///
-    /// :param iterable index_list: An iterable of node indices to remove from the
+    /// :param iterable[int] index_list: An iterable of node indices to remove from the
     ///     graph
     #[pyo3(text_signature = "(self, index_list, /)")]
     pub fn remove_nodes_from(&mut self, index_list: Bound<'_, PyAny>) -> PyResult<()> {
@@ -1136,7 +1141,7 @@ impl PyGraph {
     /// indices in order. If there is more than one node in the graph with the
     /// same weight only the first match (by node index) will be returned.
     ///
-    /// :param obj: The weight to look for in the graph.
+    /// :param Any obj: The weight to look for in the graph.
     ///
     /// :returns: the index of the first node in the graph that is equal to the
     ///     weight. If no match is found ``None`` will be returned.
@@ -1154,12 +1159,12 @@ impl PyGraph {
     /// in the case of multigraphs only a single edge data object will be
     /// returned
     ///
-    /// :param int node: The index of the node to get the neighbors
+    /// :param int node: The index of the node to get the neighbors of
     ///
     /// :returns neighbors: A dictionary where the keys are node indices and
     ///     the value is the edge data object for all nodes that share an
     ///     edge with the specified node.
-    /// :rtype: dict
+    /// :rtype: dict[int, Any]
     #[pyo3(text_signature = "(self, node, /)")]
     pub fn adj(&mut self, node: usize) -> DictMap<usize, &PyObject> {
         let index = NodeIndex::new(node);
@@ -1192,9 +1197,9 @@ impl PyGraph {
 
     /// Get the degree for a node
     ///
-    /// :param int node: The index of the  node to find the inbound degree of
+    /// :param int node: The index of the node to find the inbound degree of
     ///
-    /// :returns degree: The inbound degree for the specified node
+    /// :returns degree: The inbound degree of the specified node
     /// :rtype: int
     #[pyo3(text_signature = "(self, node, /)")]
     pub fn degree(&self, node: usize) -> usize {
@@ -1254,19 +1259,19 @@ impl PyGraph {
 
     /// Generate a dot file from the graph
     ///
-    /// :param node_attr: A callable that will take in a node data object
+    /// :param Callable node_attr: A callable that will take in a node data object
     ///     and return a dictionary of attributes to be associated with the
     ///     node in the dot file. The key and value of this dictionary **must**
     ///     be a string. If they're not strings rustworkx will raise TypeError
     ///     (unfortunately without an error message because of current
     ///     limitations in the PyO3 type checking)
-    /// :param edge_attr: A callable that will take in an edge data object
+    /// :param Callable edge_attr: A callable that will take in an edge data object
     ///     and return a dictionary of attributes to be associated with the
     ///     node in the dot file. The key and value of this dictionary **must**
     ///     be a string. If they're not strings rustworkx will raise TypeError
     ///     (unfortunately without an error message because of current
     ///     limitations in the PyO3 type checking)
-    /// :param dict graph_attr: An optional dictionary that specifies any graph
+    /// :param dict[str, str] graph_attr: An optional dictionary that specifies any graph
     ///     attributes for the output dot file. The key and value of this
     ///     dictionary **must** be a string. If they're not strings rustworkx
     ///     will raise TypeError (unfortunately without an error message
@@ -1333,18 +1338,18 @@ impl PyGraph {
     /// Read an edge list file and create a new PyGraph object from the
     /// contents
     ///
-    /// The expected format for the edge list file is a line separated list
+    /// The expected format of the edge list file is a line separated list
     /// of delimited node ids. If there are more than 3 elements on
     /// a line the 3rd on will be treated as a string weight for the edge
     ///
-    /// :param str path: The path of the file to open
-    /// :param str comment: Optional character to use as a comment by default
-    ///     there are no comment characters
-    /// :param str deliminator: Optional character to use as a deliminator by
-    ///     default any whitespace will be used
+    /// :param str path: The path of the file to read from
+    /// :param str comment: Optional character to use as a comment prefix
+    ///     (by default there are no comment characters)
+    /// :param str deliminator: Optional character to use as a deliminator
+    ///     (by default any whitespace will be used)
     /// :param bool labels: If set to ``True`` the first two separated fields
     ///     will be treated as string labels uniquely identifying a node
-    ///     instead of node indices.
+    ///     instead of node indices
     ///
     /// For example:
     ///
@@ -1363,7 +1368,7 @@ impl PyGraph {
     ///       fd.write('1 2\n')
     ///       fd.write('2 3\n')
     ///       fd.flush()
-    ///       graph = rx.PyGraph.read_edge_list(path)
+    ///       graph = rx.PyGraph.read_edge_list(path=path)
     ///   mpl_draw(graph)
     ///
     #[staticmethod]
@@ -1589,9 +1594,10 @@ impl PyGraph {
     ///
     /// :param PyGraph other: The other PyGraph object to add onto this
     ///     graph.
-    /// :param dict node_map: A dictionary mapping node indices from this
+    /// :param dict[int, tuple[int, Any]] node_map: A dictionary
+    ///     mapping node indices from this
     ///     PyGraph object to node indices in the other PyGraph object.
-    ///     The keys are a node index in this graph and the value is a tuple
+    ///     The key is a node index in this graph and the value is a tuple
     ///     of the node index in the other graph to add an edge to and the
     ///     weight of that edge. For example::
     ///
@@ -1600,11 +1606,11 @@ impl PyGraph {
     ///             2: (4, "weight2")
     ///         }
     ///
-    /// :param node_map_func: An optional python callable that will take in a
+    /// :param Callable node_map_func: An optional python callable that will take in a
     ///     single node weight/data object and return a new node weight/data
     ///     object that will be used when adding an node from other onto this
     ///     graph.
-    /// :param edge_map_func: An optional python callabble that will take in a
+    /// :param Callable edge_map_func: An optional python callabble that will take in a
     ///     single edge weight/data object and return a new edge weight/data
     ///     object that will be used when adding an edge from other onto this
     ///     graph.
@@ -1612,7 +1618,7 @@ impl PyGraph {
     /// :returns: new_node_ids: A dictionary mapping node index from the other
     ///     PyGraph to the equivalent node index in this PyDAG after they've
     ///     been combined
-    /// :rtype: dict
+    /// :rtype: dict[int, int]
     ///
     /// For example, start by building a graph:
     ///
@@ -1700,18 +1706,18 @@ impl PyGraph {
 
     /// Substitute a node with a PyGraph object
     ///
-    /// :param int node: The node to replace with the PyGraph object
+    /// :param int node: The index of the node to be replaced with the PyGraph object
     /// :param PyGraph other: The other graph to replace ``node`` with
-    /// :param callable edge_map_fn: A callable object that will take 3 position
+    /// :param Callable edge_map_fn: A callable object that will take 3 position
     ///     parameters, ``(source, target, weight)`` to represent an edge either to
     ///     or from ``node`` in this graph. The expected return value from this
     ///     callable is the node index of the node in ``other`` that an edge should
     ///     be to/from. If None is returned, that edge will be skipped and not
     ///     be copied.
-    /// :param callable node_filter: An optional callable object that when used
+    /// :param Callable node_filter: An optional callable object that when used
     ///     will receive a node's payload object from ``other`` and return
     ///     ``True`` if that node is to be included in the graph or not.
-    /// :param callable edge_weight_map: An optional callable object that when
+    /// :param Callable edge_weight_map: An optional callable object that when
     ///     used will receive an edge's weight/data payload from ``other`` and
     ///     will return an object to use as the weight for a newly created edge
     ///     after the edge is mapped from ``other``. If not specified the weight
@@ -1861,12 +1867,12 @@ impl PyGraph {
     ///     edge tuple representations (e.g. the tuples returned from
     ///     :meth:`~rustworkx.PyGraph.edge_list`).
     ///
-    /// :param list nodes: A set of nodes to be removed and replaced
+    /// :param list[int] nodes: A set of nodes to be removed and replaced
     ///     by the new node. Any nodes not in the graph are ignored.
     ///     If empty, this method behaves like :meth:`~PyGraph.add_node`
     ///     (but slower).
-    /// :param object obj: The data/weight to associate with the new node.
-    /// :param weight_combo_fn: An optional python callable that, when
+    /// :param Any obj: The data/weight to associate with the new node.
+    /// :param Callable weight_combo_fn: An optional python callable that, when
     ///     specified, is used to merge parallel edges introduced by the
     ///     contraction, which will occur if any two edges between ``nodes``
     ///     and the rest of the graph share an endpoint.
@@ -1876,6 +1882,7 @@ impl PyGraph {
     ///     combined by choosing one of the edge's weights arbitrarily based
     ///     on an internal iteration order, subject to change.
     /// :returns: The index of the newly created node.
+    /// :rtype: int
     #[pyo3(text_signature = "(self, nodes, obj, /, weight_combo_fn=None)", signature = (nodes, obj, weight_combo_fn=None))]
     pub fn contract_nodes(
         &mut self,
@@ -1903,10 +1910,10 @@ impl PyGraph {
 
     /// Return a new PyGraph object for a subgraph of this graph
     ///
-    /// :param list nodes: A list of node indices to generate the subgraph
+    /// :param list[int] nodes: A list of node indices to generate the subgraph
     ///     from. If a node index is included that is not present in the graph
     ///     it will silently be ignored.
-    /// :param preserve_attrs: If set to the True the attributes of the PyGraph
+    /// :param bool preserve_attrs: If set to the True the attributes of the PyGraph
     ///     will be copied by reference to be the attributes of the output
     ///     subgraph. By default this is set to False and the :attr:`~.PyGraph.attrs`
     ///     attribute will be ``None`` in the subgraph.
@@ -1952,7 +1959,7 @@ impl PyGraph {
     /// The induced subgraph contains each edge in `edge_list` and each node
     /// incident to any of those edges.
     ///
-    /// :param list edge_list: A list of edge tuples (2-tuples with the source
+    /// :param list[tuple[int, int]] edge_list: A list of edge tuples (2-tuples with the source
     ///     and target node) to generate the subgraph from. In cases of parallel
     ///     edges for a multigraph all edges between the specified node. In case
     ///     of an edge specified that doesn't exist in the graph it will be
@@ -2007,6 +2014,8 @@ impl PyGraph {
     ///
     /// All node and edge weight/data payloads in the copy will have a
     /// shared reference to the original graph.
+    /// :returns: A shallow copy of the graph
+    /// :rtype: PyGraph
     #[pyo3(text_signature = "(self)")]
     pub fn copy(&self) -> PyGraph {
         self.clone()
@@ -2108,7 +2117,7 @@ impl PyGraph {
     ///     indices = graph.filter_nodes(my_filter_function)
     ///     assert indices == [3, 4]
     ///
-    /// :param filter_function: Function with which to filter nodes
+    /// :param Callable filter_function: Function to filter nodes with
     /// :returns: The node indices that match the filter
     /// :rtype: NodeIndices
     #[pyo3(text_signature = "(self, filter_function)")]
@@ -2149,7 +2158,7 @@ impl PyGraph {
     ///     indices = graph.filter_edges(my_filter_function)
     ///     assert indices == [1]
     ///
-    /// :param filter_function: Function with which to filter edges
+    /// :param Callable filter_function: Function to filter edges with
     /// :returns: The edge indices that match the filter
     /// :rtype: EdgeIndices
     #[pyo3(text_signature = "(self, filter_function)")]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -402,7 +402,7 @@ impl PyGraph {
     /// Return a list of all edge data.
     ///
     /// :returns: A list of all the edge data objects in the graph
-    /// :rtype: list[Any]
+    /// :rtype: list[T]
     #[pyo3(text_signature = "(self)")]
     pub fn edges(&self) -> Vec<&PyObject> {
         self.graph
@@ -446,7 +446,7 @@ impl PyGraph {
     /// Return a list of all node data.
     ///
     /// :returns: A list of all the node data objects in the graph
-    /// :rtype: list[Any]
+    /// :rtype: list[S]
     #[pyo3(text_signature = "(self)")]
     pub fn nodes(&self) -> Vec<&PyObject> {
         self.graph
@@ -493,7 +493,7 @@ impl PyGraph {
         self.graph.contains_node(index)
     }
 
-    /// Check if there is a direct edge between ``node_a`` and ``node_b``.
+    /// Check if there is any undirected edge between ``node_a`` and ``node_b``.
     ///
     /// :param int node_a: The index of the first node
     /// :param int node_b: The index of the second node
@@ -517,7 +517,7 @@ impl PyGraph {
     /// :param int node_b: The index of the second node
     ///
     /// :returns: The data object set for the edge
-    /// :rtype: Any
+    /// :rtype: S
     /// :raises NoEdgeBetweenNodes: when there is no edge between the provided
     ///     nodes
     #[pyo3(text_signature = "(self, node_a, node_b, /)")]
@@ -686,7 +686,7 @@ impl PyGraph {
     /// :param int edge_index: The edge index to get the data for
     ///
     /// :returns: The data object for the edge
-    /// :rtype: Any
+    /// :rtype: T
     /// :raises IndexError: when there is no edge present with the provided
     ///     index
     #[pyo3(text_signature = "(self, edge_index, /)")]
@@ -752,7 +752,7 @@ impl PyGraph {
     /// Update an edge's weight/data payload in place by the edge index
     ///
     /// :param int edge_index: The index of the edge
-    /// :param Any edge: The python object to attach to the edge
+    /// :param T edge: The python object to attach to the edge
     ///
     /// :raises IndexError: when there is no edge present with the provided
     ///     index
@@ -770,7 +770,7 @@ impl PyGraph {
     /// :param int node: The index of the node
     ///
     /// :returns: The data object set for that node
-    /// :rtype: Any
+    /// :rtype: S
     /// :raises IndexError: when an invalid node index is provided
     #[pyo3(text_signature = "(self, node, /)")]
     pub fn get_node_data(&self, node: usize) -> PyResult<&PyObject> {
@@ -788,7 +788,7 @@ impl PyGraph {
     /// :param int node_b: The index of the second node
     ///
     /// :returns: A list with all the data objects for the edges between nodes
-    /// :rtype: list[Any]
+    /// :rtype: list[T]
     /// :raises NoEdgeBetweenNodes: When there is no edge between nodes
     #[pyo3(text_signature = "(self, node_a, node_b, /)")]
     pub fn get_all_edge_data(&self, node_a: usize, node_b: usize) -> PyResult<Vec<&PyObject>> {
@@ -898,7 +898,7 @@ impl PyGraph {
     ///
     /// :param int node_a: The index of the parent node
     /// :param int node_b: The index of the child node
-    /// :param Any edge: The python object to attach to the edge
+    /// :param T edge: The python object to attach to the edge
     ///
     /// :returns: The index of the newly created (or updated in the case
     ///     of an existing edge with ``multigraph=False``) edge.
@@ -917,10 +917,10 @@ impl PyGraph {
 
     /// Add new edges to the graph.
     ///
-    /// :param iterable[tuple[int, int, Any]] obj_list: An iterable of tuples of the form
-    ///     ``(node_a, node_b, obj)`` to attach to the graph. ``node_a`` and
+    /// :param iterable[tuple[int, int, T]] obj_list: An iterable of tuples of the form
+    ///     ``(node_a, node_b, T)`` to attach to the graph. ``node_a`` and
     ///     ``node_b`` are integer indices describing where an edge should be
-    ///     added, and ``obj`` is the python object for the edge data.
+    ///     added, and ``T`` is the python object for the edge data.
     ///
     /// If :attr:`~rustworkx.PyGraph.multigraph` is ``False`` and an edge already
     /// exists between ``node_a`` and ``node_b`` the weight/payload of that
@@ -1012,7 +1012,7 @@ impl PyGraph {
     /// from ``obj_list`` so if there are multiple parallel edges in ``obj_list``
     /// the last entry will be used.
     ///
-    /// :param iterable[tuple[int, int, Any]] edge_list: An iterable of tuples in the form
+    /// :param iterable[tuple[int, int, T]] edge_list: An iterable of tuples in the form
     ///     ``(source, target, weight)`` where source and target are integer
     ///     node indices. If the node index is not present in the graph,
     ///     nodes will be added (with a node weight of ``None``) to that index.
@@ -1093,7 +1093,7 @@ impl PyGraph {
 
     /// Add a new node to the graph.
     ///
-    /// :param Any obj: The python object to attach to the node
+    /// :param S obj: The python object to attach to the node
     ///
     /// :returns: The index of the newly created node
     /// :rtype: int
@@ -1105,7 +1105,7 @@ impl PyGraph {
 
     /// Add new nodes to the graph.
     ///
-    /// :param iterable[Any] obj_list: An iterable of python object to attach to the graph
+    /// :param iterable[S] obj_list: An iterable of python object to attach to the graph
     ///
     /// :returns indices: A list of indices of the newly created nodes
     /// :rtype: NodeIndices
@@ -1141,7 +1141,7 @@ impl PyGraph {
     /// indices in order. If there is more than one node in the graph with the
     /// same weight only the first match (by node index) will be returned.
     ///
-    /// :param Any obj: The weight to look for in the graph.
+    /// :param T obj: The weight to look for in the graph.
     ///
     /// :returns: the index of the first node in the graph that is equal to the
     ///     weight. If no match is found ``None`` will be returned.
@@ -1164,7 +1164,7 @@ impl PyGraph {
     /// :returns neighbors: A dictionary where the keys are node indices and
     ///     the value is the edge data object for all nodes that share an
     ///     edge with the specified node.
-    /// :rtype: dict[int, Any]
+    /// :rtype: dict[int, T]
     #[pyo3(text_signature = "(self, node, /)")]
     pub fn adj(&mut self, node: usize) -> DictMap<usize, &PyObject> {
         let index = NodeIndex::new(node);
@@ -1259,13 +1259,13 @@ impl PyGraph {
 
     /// Generate a dot file from the graph
     ///
-    /// :param Callable node_attr: A callable that will take in a node data object
+    /// :param node_attr: A callable that will take in a node data object
     ///     and return a dictionary of attributes to be associated with the
     ///     node in the dot file. The key and value of this dictionary **must**
     ///     be a string. If they're not strings rustworkx will raise TypeError
     ///     (unfortunately without an error message because of current
     ///     limitations in the PyO3 type checking)
-    /// :param Callable edge_attr: A callable that will take in an edge data object
+    /// :param edge_attr: A callable that will take in an edge data object
     ///     and return a dictionary of attributes to be associated with the
     ///     node in the dot file. The key and value of this dictionary **must**
     ///     be a string. If they're not strings rustworkx will raise TypeError
@@ -1594,7 +1594,7 @@ impl PyGraph {
     ///
     /// :param PyGraph other: The other PyGraph object to add onto this
     ///     graph.
-    /// :param dict[int, tuple[int, Any]] node_map: A dictionary
+    /// :param dict[int, tuple[int, tuple[int, T]]] node_map: A dictionary
     ///     mapping node indices from this
     ///     PyGraph object to node indices in the other PyGraph object.
     ///     The key is a node index in this graph and the value is a tuple
@@ -1871,7 +1871,7 @@ impl PyGraph {
     ///     by the new node. Any nodes not in the graph are ignored.
     ///     If empty, this method behaves like :meth:`~PyGraph.add_node`
     ///     (but slower).
-    /// :param Any obj: The data/weight to associate with the new node.
+    /// :param S obj: The data/weight to associate with the new node.
     /// :param Callable weight_combo_fn: An optional python callable that, when
     ///     specified, is used to merge parallel edges introduced by the
     ///     contraction, which will occur if any two edges between ``nodes``


### PR DESCRIPTION
As a beginner in rustworkx, when I followed the API docs, sometimes I was not quite sure whether the argument or the return value was the int node indices or the attached objects.

Unfortunately it looks like it is not possible to add Python type hints to the PyO3 signatures. Therefore I reviewed the src/graph.rs and added them wherever possible in the docstrings. I also tried to consolidate the description of the same parameters across the functions.

If this is a good way to go, I'll be happy to tackle the rest of the docstrings in the near future.

- [x] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
