### PR TITLE
Replace lambdas with direct functions or operator module

### DIFF
--- a/rustworkx/__init__.py
+++ b/rustworkx/__init__.py
@@ -236,7 +236,7 @@ def adjacency_matrix(graph, weight_fn=None, default_weight=1.0, null_value=0.0):
 
         to return a weight of 1 for all edges. Also::
 
-            adjacency_matrix(graph, weight_fn: lambda x: float(x))
+            adjacency_matrix(graph, weight_fn: float)
 
         to cast the edge object as a float as the weight. If this is not
         specified a default value (either ``default_weight`` or 1) will be used
@@ -363,7 +363,7 @@ def floyd_warshall_numpy(
 
         to return a weight of 1 for all edges. Also::
 
-            floyd_warshall_numpy(graph, weight_fn: lambda x: float(x))
+            floyd_warshall_numpy(graph, weight_fn: float)
 
         to cast the edge object as a float as the weight. If this is not
         specified a default value (either ``default_weight`` or 1) will be used
@@ -2053,7 +2053,7 @@ def longest_simple_path(graph):
 
         from rustworkx import all_pairs_all_simple_paths
 
-        max((y.values for y in all_pairs_all_simple_paths(graph).values()), key=lambda x: len(x))
+        max((y.values for y in all_pairs_all_simple_paths(graph).values()), key=len)
 
     but this function will be more efficient than using ``max()`` as the search
     is evaluated in parallel before returning to Python. In the case of multiple

--- a/tests/digraph/test_adjacency_matrix.py
+++ b/tests/digraph/test_adjacency_matrix.py
@@ -72,7 +72,7 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         dag = rustworkx.PyDAG()
         node_a = dag.add_node("a")
         dag.add_child(node_a, "b", 7.0)
-        res = rustworkx.digraph_adjacency_matrix(dag, lambda x: float(x))
+        res = rustworkx.digraph_adjacency_matrix(dag, float)
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(np.array_equal(np.array([[0.0, 7.0], [0.0, 0.0]]), res))
 
@@ -81,7 +81,7 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         node_a = dag.add_node("a")
         node_b = dag.add_child(node_a, "b", 7.0)
         dag.add_edge(node_a, node_b, 0.5)
-        res = rustworkx.digraph_adjacency_matrix(dag, lambda x: float(x))
+        res = rustworkx.digraph_adjacency_matrix(dag, float)
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(np.array_equal(np.array([[0.0, 7.5], [0.0, 0.0]]), res))
 
@@ -91,7 +91,7 @@ class TestDAGAdjacencyMatrix(unittest.TestCase):
         node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, 7.0)
         graph.add_edge(node_a, node_b, 0.5)
-        res = rustworkx.adjacency_matrix(graph, lambda x: float(x), null_value=np.inf)
+        res = rustworkx.adjacency_matrix(graph, float, null_value=np.inf)
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(np.array_equal(np.array([[np.inf, 7.5], [np.inf, np.inf]]), res))
 
@@ -281,35 +281,25 @@ class TestFromComplexAdjacencyMatrix(unittest.TestCase):
             ]
         )
 
-        min_matrix = rustworkx.digraph_adjacency_matrix(
-            graph, weight_fn=lambda x: float(x), parallel_edge="min"
-        )
+        min_matrix = rustworkx.digraph_adjacency_matrix(graph, weight_fn=float, parallel_edge="min")
         np.testing.assert_array_equal(
             [[0.0, 1.0, 2.0], [0.0, 0.0, 2.0], [1.0, 0.0, 0.0]], min_matrix
         )
 
-        max_matrix = rustworkx.digraph_adjacency_matrix(
-            graph, weight_fn=lambda x: float(x), parallel_edge="max"
-        )
+        max_matrix = rustworkx.digraph_adjacency_matrix(graph, weight_fn=float, parallel_edge="max")
         np.testing.assert_array_equal(
             [[0.0, 4.0, 2.0], [0.0, 0.0, 7.0], [1.0, 0.0, 0.0]], max_matrix
         )
 
-        avg_matrix = rustworkx.digraph_adjacency_matrix(
-            graph, weight_fn=lambda x: float(x), parallel_edge="avg"
-        )
+        avg_matrix = rustworkx.digraph_adjacency_matrix(graph, weight_fn=float, parallel_edge="avg")
         np.testing.assert_array_equal(
             [[0.0, 8 / 3.0, 2.0], [0.0, 0.0, 4.5], [1.0, 0.0, 0.0]], avg_matrix
         )
 
-        sum_matrix = rustworkx.digraph_adjacency_matrix(
-            graph, weight_fn=lambda x: float(x), parallel_edge="sum"
-        )
+        sum_matrix = rustworkx.digraph_adjacency_matrix(graph, weight_fn=float, parallel_edge="sum")
         np.testing.assert_array_equal(
             [[0.0, 8.0, 2.0], [0.0, 0.0, 9.0], [1.0, 0.0, 0.0]], sum_matrix
         )
 
         with self.assertRaises(ValueError):
