### PR TITLE
Consolidate the hashset/match syntax

### DIFF
--- a/rustworkx-core/src/dag_algo.rs
+++ b/rustworkx-core/src/dag_algo.rs
@@ -16,6 +16,7 @@ use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::hash::Hash;
 
+use hashbrown::hash_set::Entry;
 use hashbrown::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::mem::swap;
@@ -442,11 +443,15 @@ where
                     .neighbors_directed(*node, petgraph::Direction::Outgoing);
                 let mut used_indices: HashSet<G::NodeId> = HashSet::new();
                 for succ in children {
-                    // Skip duplicate successors
-                    if used_indices.contains(&succ) {
-                        continue;
+                    match used_indices.entry(succ) {
+                        Entry::Occupied(_) => {
+                            // Skip duplicate successors
+                            continue;
+                        }
+                        Entry::Vacant(used_indices_entry) => {
+                            used_indices_entry.insert();
+                        }
                     }
-                    used_indices.insert(succ);
                     let mut multiplicity: usize = 0;
                     let raw_edges: G::EdgesDirected = self
                         .graph

--- a/rustworkx-core/src/graph_ext/contraction.rs
+++ b/rustworkx-core/src/graph_ext/contraction.rs
@@ -15,7 +15,7 @@
 use crate::dictmap::{DictMap, InitWithHasher};
 use crate::err::{ContractError, ContractSimpleError};
 use crate::graph_ext::NodeRemovable;
-use indexmap::map::Entry::{Occupied, Vacant};
+use indexmap::map::Entry;
 use indexmap::IndexSet;
 use petgraph::data::Build;
 use petgraph::graphmap;
@@ -458,10 +458,10 @@ where
     let mut kvs = DictMap::with_capacity(xs.len());
     for (k, v) in xs {
         match kvs.entry(k) {
-            Occupied(entry) => {
+            Entry::Occupied(entry) => {
                 *entry.into_mut() = merge_fn(&v, entry.get())?;
             }
-            Vacant(entry) => {
+            Entry::Vacant(entry) => {
                 entry.insert(v);
             }
         }

--- a/rustworkx-core/src/shortest_path/astar.rs
+++ b/rustworkx-core/src/shortest_path/astar.rs
@@ -21,7 +21,7 @@
 use std::collections::BinaryHeap;
 use std::hash::Hash;
 
-use hashbrown::hash_map::Entry::{Occupied, Vacant};
+use hashbrown::hash_map::Entry;
 use hashbrown::HashMap;
 
 use petgraph::algo::Measure;
@@ -144,7 +144,7 @@ where
             let mut next_score = node_score + cost;
 
             match scores.entry(next) {
-                Occupied(ent) => {
+                Entry::Occupied(ent) => {
                     let old_score = *ent.get();
                     if next_score < old_score {
                         *ent.into_mut() = next_score;
@@ -153,7 +153,7 @@ where
                         next_score = old_score;
                     }
                 }
-                Vacant(ent) => {
+                Entry::Vacant(ent) => {
                     ent.insert(next_score);
                     path_tracker.set_predecessor(next, node);
                 }

--- a/rustworkx-core/src/traversal/dijkstra_visit.rs
+++ b/rustworkx-core/src/traversal/dijkstra_visit.rs
@@ -20,7 +20,7 @@
 use std::collections::BinaryHeap;
 use std::hash::Hash;
 
-use hashbrown::hash_map::Entry::{Occupied, Vacant};
+use hashbrown::hash_map::Entry;
 use hashbrown::HashMap;
 
 use petgraph::algo::Measure;
@@ -252,7 +252,7 @@ where
             let cost = edge_cost(edge)?;
             let next_score = node_score + cost;
             match scores.entry(next) {
-                Occupied(ent) => {
+                Entry::Occupied(ent) => {
                     if next_score < *ent.get() {
                         try_control_with_result!(
                             visitor(DijkstraEvent::EdgeRelaxed(node, next, edge.weight())),
@@ -267,7 +267,7 @@ where
                         );
                     }
                 }
-                Vacant(ent) => {
+                Entry::Vacant(ent) => {
                     try_control_with_result!(
                         visitor(DijkstraEvent::EdgeRelaxed(node, next, edge.weight())),
                         continue

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -782,12 +782,15 @@ impl PyDiGraph {
 
         for edge in raw_edges {
             let succ = edge.target();
-            if !used_indices.contains(&succ) {
-                let edge_weight = edge.weight();
-                if filter_edge(edge_weight)? {
-                    used_indices.insert(succ);
-                    successors.push(self.graph.node_weight(succ).unwrap());
+            match used_indices.entry(succ) {
+                Entry::Vacant(used_indices_entry) => {
+                    let edge_weight = edge.weight();
+                    if filter_edge(edge_weight)? {
+                        used_indices_entry.insert();
+                        successors.push(self.graph.node_weight(succ).unwrap());
+                    }
                 }
+                Entry::Occupied(_) => {}
             }
         }
         Ok(successors)
@@ -841,12 +844,15 @@ impl PyDiGraph {
 
         for edge in raw_edges {
             let pred = edge.source();
-            if !used_indices.contains(&pred) {
-                let edge_weight = edge.weight();
-                if filter_edge(edge_weight)? {
-                    used_indices.insert(pred);
-                    predec.push(self.graph.node_weight(pred).unwrap());
+            match used_indices.entry(pred) {
+                Entry::Vacant(used_indices_entry) => {
+                    let edge_weight = edge.weight();
+                    if filter_edge(edge_weight)? {
+                        used_indices_entry.insert();
+                        predec.push(self.graph.node_weight(pred).unwrap());
+                    }
                 }
+                Entry::Occupied(_) => {}
             }
         }
         Ok(predec)


### PR DESCRIPTION
This just consolidates the usage of `hashbrown::hash_set::Entry` across the project (except the changes done in #1405).
