### PR TITLE
docs: add a note that subgraph recreates indexes

### DIFF
--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -3003,7 +3003,9 @@ impl PyDiGraph {
     ///     It is worth noting that node and edge weight/data payloads are
     ///     passed by reference so if you update (not replace) an object used
     ///     as the weight in graph or the subgraph it will also be updated in
-    ///     the other.
+    ///     the other. Because the indexes will be recreated, the subgraph will
+    ///     have different indexes, meaning you cannot access nodes using the
+    ///     original graph's indexes.
     /// :rtype: PyGraph
     ///
     #[pyo3(signature=(nodes, preserve_attrs=false),text_signature = "(self, nodes, /, preserve_attrs=False)")]

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -3003,9 +3003,8 @@ impl PyDiGraph {
     ///     It is worth noting that node and edge weight/data payloads are
     ///     passed by reference so if you update (not replace) an object used
     ///     as the weight in graph or the subgraph it will also be updated in
-    ///     the other. Because the indexes will be recreated, the subgraph will
-    ///     have different indexes, meaning you cannot access nodes using the
-    ///     original graph's indexes.
+    ///     the other. Node and edge the indices will be recreated for the subgraph for compactness.
+    ///     Therefore, do not access data using the original graph's indices.
     /// :rtype: PyGraph
     ///
     #[pyo3(signature=(nodes, preserve_attrs=false),text_signature = "(self, nodes, /, preserve_attrs=False)")]


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] ~I ran rustfmt locally~ (I consider this to be irrelevant.)
- [ ] ~I have added the tests to cover my changes.~ (I consider this to be irrelevant.)
- [ ] ~I have updated the documentation accordingly.~ (I consider this to be irrelevant.)
- [x] I have read the CONTRIBUTING document.
-->

The inability to find the desired index in the subgraph was unexpected. This behavior, if it is a feature rather than a bug, needs to be documented.