-            rustworkx.digraph_adjacency_matrix(
-                graph, weight_fn=lambda x: float(x), parallel_edge="error"
-            )
+            rustworkx.digraph_adjacency_matrix(graph, weight_fn=float, parallel_edge="error")

--- a/tests/digraph/test_astar.py
+++ b/tests/digraph/test_astar.py
@@ -34,7 +34,7 @@ class TestAstarDigraph(unittest.TestCase):
         g.add_edge(c, f, 11)
         g.add_edge(e, f, 6)
         path = rustworkx.digraph_astar_shortest_path(
-            g, a, lambda goal: goal == "E", lambda x: float(x), lambda y: 0
+            g, a, lambda goal: goal == "E", float, lambda y: 0
         )
         expected = [a, d, e]
         self.assertEqual(expected, path)
@@ -77,7 +77,7 @@ class TestAstarDigraph(unittest.TestCase):
                 g,
                 a,
                 lambda finish: finish_func(end, finish),
-                lambda x: float(x),
+                float,
                 heuristic_func,
             )
             self.assertEqual(expected[index], path)
@@ -87,7 +87,7 @@ class TestAstarDigraph(unittest.TestCase):
                 g,
                 a,
                 lambda finish: finish_func(no_path, finish),
-                lambda x: float(x),
+                float,
                 heuristic_func,
             )
 
@@ -123,6 +123,6 @@ class TestAstarDigraph(unittest.TestCase):
                 g,
                 len(g.node_indices()) + 1,
                 goal_fn=lambda goal: goal == "B",
-                edge_cost_fn=lambda x: float(x),
+                edge_cost_fn=float,
                 estimate_cost_fn=lambda _: 0,
             )

--- a/tests/digraph/test_bellman_ford.py
+++ b/tests/digraph/test_bellman_ford.py
@@ -38,9 +38,7 @@ class TestBellmanFordDiGraph(unittest.TestCase):
         self.graph.add_edges_from(edge_list)
 
     def test_bellman_ford(self):
-        path = rustworkx.digraph_bellman_ford_shortest_path_lengths(
-            self.graph, self.a, lambda x: float(x)
-        )
+        path = rustworkx.digraph_bellman_ford_shortest_path_lengths(self.graph, self.a, float)
         expected = {1: 7.0, 2: 16.0, 3: 14.0, 4: 23.0, 5: 22.0}
         self.assertEqual(expected, path)
 
@@ -116,19 +114,19 @@ class TestBellmanFordDiGraph(unittest.TestCase):
 
     def test_bellman_path(self):
         path = rustworkx.digraph_bellman_ford_shortest_paths(
-            self.graph, self.a, weight_fn=lambda x: float(x), target=self.e
+            self.graph, self.a, weight_fn=float, target=self.e
         )
         expected = rustworkx.digraph_dijkstra_shortest_paths(
-            self.graph, self.a, weight_fn=lambda x: float(x), target=self.e
+            self.graph, self.a, weight_fn=float, target=self.e
         )
         self.assertEqual(expected, path)
 
     def test_bellman_path_lengths(self):
         path = rustworkx.digraph_bellman_ford_shortest_path_lengths(
-            self.graph, self.a, lambda x: float(x), goal=self.e
+            self.graph, self.a, float, goal=self.e
         )
         expected = rustworkx.digraph_dijkstra_shortest_path_lengths(
-            self.graph, self.a, lambda x: float(x), goal=self.e
+            self.graph, self.a, float, goal=self.e
         )
         self.assertEqual(expected, path)
 
@@ -148,7 +146,7 @@ class TestBellmanFordDiGraph(unittest.TestCase):
         g = rustworkx.PyDiGraph()
         a = g.add_node("A")
         g.add_node("B")
-        path = rustworkx.digraph_bellman_ford_shortest_path_lengths(g, a, lambda x: float(x))
+        path = rustworkx.digraph_bellman_ford_shortest_path_lengths(g, a, float)
         expected = {}
         self.assertEqual(expected, path)
 
@@ -446,11 +444,11 @@ class TestBellmanFordDiGraph(unittest.TestCase):
     def test_raises_index_error_bellman_ford_paths(self):
         with self.assertRaises(IndexError):
             rustworkx.digraph_bellman_ford_shortest_paths(
-                self.graph, len(self.graph.node_indices()) + 1, weight_fn=lambda x: float(x)
+                self.graph, len(self.graph.node_indices()) + 1, weight_fn=float
             )
 
     def test_raises_index_error_bellman_ford_path_lengths(self):
         with self.assertRaises(IndexError):
             rustworkx.digraph_bellman_ford_shortest_path_lengths(
-                self.graph, len(self.graph.node_indices()) + 1, edge_cost_fn=lambda x: float(x)
+                self.graph, len(self.graph.node_indices()) + 1, edge_cost_fn=float
             )

--- a/tests/digraph/test_contract_nodes.py
+++ b/tests/digraph/test_contract_nodes.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import operator as op
 import unittest
 
 import rustworkx
@@ -250,7 +251,7 @@ class TestContractNodesSimpleGraph(unittest.TestCase):
         self.dag.contract_nodes(
             [self.node_b, self.node_c, self.node_d],
             "m",
-            weight_combo_fn=lambda w1, w2: w1 + w2,
+            weight_combo_fn=op.add,
         )
 
         self.assertEqual(set(self.dag.nodes()), {"a", "e", "m"})

--- a/tests/digraph/test_deepcopy.py
+++ b/tests/digraph/test_deepcopy.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import copy
+import operator as op
 import unittest
 
 import rustworkx
@@ -23,7 +24,7 @@ class TestDeepcopy(unittest.TestCase):
         dag_a.add_child(node_a, "a_2", "a_1")
         dag_a.add_child(node_a, "a_3", "a_2")
         dag_b = copy.deepcopy(dag_a)
-        self.assertTrue(rustworkx.is_isomorphic_node_match(dag_a, dag_b, lambda x, y: x == y))
+        self.assertTrue(rustworkx.is_isomorphic_node_match(dag_a, dag_b, op.eq))
 
     def test_deepcopy_with_holes(self):
         dag_a = rustworkx.PyDAG()

--- a/tests/digraph/test_dijkstra.py
+++ b/tests/digraph/test_dijkstra.py
@@ -38,9 +38,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
         self.graph.add_edges_from(edge_list)
 
     def test_dijkstra(self):
-        path = rustworkx.digraph_dijkstra_shortest_path_lengths(
-            self.graph, self.a, lambda x: float(x), self.e
-        )
+        path = rustworkx.digraph_dijkstra_shortest_path_lengths(self.graph, self.a, float, self.e)
         expected = {4: 23.0}
         self.assertEqual(expected, path)
 
@@ -167,7 +165,7 @@ class TestDijkstraDiGraph(unittest.TestCase):
         g = rustworkx.PyDiGraph()
         a = g.add_node("A")
         g.add_node("B")
-        path = rustworkx.digraph_dijkstra_shortest_path_lengths(g, a, lambda x: float(x))
+        path = rustworkx.digraph_dijkstra_shortest_path_lengths(g, a, float)
         expected = {}
         self.assertEqual(expected, path)
 

--- a/tests/digraph/test_isomorphic.py
+++ b/tests/digraph/test_isomorphic.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import copy
+import operator as op
 import unittest
 
 import rustworkx
@@ -31,9 +32,7 @@ class TestIsomorphic(unittest.TestCase):
 
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    rustworkx.is_isomorphic(dag_a, dag_b, lambda x, y: x == y, id_order=id_order)
-                )
+                self.assertTrue(rustworkx.is_isomorphic(dag_a, dag_b, op.eq, id_order=id_order))
 
     def test_isomorphic_identical(self):
         dag_a = rustworkx.PyDAG()
@@ -78,9 +77,7 @@ class TestIsomorphic(unittest.TestCase):
         dag_b.add_child(node_b, "b_3", "b_2")
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertFalse(
-                    rustworkx.is_isomorphic(dag_a, dag_b, lambda x, y: x == y, id_order=id_order)
-                )
+                self.assertFalse(rustworkx.is_isomorphic(dag_a, dag_b, op.eq, id_order=id_order))
 
     def test_is_isomorphic_nodes_compare_raises(self):
         dag_a = rustworkx.PyDAG()
@@ -112,9 +109,7 @@ class TestIsomorphic(unittest.TestCase):
         dag_b.add_child(node_b, "a_3", "a_2")
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    rustworkx.is_isomorphic(dag_a, dag_b, lambda x, y: x == y, id_order=id_order)
-                )
+                self.assertTrue(rustworkx.is_isomorphic(dag_a, dag_b, op.eq, id_order=id_order))
 
     def test_isomorphic_compare_edges_identical(self):
         dag_a = rustworkx.PyDAG()
@@ -133,7 +128,7 @@ class TestIsomorphic(unittest.TestCase):
                     rustworkx.is_isomorphic(
                         dag_a,
                         dag_b,
-                        edge_matcher=lambda x, y: x == y,
+                        edge_matcher=op.eq,
                         id_order=id_order,
                     )
                 )
@@ -177,9 +172,7 @@ class TestIsomorphic(unittest.TestCase):
 
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    rustworkx.is_isomorphic(dag_a, dag_b, lambda x, y: x == y, id_order=id_order)
-                )
+                self.assertTrue(rustworkx.is_isomorphic(dag_a, dag_b, op.eq, id_order=id_order))
 
     def test_isomorphic_compare_nodes_with_removals_deepcopy(self):
         dag_a = rustworkx.PyDAG()
@@ -224,7 +217,7 @@ class TestIsomorphic(unittest.TestCase):
                     rustworkx.is_isomorphic(
                         copy.deepcopy(dag_a),
                         copy.deepcopy(dag_b),
-                        lambda x, y: x == y,
+                        op.eq,
                         id_order=id_order,
                     )
                 )
@@ -232,7 +225,7 @@ class TestIsomorphic(unittest.TestCase):
     def test_digraph_isomorphic_parallel_edges_with_edge_matcher(self):
         graph = rustworkx.PyDiGraph()
         graph.extend_from_weighted_edge_list([(0, 1, "a"), (0, 1, "b"), (1, 2, "c")])
-        self.assertTrue(rustworkx.is_isomorphic(graph, graph, edge_matcher=lambda x, y: x == y))
+        self.assertTrue(rustworkx.is_isomorphic(graph, graph, edge_matcher=op.eq))
 
     def test_digraph_isomorphic_self_loop(self):
         graph = rustworkx.PyDiGraph()
@@ -247,9 +240,7 @@ class TestIsomorphic(unittest.TestCase):
         second_graph = rustworkx.PyDiGraph()
         second_graph.add_nodes_from([0])
         second_graph.add_edges_from([(0, 0, "b")])
-        self.assertFalse(
-            rustworkx.is_isomorphic(graph, second_graph, edge_matcher=lambda x, y: x == y)
-        )
+        self.assertFalse(rustworkx.is_isomorphic(graph, second_graph, edge_matcher=op.eq))
 
     def test_digraph_non_isomorphic_rule_out_incoming(self):
         graph = rustworkx.PyDiGraph()

--- a/tests/digraph/test_subgraph_isomorphic.py
+++ b/tests/digraph/test_subgraph_isomorphic.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import operator as op
 import unittest
 
 import rustworkx
@@ -35,9 +36,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
-                    rustworkx.is_subgraph_isomorphic(
-                        g_a, g_b, lambda x, y: x == y, id_order=id_order
-                    )
+                    rustworkx.is_subgraph_isomorphic(g_a, g_b, op.eq, id_order=id_order)
                 )
 
     def test_subgraph_isomorphic_identical(self):
@@ -85,9 +84,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertFalse(
-                    rustworkx.is_subgraph_isomorphic(
-                        g_a, g_b, lambda x, y: x == y, id_order=id_order
-                    )
+                    rustworkx.is_subgraph_isomorphic(g_a, g_b, op.eq, id_order=id_order)
                 )
 
     def test_subgraph_isomorphic_compare_nodes_identical(self):
@@ -108,9 +105,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
-                    rustworkx.is_subgraph_isomorphic(
-                        g_a, g_b, lambda x, y: x == y, id_order=id_order
-                    )
+                    rustworkx.is_subgraph_isomorphic(g_a, g_b, op.eq, id_order=id_order)
                 )
 
     def test_is_subgraph_isomorphic_nodes_compare_raises(self):
@@ -148,7 +143,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
                     rustworkx.is_subgraph_isomorphic(
                         g_a,
                         g_b,
-                        edge_matcher=lambda x, y: x == y,
+                        edge_matcher=op.eq,
                         id_order=id_order,
                     )
                 )
@@ -173,9 +168,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         second.extend_from_weighted_edge_list([(0, 1, "a"), (1, 2, "b")])
 
         self.assertTrue(
-            rustworkx.is_subgraph_isomorphic(
-                first, second, induced=False, edge_matcher=lambda x, y: x == y
-            )
+            rustworkx.is_subgraph_isomorphic(first, second, induced=False, edge_matcher=op.eq)
         )
 
     def test_subgraph_isomorphic_mismatch_edge_data_parallel_edges(self):
@@ -185,9 +178,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         second.extend_from_weighted_edge_list([(0, 1, "a"), (0, 1, "a"), (1, 2, "b")])
 
         self.assertFalse(
-            rustworkx.is_subgraph_isomorphic(
-                first, second, id_order=True, edge_matcher=lambda x, y: x == y
-            )
+            rustworkx.is_subgraph_isomorphic(first, second, id_order=True, edge_matcher=op.eq)
         )
 
     def test_non_induced_subgraph_isomorphic(self):

--- a/tests/digraph/test_to_undirected.py
+++ b/tests/digraph/test_to_undirected.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import operator as op
 import unittest
 
 import rustworkx
@@ -44,7 +45,7 @@ class TestToUndirected(unittest.TestCase):
         digraph = rustworkx.PyDiGraph()
         digraph.add_nodes_from([0, 1])
         digraph.add_edges_from([(0, 1, "a"), (0, 1, "b")])
-        graph = digraph.to_undirected(multigraph=False, weight_combo_fn=lambda x, y: x + y)
+        graph = digraph.to_undirected(multigraph=False, weight_combo_fn=op.add)
         self.assertEqual(graph.weighted_edge_list(), [(0, 1, "ab")])
 
     def test_shared_ref(self):

--- a/tests/graph/test_adjacency_matrix.py
+++ b/tests/graph/test_adjacency_matrix.py
@@ -79,7 +79,7 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
         node_a = graph.add_node("a")
         node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, 7.0)
-        res = rustworkx.graph_adjacency_matrix(graph, lambda x: float(x))
+        res = rustworkx.graph_adjacency_matrix(graph, float)
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(np.array_equal(np.array([[0.0, 7.0], [7.0, 0.0]]), res))
 
@@ -89,7 +89,7 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
         node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, 7.0)
         graph.add_edge(node_a, node_b, 0.5)
-        res = rustworkx.graph_adjacency_matrix(graph, lambda x: float(x))
+        res = rustworkx.graph_adjacency_matrix(graph, float)
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(np.array_equal(np.array([[0.0, 7.5], [7.5, 0.0]]), res))
 
@@ -99,7 +99,7 @@ class TestGraphAdjacencyMatrix(unittest.TestCase):
         node_b = graph.add_node("b")
         graph.add_edge(node_a, node_b, 7.0)
         graph.add_edge(node_a, node_b, 0.5)
-        res = rustworkx.graph_adjacency_matrix(graph, lambda x: float(x), null_value=np.inf)
+        res = rustworkx.graph_adjacency_matrix(graph, float, null_value=np.inf)
         self.assertIsInstance(res, np.ndarray)
         self.assertTrue(np.array_equal(np.array([[np.inf, 7.5], [7.5, np.inf]]), res))
 
@@ -279,35 +279,25 @@ class TestFromComplexAdjacencyMatrix(unittest.TestCase):
             ]
         )
 
-        min_matrix = rustworkx.graph_adjacency_matrix(
-            graph, weight_fn=lambda x: float(x), parallel_edge="min"
-        )
+        min_matrix = rustworkx.graph_adjacency_matrix(graph, weight_fn=float, parallel_edge="min")
         np.testing.assert_array_equal(
             [[0.0, 1.0, 1.0], [1.0, 0.0, 2.0], [1.0, 2.0, 0.0]], min_matrix
         )
 
-        max_matrix = rustworkx.graph_adjacency_matrix(
-            graph, weight_fn=lambda x: float(x), parallel_edge="max"
-        )
+        max_matrix = rustworkx.graph_adjacency_matrix(graph, weight_fn=float, parallel_edge="max")
         np.testing.assert_array_equal(
             [[0.0, 4.0, 2.0], [4.0, 0.0, 7.0], [2.0, 7.0, 0.0]], max_matrix
         )
 
-        avg_matrix = rustworkx.graph_adjacency_matrix(
-            graph, weight_fn=lambda x: float(x), parallel_edge="avg"
-        )
+        avg_matrix = rustworkx.graph_adjacency_matrix(graph, weight_fn=float, parallel_edge="avg")
         np.testing.assert_array_equal(
             [[0.0, 8 / 3.0, 1.5], [8 / 3.0, 0.0, 4.5], [1.5, 4.5, 0.0]], avg_matrix
         )
 
-        sum_matrix = rustworkx.graph_adjacency_matrix(
-            graph, weight_fn=lambda x: float(x), parallel_edge="sum"
-        )
+        sum_matrix = rustworkx.graph_adjacency_matrix(graph, weight_fn=float, parallel_edge="sum")
         np.testing.assert_array_equal(
             [[0.0, 8.0, 3.0], [8.0, 0.0, 9.0], [3.0, 9.0, 0.0]], sum_matrix
         )
 
         with self.assertRaises(ValueError):
-            rustworkx.graph_adjacency_matrix(
-                graph, weight_fn=lambda x: float(x), parallel_edge="error"
-            )
+            rustworkx.graph_adjacency_matrix(graph, weight_fn=float, parallel_edge="error")

--- a/tests/graph/test_all_shortest_paths.py
+++ b/tests/graph/test_all_shortest_paths.py
@@ -35,7 +35,7 @@ class TestGraphAllShortestPaths(unittest.TestCase):
         self.graph.add_edge(self.e, self.f, 6)
 
     def test_all_shortest_paths_single(self):
-        paths = rustworkx.graph_all_shortest_paths(self.graph, self.a, self.e, lambda x: float(x))
+        paths = rustworkx.graph_all_shortest_paths(self.graph, self.a, self.e, float)
         # a -> d -> e = 23
         # a -> c -> d -> e = 20
         expected = [[self.a, self.c, self.d, self.e]]
@@ -44,7 +44,7 @@ class TestGraphAllShortestPaths(unittest.TestCase):
     def test_all_shortest_paths(self):
         self.graph.update_edge(self.a, self.d, 11)
 
-        paths = rustworkx.graph_all_shortest_paths(self.graph, self.a, self.e, lambda x: float(x))
+        paths = rustworkx.graph_all_shortest_paths(self.graph, self.a, self.e, float)
         # a -> d -> e = 20
         # a -> c -> d -> e = 20
         expected = [[self.a, self.d, self.e], [self.a, self.c, self.d, self.e]]
@@ -56,7 +56,7 @@ class TestGraphAllShortestPaths(unittest.TestCase):
         g = rustworkx.PyGraph()
         a = g.add_node("A")
         b = g.add_node("B")
-        paths = rustworkx.graph_all_shortest_paths(g, a, b, lambda x: float(x))
+        paths = rustworkx.graph_all_shortest_paths(g, a, b, float)
         expected = []
         self.assertEqual(expected, paths)
 

--- a/tests/graph/test_astar.py
+++ b/tests/graph/test_astar.py
@@ -34,7 +34,7 @@ class TestAstarGraph(unittest.TestCase):
         g.add_edge(c, f, 11)
         g.add_edge(e, f, 6)
         path = rustworkx.graph_astar_shortest_path(
-            g, a, lambda goal: goal == "E", lambda x: float(x), lambda y: 0
+            g, a, lambda goal: goal == "E", float, lambda y: 0
         )
         expected = [a, c, d, e]
         self.assertEqual(expected, path)
@@ -77,7 +77,7 @@ class TestAstarGraph(unittest.TestCase):
                 g,
                 a,
                 lambda finish: finish_func(end, finish),
-                lambda x: float(x),
+                float,
                 heuristic_func,
             )
             self.assertEqual(expected[index], path)
@@ -87,7 +87,7 @@ class TestAstarGraph(unittest.TestCase):
                 g,
                 a,
                 lambda finish: finish_func(no_path, finish),
-                lambda x: float(x),
+                float,
                 heuristic_func,
             )
 
@@ -123,6 +123,6 @@ class TestAstarGraph(unittest.TestCase):
                 g,
                 len(g.node_indices()) + 1,
                 goal_fn=lambda goal: goal == "B",
-                edge_cost_fn=lambda x: float(x),
+                edge_cost_fn=float,
                 estimate_cost_fn=lambda _: 0,
             )

--- a/tests/graph/test_bellman_ford.py
+++ b/tests/graph/test_bellman_ford.py
@@ -35,23 +35,15 @@ class TestBellmanFordGraph(unittest.TestCase):
         self.graph.add_edge(self.e, self.f, 6)
 
     def test_bellman_ford(self):
-        path = rustworkx.graph_bellman_ford_shortest_path_lengths(
-            self.graph, self.a, lambda x: float(x)
-        )
-        path_dijkstra = rustworkx.graph_dijkstra_shortest_path_lengths(
-            self.graph, self.a, lambda x: float(x)
-        )
+        path = rustworkx.graph_bellman_ford_shortest_path_lengths(self.graph, self.a, float)
+        path_dijkstra = rustworkx.graph_dijkstra_shortest_path_lengths(self.graph, self.a, float)
         self.assertEqual(path_dijkstra, path)
 
     def test_bellman_ford_path(self):
-        path = rustworkx.graph_bellman_ford_shortest_paths(
-            self.graph, self.a, weight_fn=lambda x: float(x)
-        )
+        path = rustworkx.graph_bellman_ford_shortest_paths(self.graph, self.a, weight_fn=float)
         # a -> d -> e = 23
         # a -> c -> d -> e = 20
-        expected = rustworkx.graph_dijkstra_shortest_paths(
-            self.graph, self.a, weight_fn=lambda x: float(x)
-        )
+        expected = rustworkx.graph_dijkstra_shortest_paths(self.graph, self.a, weight_fn=float)
         self.assertEqual(expected, path)
 
     def test_bellman_ford_with_no_goal_set(self):
@@ -61,19 +53,19 @@ class TestBellmanFordGraph(unittest.TestCase):
 
     def test_bellman_path(self):
         path = rustworkx.graph_bellman_ford_shortest_paths(
-            self.graph, self.a, weight_fn=lambda x: float(x), target=self.e
+            self.graph, self.a, weight_fn=float, target=self.e
         )
         expected = rustworkx.graph_dijkstra_shortest_paths(
-            self.graph, self.a, weight_fn=lambda x: float(x), target=self.e
+            self.graph, self.a, weight_fn=float, target=self.e
         )
         self.assertEqual(expected, path)
 
     def test_bellman_path_lengths(self):
         path = rustworkx.graph_bellman_ford_shortest_path_lengths(
-            self.graph, self.a, lambda x: float(x), goal=self.e
+            self.graph, self.a, float, goal=self.e
         )
         expected = rustworkx.graph_dijkstra_shortest_path_lengths(
-            self.graph, self.a, lambda x: float(x), goal=self.e
+            self.graph, self.a, float, goal=self.e
         )
         self.assertEqual(expected, path)
 
@@ -110,7 +102,7 @@ class TestBellmanFordGraph(unittest.TestCase):
         g = rustworkx.PyGraph()
         a = g.add_node("A")
         g.add_node("B")
-        path = rustworkx.graph_bellman_ford_shortest_path_lengths(g, a, lambda x: float(x))
+        path = rustworkx.graph_bellman_ford_shortest_path_lengths(g, a, float)
         expected = {}
         self.assertEqual(expected, path)
 
@@ -118,7 +110,7 @@ class TestBellmanFordGraph(unittest.TestCase):
         g = rustworkx.PyGraph()
         a = g.add_node("A")
         g.add_node("B")
-        path = rustworkx.graph_bellman_ford_shortest_paths(g, a, weight_fn=lambda x: float(x))
+        path = rustworkx.graph_bellman_ford_shortest_paths(g, a, weight_fn=float)
         expected = {}
         self.assertEqual(expected, path)
 
@@ -310,11 +302,11 @@ class TestBellmanFordGraph(unittest.TestCase):
     def test_raises_index_error_bellman_ford_paths(self):
         with self.assertRaises(IndexError):
             rustworkx.graph_bellman_ford_shortest_paths(
-                self.graph, len(self.graph.node_indices()) + 1, weight_fn=lambda x: float(x)
+                self.graph, len(self.graph.node_indices()) + 1, weight_fn=float
             )
 
     def test_raises_index_error_bellman_ford_path_lengths(self):
         with self.assertRaises(IndexError):
             rustworkx.graph_bellman_ford_shortest_path_lengths(
-                self.graph, len(self.graph.node_indices()) + 1, edge_cost_fn=lambda x: float(x)
+                self.graph, len(self.graph.node_indices()) + 1, edge_cost_fn=float
             )

--- a/tests/graph/test_contract_nodes.py
+++ b/tests/graph/test_contract_nodes.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import operator as op
 import unittest
 
 import rustworkx
@@ -227,7 +228,7 @@ class TestContractNodesSimpleGraph(unittest.TestCase):
         self.dag.contract_nodes(
             [self.node_b, self.node_c, self.node_d],
             "m",
-            weight_combo_fn=lambda w1, w2: w1 + w2,
+            weight_combo_fn=op.add,
         )
 
         self.assertEqual(set(self.dag.nodes()), {"a", "e", "m"})

--- a/tests/graph/test_dijkstra.py
+++ b/tests/graph/test_dijkstra.py
@@ -35,15 +35,13 @@ class TestDijkstraGraph(unittest.TestCase):
         self.graph.add_edge(self.e, self.f, 6)
 
     def test_dijkstra(self):
-        path = rustworkx.graph_dijkstra_shortest_path_lengths(
-            self.graph, self.a, lambda x: float(x), self.e
-        )
+        path = rustworkx.graph_dijkstra_shortest_path_lengths(self.graph, self.a, float, self.e)
         expected = {4: 20.0}
         self.assertEqual(expected, path)
 
     def test_dijkstra_path(self):
         path = rustworkx.graph_dijkstra_shortest_paths(
-            self.graph, self.a, weight_fn=lambda x: float(x), target=self.e
+            self.graph, self.a, weight_fn=float, target=self.e
         )
         # a -> d -> e = 23
         # a -> c -> d -> e = 20
@@ -95,7 +93,7 @@ class TestDijkstraGraph(unittest.TestCase):
         g = rustworkx.PyGraph()
         a = g.add_node("A")
         g.add_node("B")
-        path = rustworkx.graph_dijkstra_shortest_path_lengths(g, a, lambda x: float(x))
+        path = rustworkx.graph_dijkstra_shortest_path_lengths(g, a, float)
         expected = {}
         self.assertEqual(expected, path)
 
@@ -103,7 +101,7 @@ class TestDijkstraGraph(unittest.TestCase):
         g = rustworkx.PyGraph()
         a = g.add_node("A")
         g.add_node("B")
-        path = rustworkx.graph_dijkstra_shortest_paths(g, a, weight_fn=lambda x: float(x))
+        path = rustworkx.graph_dijkstra_shortest_paths(g, a, weight_fn=float)
         expected = {}
         self.assertEqual(expected, path)
 

--- a/tests/graph/test_isomorphic.py
+++ b/tests/graph/test_isomorphic.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import operator as op
 import unittest
 
 import rustworkx
@@ -35,9 +36,7 @@ class TestIsomorphic(unittest.TestCase):
         g_b = rustworkx.PyGraph()
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    rustworkx.is_isomorphic(g_a, g_b, lambda x, y: x == y, id_order=id_order)
-                )
+                self.assertTrue(rustworkx.is_isomorphic(g_a, g_b, op.eq, id_order=id_order))
 
     def test_isomorphic_identical(self):
         g_a = rustworkx.PyGraph()
@@ -76,9 +75,7 @@ class TestIsomorphic(unittest.TestCase):
         g_b.add_edges_from([(nodes[0], nodes[1], "b_1"), (nodes[1], nodes[2], "b_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertFalse(
-                    rustworkx.is_isomorphic(g_a, g_b, lambda x, y: x == y, id_order=id_order)
-                )
+                self.assertFalse(rustworkx.is_isomorphic(g_a, g_b, op.eq, id_order=id_order))
 
     def test_is_isomorphic_nodes_compare_raises(self):
         g_a = rustworkx.PyGraph()
@@ -106,9 +103,7 @@ class TestIsomorphic(unittest.TestCase):
         g_b.add_edges_from([(nodes[0], nodes[1], "a_1"), (nodes[1], nodes[2], "a_2")])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    rustworkx.is_isomorphic(g_a, g_b, lambda x, y: x == y, id_order=id_order)
-                )
+                self.assertTrue(rustworkx.is_isomorphic(g_a, g_b, op.eq, id_order=id_order))
 
     def test_isomorphic_compare_edges_identical(self):
         g_a = rustworkx.PyGraph()
@@ -125,7 +120,7 @@ class TestIsomorphic(unittest.TestCase):
                     rustworkx.is_isomorphic(
                         g_a,
                         g_b,
-                        edge_matcher=lambda x, y: x == y,
+                        edge_matcher=op.eq,
                         id_order=id_order,
                     )
                 )
@@ -149,9 +144,7 @@ class TestIsomorphic(unittest.TestCase):
         g_b.remove_node(nodes[0])
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
-                self.assertTrue(
-                    rustworkx.is_isomorphic(g_a, g_b, lambda x, y: x == y, id_order=id_order)
-                )
+                self.assertTrue(rustworkx.is_isomorphic(g_a, g_b, op.eq, id_order=id_order))
 
     def test_isomorphic_node_count_not_equal(self):
         g_a = rustworkx.PyGraph()
@@ -243,7 +236,7 @@ class TestIsomorphic(unittest.TestCase):
     def test_isomorphic_parallel_edges_with_edge_matcher(self):
         graph = rustworkx.PyGraph()
         graph.extend_from_weighted_edge_list([(0, 1, "a"), (0, 1, "b"), (1, 2, "c")])
-        self.assertTrue(rustworkx.is_isomorphic(graph, graph, edge_matcher=lambda x, y: x == y))
+        self.assertTrue(rustworkx.is_isomorphic(graph, graph, edge_matcher=op.eq))
 
     def test_graph_isomorphic_insufficient_call_limit(self):
         graph = rustworkx.generators.path_graph(5)

--- a/tests/graph/test_subgraph_isomorphic.py
+++ b/tests/graph/test_subgraph_isomorphic.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import operator as op
 import unittest
 
 import rustworkx
@@ -35,9 +36,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
-                    rustworkx.is_subgraph_isomorphic(
-                        g_a, g_b, lambda x, y: x == y, id_order=id_order
-                    )
+                    rustworkx.is_subgraph_isomorphic(g_a, g_b, op.eq, id_order=id_order)
                 )
 
     def test_subgraph_isomorphic_identical(self):
@@ -85,9 +84,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertFalse(
-                    rustworkx.is_subgraph_isomorphic(
-                        g_a, g_b, lambda x, y: x == y, id_order=id_order
-                    )
+                    rustworkx.is_subgraph_isomorphic(g_a, g_b, op.eq, id_order=id_order)
                 )
 
     def test_subgraph_isomorphic_compare_nodes_identical(self):
@@ -108,9 +105,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         for id_order in [False, True]:
             with self.subTest(id_order=id_order):
                 self.assertTrue(
-                    rustworkx.is_subgraph_isomorphic(
-                        g_a, g_b, lambda x, y: x == y, id_order=id_order
-                    )
+                    rustworkx.is_subgraph_isomorphic(g_a, g_b, op.eq, id_order=id_order)
                 )
 
     def test_is_subgraph_isomorphic_nodes_compare_raises(self):
@@ -148,7 +143,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
                     rustworkx.is_subgraph_isomorphic(
                         g_a,
                         g_b,
-                        edge_matcher=lambda x, y: x == y,
+                        edge_matcher=op.eq,
                         id_order=id_order,
                     )
                 )
@@ -198,9 +193,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         second.extend_from_weighted_edge_list([(0, 1, "a"), (1, 2, "b")])
 
         self.assertTrue(
-            rustworkx.is_subgraph_isomorphic(
-                first, second, induced=False, edge_matcher=lambda x, y: x == y
-            )
+            rustworkx.is_subgraph_isomorphic(first, second, induced=False, edge_matcher=op.eq)
         )
 
     def test_subgraph_isomorphic_mismatch_edge_data_parallel_edges(self):
@@ -210,9 +203,7 @@ class TestSubgraphIsomorphic(unittest.TestCase):
         second.extend_from_weighted_edge_list([(0, 1, "a"), (0, 1, "a"), (1, 2, "b")])
 
         self.assertFalse(
-            rustworkx.is_subgraph_isomorphic(
-                first, second, id_order=True, edge_matcher=lambda x, y: x == y
-            )
+            rustworkx.is_subgraph_isomorphic(first, second, id_order=True, edge_matcher=op.eq)
         )
 
     def test_subgraph_isomorphic_parallel_edges(self):


### PR DESCRIPTION
This just replaces `lambda`s with direct functions (e.g. `lambda x: float(x)` → `float`) or with `operator` module (e.g. `lambda x, y: x == y` → `op.eq`). Makes a lot of lines actually fit into a single line and hopefully improved the readability.