### PR TITLE
Fix clippy warnings for Rust 1.86

### DIFF
--- a/rustworkx-core/src/bipartite_coloring.rs
+++ b/rustworkx-core/src/bipartite_coloring.rs
@@ -411,7 +411,7 @@ fn rbmg_edge_color(g0: &RegularBipartiteMultiGraph) -> Vec<Matching> {
 /// Arguments:
 ///
 /// * `graph` - The graph object to run the algorithm on. The graph is
-///     assumed to be bipartite.
+///   assumed to be bipartite.
 /// * `l_nodes` - The vector containing the "left" nodes of the graph.
 /// * `r_nodes` - The vector containing the "right" nodes of the graph.
 ///

--- a/rustworkx-core/src/centrality.rs
+++ b/rustworkx-core/src/centrality.rs
@@ -39,14 +39,14 @@ use rayon_cond::CondIterator;
 ///
 /// * `graph` - The graph object to run the algorithm on
 /// * `include_endpoints` - Whether to include the endpoints of paths in the path
-///     lengths used to compute the betweenness
+///   lengths used to compute the betweenness
 /// * `normalized` - Whether to normalize the betweenness scores by the number
-///     of distinct paths between all pairs of nodes
+///   of distinct paths between all pairs of nodes
 /// * `parallel_threshold` - The number of nodes to calculate the betweenness
-///     centrality in parallel at, if the number of nodes in `graph` is less
-///     than this value it will run in a single thread. A good default to use
-///     here if you're not sure is `50` as that was found to be roughly the
-///     number of nodes where parallelism improves performance
+///   centrality in parallel at, if the number of nodes in `graph` is less
+///   than this value it will run in a single thread. A good default to use
+///   here if you're not sure is `50` as that was found to be roughly the
+///   number of nodes where parallelism improves performance
 ///
 /// # Example
 /// ```rust
@@ -147,12 +147,12 @@ where
 ///
 /// * `graph` - The graph object to run the algorithm on
 /// * `normalized` - Whether to normalize the betweenness scores by the number
-///     of distinct paths between all pairs of nodes
+///   of distinct paths between all pairs of nodes
 /// * `parallel_threshold` - The number of nodes to calculate the betweenness
-///     centrality in parallel at, if the number of nodes in `graph` is less
-///     than this value it will run in a single thread. A good default to use
-///     here if you're not sure is `50` as that was found to be roughly the
-///     number of nodes where parallelism improves performance
+///   centrality in parallel at, if the number of nodes in `graph` is less
+///   than this value it will run in a single thread. A good default to use
+///   here if you're not sure is `50` as that was found to be roughly the
+///   number of nodes where parallelism improves performance
 ///
 /// # Example
 /// ```rust
@@ -666,12 +666,12 @@ mod test_edge_betweenness_centrality {
 ///
 /// * `graph` - The graph object to run the algorithm on
 /// * `weight_fn` - An input callable that will be passed the `EdgeRef` for
-///     an edge in the graph and is expected to return a `Result<f64>` of
-///     the weight of that edge.
+///   an edge in the graph and is expected to return a `Result<f64>` of
+///   the weight of that edge.
 /// * `max_iter` - The maximum number of iterations in the power method. If
-///     set to `None` a default value of 100 is used.
+///   set to `None` a default value of 100 is used.
 /// * `tol` - The error tolerance used when checking for convergence in the
-///     power method. If set to `None` a default value of 1e-6 is used.
+///   power method. If set to `None` a default value of 1e-6 is used.
 ///
 /// # Example
 /// ```rust
@@ -752,16 +752,16 @@ where
 ///
 /// * `graph` - The graph object to run the algorithm on
 /// * `weight_fn` - An input callable that will be passed the `EdgeRef` for
-///     an edge in the graph and is expected to return a `Result<f64>` of
-///     the weight of that edge.
+///   an edge in the graph and is expected to return a `Result<f64>` of
+///   the weight of that edge.
 /// * `alpha` - Attenuation factor. If set to `None`, a default value of 0.1 is used.
 /// * `beta_map` - Immediate neighbourhood weights. Must contain all node indices or be `None`.
 /// * `beta_scalar` - Immediate neighbourhood scalar that replaces `beta_map` in case `beta_map` is None.
-///     Defaults to 1.0 in case `None` is provided.
+///   Defaults to 1.0 in case `None` is provided.
 /// * `max_iter` - The maximum number of iterations in the power method. If
-///     set to `None` a default value of 100 is used.
+///   set to `None` a default value of 100 is used.
 /// * `tol` - The error tolerance used when checking for convergence in the
-///     power method. If set to `None` a default value of 1e-6 is used.
+///   power method. If set to `None` a default value of 1e-6 is used.
 ///
 /// # Example
 /// ```rust
@@ -1170,9 +1170,9 @@ where
 /// * `graph` - The graph object to run the algorithm on
 /// * `wf_improved` - If `true`, scale by the fraction of nodes reachable.
 /// * `weight_fn` - An input callable that will be passed the
-///     `ReversedEdgeReference<<G as IntoEdgeReferences>::EdgeRef>` for
-///     an edge in the graph and is expected to return a `f64` of
-///     the weight of that edge.
+///   `ReversedEdgeReference<<G as IntoEdgeReferences>::EdgeRef>` for
+///   an edge in the graph and is expected to return a `f64` of
+///   the weight of that edge.
 ///
 /// # Example
 ///

--- a/rustworkx-core/src/coloring.rs
+++ b/rustworkx-core/src/coloring.rs
@@ -402,9 +402,9 @@ where
 ///
 /// * `graph` - The graph object to run the algorithm on
 /// * `preset_color_fn` - A callback function that will receive the node identifier
-///     for each node in the graph and is expected to return an `Option<usize>`
-///     (wrapped in a `Result`) that is `None` if the node has no preset and
-///     the usize represents the preset color.
+///   for each node in the graph and is expected to return an `Option<usize>`
+///   (wrapped in a `Result`) that is `None` if the node has no preset and
+///   the usize represents the preset color.
 ///
 /// # Example
 /// ```rust
@@ -468,9 +468,9 @@ where
 ///
 /// * `graph` - The graph object to run the algorithm on.
 /// * `preset_color_fn` - A callback function that will receive the node identifier
-///     for each node in the graph and is expected to return an `Option<usize>`
-///     (wrapped in a `Result`) that is `None` if the node has no preset and
-///     the usize represents the preset color.
+///   for each node in the graph and is expected to return an `Option<usize>`
+///   (wrapped in a `Result`) that is `None` if the node has no preset and
+///   the usize represents the preset color.
 /// * `strategy` - The greedy strategy used by the algorithm.
 ///
 /// # Example
@@ -581,9 +581,9 @@ where
 ///
 /// * `graph` - The graph object to run the algorithm on.
 /// * `preset_color_fn` - A callback function that will receive the edge identifier
-///     for each edge in the graph and is expected to return an `Option<usize>`
-///     (wrapped in a `Result`) that is `None` if the edge has no preset and
-///     the usize represents the preset color.
+///   for each edge in the graph and is expected to return an `Option<usize>`
+///   (wrapped in a `Result`) that is `None` if the edge has no preset and
+///   the usize represents the preset color.
 /// * `strategy` - The greedy strategy used by the algorithm.
 ///
 /// # Example

--- a/rustworkx-core/src/connectivity/cycle_basis.rs
+++ b/rustworkx-core/src/connectivity/cycle_basis.rs
@@ -34,7 +34,7 @@ use std::hash::Hash;
 ///
 /// * `graph` - The graph in which to find the basis.
 /// * `root` - Optional node index for starting the basis search. If not
-///     specified, an arbitrary node is chosen.
+///   specified, an arbitrary node is chosen.
 ///
 /// # Example
 /// ```rust

--- a/rustworkx-core/src/connectivity/find_cycle.rs
+++ b/rustworkx-core/src/connectivity/find_cycle.rs
@@ -25,7 +25,7 @@ use std::hash::Hash;
 ///
 /// * `graph` - The directed graph in which to find the first cycle.
 /// * `source` - Optional node index for starting the search. If not specified,
-///     an arbitrary node is chosen to start the search.
+///   an arbitrary node is chosen to start the search.
 ///
 /// # Example
 /// ```rust

--- a/rustworkx-core/src/dag_algo.rs
+++ b/rustworkx-core/src/dag_algo.rs
@@ -80,19 +80,19 @@ impl<E: Error> Error for TopologicalSortError<E> {}
 ///
 /// * `dag`: The DAG to get the topological sorted nodes from
 /// * `key`: A function that gets passed a single argument, the node id from
-///     `dag` and is expected to return a key which will be used for
-///     resolving ties in the sorting order.
+///   `dag` and is expected to return a key which will be used for
+///   resolving ties in the sorting order.
 /// * `reverse`: If `false`, perform a regular topological ordering.  If `true`,
-///     return the lexicographical topological order that would have been found
-///     if all the edges in the graph were reversed.  This does not affect the
-///     comparisons from the `key`.
+///   return the lexicographical topological order that would have been found
+///   if all the edges in the graph were reversed.  This does not affect the
+///   comparisons from the `key`.
 /// * `initial`: If given, the initial node indices to start the topological
-///     ordering from.  If not given, the topological ordering will certainly contain every node in
-///     the graph.  If given, only the `initial` nodes and nodes that are dominated by the
-///     `initial` set will be in the ordering.  Notably, any node that has a natural in degree of
-///     zero will not be in the output ordering if `initial` is given and the zero-in-degree node
-///     is not in it.  It is not supported to give an `initial` set where the nodes have even
-///     a partial topological order between themselves and `None` will be returned in this case
+///   ordering from.  If not given, the topological ordering will certainly contain every node in
+///   the graph.  If given, only the `initial` nodes and nodes that are dominated by the
+///   `initial` set will be in the ordering.  Notably, any node that has a natural in degree of
+///   zero will not be in the output ordering if `initial` is given and the zero-in-degree node
+///   is not in it.  It is not supported to give an `initial` set where the nodes have even
+///   a partial topological order between themselves and `None` will be returned in this case
 ///
 /// # Returns
 ///
@@ -348,7 +348,7 @@ where
 ///
 /// * `graph` - The graph to get the layers from
 /// * `first_layer` - A list of node ids for the first layer. This
-///     will be the first layer in the output
+///   will be the first layer in the output
 ///
 /// Will `panic!` if a provided node is not in the graph.
 /// ```
@@ -503,20 +503,20 @@ where
 ///
 /// * `graph`: The DAG to find bicolor runs in
 /// * `filter_fn`: The filter function to use for matching nodes. It takes
-///     in one argument, the node data payload/weight object, and will return a
-///     boolean whether the node matches the conditions or not.
-///     If it returns ``true``, it will continue the bicolor chain.
-///     If it returns ``false``, it will stop the bicolor chain.
-///     If it returns ``None`` it will skip that node.
+///   in one argument, the node data payload/weight object, and will return a
+///   boolean whether the node matches the conditions or not.
+///   If it returns ``true``, it will continue the bicolor chain.
+///   If it returns ``false``, it will stop the bicolor chain.
+///   If it returns ``None`` it will skip that node.
 /// * `color_fn`: The function that gives the color of the edge. It takes
-///     in one argument, the edge data payload/weight object, and will
-///     return a non-negative integer, the edge color. If the color is None,
-///     the edge is ignored.
+///   in one argument, the edge data payload/weight object, and will
+///   return a non-negative integer, the edge color. If the color is None,
+///   the edge is ignored.
 ///
 /// # Returns:
 ///
 /// * `Vec<Vec<G::NodeId>>`: a list of groups with exactly two edge colors, where each group
-///     is a list of node data payload/weight for the nodes in the bicolor run
+///   is a list of node data payload/weight for the nodes in the bicolor run
 /// * `None` if a cycle is found in the graph
 /// * Raises an error if found computing the bicolor runs
 ///
@@ -665,9 +665,9 @@ where
 ///
 /// * `graph`: The DAG to collect runs from
 /// * `include_node_fn`: A filter function used for matching nodes. It takes
-///     in one argument, the node data payload/weight object, and returns a
-///     boolean whether the node matches the conditions or not.
-///     If it returns ``false``, the node will be skipped, cutting the run it's part of.
+///   in one argument, the node data payload/weight object, and returns a
+///   boolean whether the node matches the conditions or not.
+///   If it returns ``false``, the node will be skipped, cutting the run it's part of.
 ///
 /// # Returns:
 ///

--- a/rustworkx-core/src/generators/barbell_graph.rs
+++ b/rustworkx-core/src/generators/barbell_graph.rs
@@ -28,23 +28,23 @@ use crate::utils::pairwise;
 /// Arguments:
 ///
 /// * `num_mesh_nodes` - The number of nodes to generate the mesh graph
-///     with. Node weights will be None if this is specified. If both
-///     `num_mesh_nodes` and `mesh_weights` are set, this will be ignored and
-///     `mesh_weights` will be used.
+///   with. Node weights will be None if this is specified. If both
+///   `num_mesh_nodes` and `mesh_weights` are set, this will be ignored and
+///   `mesh_weights` will be used.
 /// * `num_path_nodes` - The number of nodes to generate the path
-///     with. Node weights will be None if this is specified. If both
-///     `num_path_nodes` and `path_weights` are set, this will be ignored and
-///     `path_weights` will be used.
+///   with. Node weights will be None if this is specified. If both
+///   `num_path_nodes` and `path_weights` are set, this will be ignored and
+///   `path_weights` will be used.
 /// * `mesh_weights` - A list of node weights for the mesh graph. If both
-///     `num_mesh_nodes` and `mesh_weights` are set, `num_mesh_nodes` will
-///     be ignored and `mesh_weights` will be used.
+///   `num_mesh_nodes` and `mesh_weights` are set, `num_mesh_nodes` will
+///   be ignored and `mesh_weights` will be used.
 /// * `path_weights` - A list of node weights for the path. If both
-///     `num_path_nodes` and `path_weights` are set, `num_path_nodes` will
-///     be ignored and `path_weights` will be used.
+///   `num_path_nodes` and `path_weights` are set, `num_path_nodes` will
+///   be ignored and `path_weights` will be used.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes. This is ignored if node weights are specified.
+///   for newly created nodes. This is ignored if node weights are specified.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 ///
 /// # Example
 /// ```rust

--- a/rustworkx-core/src/generators/binomial_tree_graph.rs
+++ b/rustworkx-core/src/generators/binomial_tree_graph.rs
@@ -21,14 +21,14 @@ use super::InvalidInputError;
 ///
 /// * `order` - The order of the binomial tree.
 /// * `weights` - A `Vec` of node weight objects. If the number of weights is
-///     less than 2**order, extra nodes with None will be appended.
+///   less than 2**order, extra nodes with None will be appended.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes. This is ignored if `weights` is specified.
+///   for newly created nodes. This is ignored if `weights` is specified.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 /// * `bidirectional` - Whether edges are added bidirectionally. If set to
-///     `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
-///     If the graph is undirected this will result in a parallel edge.
+///   `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
+///   If the graph is undirected this will result in a parallel edge.
 ///
 /// # Example
 /// ```rust

--- a/rustworkx-core/src/generators/complete_graph.rs
+++ b/rustworkx-core/src/generators/complete_graph.rs
@@ -21,13 +21,13 @@ use super::InvalidInputError;
 /// Arguments:
 ///
 /// * `num_nodes` - The number of nodes to create a complete graph for. Either this or
-///     `weights` must be specified. If both this and `weights` are specified, `weights`
-///     will take priority and this argument will be ignored
+///   `weights` must be specified. If both this and `weights` are specified, `weights`
+///   will take priority and this argument will be ignored
 /// * `weights` - A `Vec` of node weight objects.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes. This is ignored if `weights` is specified.
+///   for newly created nodes. This is ignored if `weights` is specified.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 ///
 /// # Example
 /// ```rust

--- a/rustworkx-core/src/generators/cycle_graph.rs
+++ b/rustworkx-core/src/generators/cycle_graph.rs
@@ -21,16 +21,16 @@ use super::InvalidInputError;
 /// Arguments:
 ///
 /// * `num_nodes` - The number of nodes to create a cycle graph for. Either this or
-///     `weights` must be specified. If both this and `weights` are specified, `weights`
-///     will take priority and this argument will be ignored.
+///   `weights` must be specified. If both this and `weights` are specified, `weights`
+///   will take priority and this argument will be ignored.
 /// * `weights` - A `Vec` of node weight objects.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes. This is ignored if `weights` is specified.
+///   for newly created nodes. This is ignored if `weights` is specified.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 /// * `bidirectional` - Whether edges are added bidirectionally. If set to
-///     `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
-///     If the graph is undirected this will result in a parallel edge.
+///   `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
+///   If the graph is undirected this will result in a parallel edge.
 ///
 /// # Example
 /// ```rust

--- a/rustworkx-core/src/generators/full_rary_tree_graph.rs
+++ b/rustworkx-core/src/generators/full_rary_tree_graph.rs
@@ -26,14 +26,14 @@ use super::InvalidInputError;
 /// * `branching factor` - The number of children at each node.
 /// * `num_nodes` - The number of nodes in the graph.
 /// * `weights` - A list of node weights. If the number of weights is
-///     less than n, extra nodes with None weight will be appended.
+///   less than n, extra nodes with None weight will be appended.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes. This is ignored if `weights` is specified.
+///   for newly created nodes. This is ignored if `weights` is specified.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 /// * `bidirectional` - Whether edges are added bidirectionally. If set to
-///     `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
-///     If the graph is undirected this will result in a parallel edge.
+///   `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
+///   If the graph is undirected this will result in a parallel edge.
 ///
 /// # Example
 /// ```rust

--- a/rustworkx-core/src/generators/grid_graph.rs
+++ b/rustworkx-core/src/generators/grid_graph.rs
@@ -20,24 +20,24 @@ use super::InvalidInputError;
 /// Arguments:
 ///
 /// * `rows` - The number of rows to generate the graph with.
-///     If specified, cols also need to be specified.
+///   If specified, cols also need to be specified.
 /// * `cols`: The number of columns to generate the graph with.
-///     If specified, rows also need to be specified. rows*cols
-///     defines the number of nodes in the graph.
+///   If specified, rows also need to be specified. rows*cols
+///   defines the number of nodes in the graph.
 /// * `weights`: A `Vec` of node weights. Nodes are filled row wise.
-///     If rows and cols are not specified, then a linear graph containing
-///     all the values in weights list is created.
-///     If number of nodes(rows*cols) is less than length of
-///     weights list, the trailing weights are ignored.
-///     If number of nodes(rows*cols) is greater than length of
-///     weights list, extra nodes with None weight are appended.
+///   If rows and cols are not specified, then a linear graph containing
+///   all the values in weights list is created.
+///   If number of nodes(rows*cols) is less than length of
+///   weights list, the trailing weights are ignored.
+///   If number of nodes(rows*cols) is greater than length of
+///   weights list, extra nodes with None weight are appended.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes. This is ignored if `weights` is specified.
+///   for newly created nodes. This is ignored if `weights` is specified.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 /// * `bidirectional` - Whether edges are added bidirectionally. If set to
-///     `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
-///     If the graph is undirected this will result in a parallel edge.
+///   `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
+///   If the graph is undirected this will result in a parallel edge.
 ///
 /// # Example
 /// ```rust

--- a/rustworkx-core/src/generators/heavy_hex_graph.rs
+++ b/rustworkx-core/src/generators/heavy_hex_graph.rs
@@ -56,14 +56,14 @@ use super::InvalidInputError;
 /// Arguments:
 ///
 /// * `d` - Distance of the code. If `d` is set to `1` a graph with a
-///     single node will be returned. `d` must be an odd number.
+///   single node will be returned. `d` must be an odd number.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes. This is ignored if `weights` is specified.
+///   for newly created nodes. This is ignored if `weights` is specified.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 /// * `bidirectional` - Whether edges are added bidirectionally. If set to
-///     `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
-///     If the graph is undirected this will result in a parallel edge.
+///   `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
+///   If the graph is undirected this will result in a parallel edge.
 ///
 /// # Example
 /// ```rust
@@ -128,7 +128,7 @@ where
         return Ok(graph);
     }
     let num_data = d * d;
-    let num_syndrome = (d - 1) * (d + 1) / 2;
+    let num_syndrome = (d - 1) * d.div_ceil(2);
     let num_flag = d * (d - 1);
 
     let nodes_data: Vec<G::NodeId> = (0..num_data)
@@ -154,7 +154,7 @@ where
     }
 
     // connect data and syndromes
-    for (i, syndrome_chunk) in nodes_syndrome.chunks((d + 1) / 2).enumerate() {
+    for (i, syndrome_chunk) in nodes_syndrome.chunks(d.div_ceil(2)).enumerate() {
         if i % 2 == 0 {
             graph.add_edge(nodes_data[i * d], syndrome_chunk[0], default_edge_weight());
             graph.add_edge(
@@ -197,7 +197,7 @@ where
     }
 
     // connect flag and syndromes
-    for (i, syndrome_chunk) in nodes_syndrome.chunks((d + 1) / 2).enumerate() {
+    for (i, syndrome_chunk) in nodes_syndrome.chunks(d.div_ceil(2)).enumerate() {
         if i % 2 == 0 {
             for (j, syndrome) in syndrome_chunk.iter().enumerate() {
                 if j != 0 {

--- a/rustworkx-core/src/generators/heavy_square_graph.rs
+++ b/rustworkx-core/src/generators/heavy_square_graph.rs
@@ -45,14 +45,14 @@ use super::InvalidInputError;
 /// Arguments:
 ///
 /// * `d` - Distance of the code. If `d` is set to `1` a graph with a
-///     single node will be returned. `d` must be an odd number.
+///   single node will be returned. `d` must be an odd number.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes. This is ignored if `weights` is specified.
+///   for newly created nodes. This is ignored if `weights` is specified.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 /// * `bidirectional` - Whether edges are added bidirectionally. If set to
-///     `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
-///     If the graph is undirected this will result in a parallel edge.
+///   `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
+///   If the graph is undirected this will result in a parallel edge.
 ///
 /// # Example
 /// ```rust

--- a/rustworkx-core/src/generators/hexagonal_lattice_graph.rs
+++ b/rustworkx-core/src/generators/hexagonal_lattice_graph.rs
@@ -206,15 +206,15 @@ impl HexagonalLatticeBuilder {
 /// * `rows` - The number of rows to generate the graph with.
 /// * `cols` - The number of columns to generate the graph with.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes.
+///   for newly created nodes.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 /// * `bidirectional` - Whether edges are added bidirectionally. If set to
-///     `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
-///     If the graph is undirected this will result in a parallel edge.
+///   `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
+///   If the graph is undirected this will result in a parallel edge.
 /// * `periodic` - If set to `true`, the boundaries of the lattice will be
-///     joined to form a periodic grid. Requires `cols` to be even,
-///     `rows > 1`, and `cols > 1`.
+///   joined to form a periodic grid. Requires `cols` to be even,
+///   `rows > 1`, and `cols > 1`.
 ///
 /// # Example
 /// ```rust

--- a/rustworkx-core/src/generators/hexagonal_lattice_graph.rs
+++ b/rustworkx-core/src/generators/hexagonal_lattice_graph.rs
@@ -292,17 +292,17 @@ where
 /// * `rows` - The number of rows to generate the graph with.
 /// * `cols` - The number of columns to generate the graph with.
 /// * `node_weight` - A callable that will return the weight to use
-///     for newly created nodes. Must take two arguments `i` and `j` of
-///     type `usize`, where `(i, j)` gives the position of the node
-///     in the lattice.
+///   for newly created nodes. Must take two arguments `i` and `j` of
+///   type `usize`, where `(i, j)` gives the position of the node
+///   in the lattice.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 /// * `bidirectional` - Whether edges are added bidirectionally. If set to
-///     `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
-///     If the graph is undirected this will result in a parallel edge.
+///   `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
+///   If the graph is undirected this will result in a parallel edge.
 /// * `periodic` - If set to `true`, the boundaries of the lattice will be
-///     joined to form a periodic grid. Requires `cols` to be even,
-///     `rows > 1`, and `cols > 1`.
+///   joined to form a periodic grid. Requires `cols` to be even,
+///   `rows > 1`, and `cols > 1`.
 ///
 /// # Example
 /// ```rust

--- a/rustworkx-core/src/generators/karate_club.rs
+++ b/rustworkx-core/src/generators/karate_club.rs
@@ -22,11 +22,11 @@ use petgraph::visit::{Data, NodeIndexable};
 /// Arguments:
 ///
 /// * `default_node_weight` - A callable that will receive a boolean, indicating
-///     if a node is part of Mr Hi's faction (True) or the Officer's faction (false).
-///     It should return the node weight according to the desired type.
+///   if a node is part of Mr Hi's faction (True) or the Officer's faction (false).
+///   It should return the node weight according to the desired type.
 /// * `default_edge_weight` - A callable that will receive the integer representing
-///     the strength of the relation between two nodes. It should return the edge
-///      weight according to the desired type.
+///   the strength of the relation between two nodes. It should return the edge
+///   weight according to the desired type.
 ///
 pub fn karate_club_graph<G, T, F, H, M>(mut default_node_weight: F, mut default_edge_weight: H) -> G
 where

--- a/rustworkx-core/src/generators/lollipop_graph.rs
+++ b/rustworkx-core/src/generators/lollipop_graph.rs
@@ -27,23 +27,23 @@ use crate::utils::pairwise;
 /// Arguments:
 ///
 /// * `num_mesh_nodes` - The number of nodes to generate the mesh graph
-///     with. Node weights will be None if this is specified. If both
-///     `num_mesh_nodes` and `mesh_weights` are set this will be ignored and
-///     `mesh_weights` will be used.
+///   with. Node weights will be None if this is specified. If both
+///   `num_mesh_nodes` and `mesh_weights` are set this will be ignored and
+///   `mesh_weights` will be used.
 /// * `num_path_nodes` - The number of nodes to generate the path
-///     with. Node weights will be None if this is specified. If both
-///     `num_path_nodes` and `path_weights` are set this will be ignored and
-///     `path_weights` will be used.
+///   with. Node weights will be None if this is specified. If both
+///   `num_path_nodes` and `path_weights` are set this will be ignored and
+///   `path_weights` will be used.
 /// * `mesh_weights` - A list of node weights for the mesh graph. If both
-///     `num_mesh_nodes` and `mesh_weights` are set `num_mesh_nodes` will
-///     be ignored and `mesh_weights` will be used.
+///   `num_mesh_nodes` and `mesh_weights` are set `num_mesh_nodes` will
+///   be ignored and `mesh_weights` will be used.
 /// * `path_weights` - A list of node weights for the path. If both
-///     `num_path_nodes` and `path_weights` are set `num_path_nodes` will
-///     be ignored and `path_weights` will be used.
+///   `num_path_nodes` and `path_weights` are set `num_path_nodes` will
+///   be ignored and `path_weights` will be used.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes. This is ignored if `weights` is specified.
+///   for newly created nodes. This is ignored if `weights` is specified.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 ///
 /// # Example
 /// ```rust

--- a/rustworkx-core/src/generators/path_graph.rs
+++ b/rustworkx-core/src/generators/path_graph.rs
@@ -21,16 +21,16 @@ use super::InvalidInputError;
 /// Arguments:
 ///
 /// * `num_nodes` - The number of nodes to create a path graph for. Either this or
-///     `weights` must be specified. If both this and `weights` are specified, `weights`
-///     will take priority and this argument will be ignored
+///   `weights` must be specified. If both this and `weights` are specified, `weights`
+///   will take priority and this argument will be ignored
 /// * `weights` - A `Vec` of node weight objects.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes. This is ignored if `weights` is specified.
+///   for newly created nodes. This is ignored if `weights` is specified.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 /// * `bidirectional` - Whether edges are added bidirectionally. If set to
-///     `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
-///     If the graph is undirected this will result in a parallel edge.
+///   `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
+///   If the graph is undirected this will result in a parallel edge.
 ///
 /// # Example
 /// ```rust

--- a/rustworkx-core/src/generators/petersen_graph.rs
+++ b/rustworkx-core/src/generators/petersen_graph.rs
@@ -23,15 +23,15 @@ use super::InvalidInputError;
 ///   The Petersen graph itself is denoted `G(5, 2)`
 ///
 /// * `n` - Number of nodes in the internal star and external regular polygon.
-///     n > 2.
+///   n > 2.
 /// * `k` - Shift that changes the internal star graph. k > 0 and 2 * k < n.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes. This is ignored if `weights` is specified.
+///   for newly created nodes. This is ignored if `weights` is specified.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 /// * `bidirectional` - Whether edges are added bidirectionally. If set to
-///     `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
-///     If the graph is undirected this will result in a parallel edge.
+///   `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
+///   If the graph is undirected this will result in a parallel edge.
 ///
 /// # Example
 /// ```rust

--- a/rustworkx-core/src/generators/random_graph.rs
+++ b/rustworkx-core/src/generators/random_graph.rs
@@ -319,13 +319,13 @@ where
 ///
 /// * `sizes` - Number of nodes in each block.
 /// * `probabilities` - B x B array that contains the connection probability between
-///     nodes of different blocks. Must be symmetric for undirected graphs.
+///   nodes of different blocks. Must be symmetric for undirected graphs.
 /// * `loops` - Determines whether the graph can have loops or not.
 /// * `seed` - An optional seed to use for the random number generator.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes.
+///   for newly created nodes.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 ///
 /// # Example
 /// ```rust
@@ -470,12 +470,12 @@ fn distance(x: &[f64], y: &[f64], p: f64) -> f64 {
 /// * `dim` - Dimension of node positions. Default: 2
 /// * `pos` - Optional list with node positions as values.
 /// * `p` - Which Minkowski distance metric to use.  `p` has to meet the condition
-///     ``1 <= p <= infinity``.
-///     If this argument is not specified, the L<sup>2</sup> metric
-///     (the Euclidean distance metric), `p = 2` is used.
+///   ``1 <= p <= infinity``.
+///   If this argument is not specified, the L<sup>2</sup> metric
+///   (the Euclidean distance metric), `p = 2` is used.
 /// * `seed` - An optional seed to use for the random number generator.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 ///
 /// # Example
 /// ```rust
@@ -563,13 +563,13 @@ where
 /// * `m` - The number of edges to attach from a new node to existing nodes.
 /// * `seed` - An optional seed to use for the random number generator.
 /// * `initial_graph` - An optional starting graph to expand, if not specified
-///     a star graph of `m` nodes is generated and used. If specified the input
-///     graph is mutated by this function and is expected to be moved into this
-///     function.
+///   a star graph of `m` nodes is generated and used. If specified the input
+///   graph is mutated by this function and is expected to be moved into this
+///   function.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes.
+///   for newly created nodes.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 ///
 /// An `InvalidInput` error is returned under the following conditions. If `m < 1`
 /// or `m >= n` and if an `initial_graph` is specified and the number of nodes in
@@ -678,9 +678,9 @@ where
 /// * `probability` - The probability of creating an edge between two nodes as a float.
 /// * `seed` - An optional seed to use for the random number generator.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes.
+///   for newly created nodes.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 ///
 /// # Example
 /// ```rust
@@ -758,15 +758,15 @@ where
 /// Arguments:
 ///
 /// * `pos` - Hyperboloid model coordinates of the nodes `[p_1, p_2, ...]` where `p_i` is the
-///     position of node i. The "time" coordinates are inferred.
+///   position of node i. The "time" coordinates are inferred.
 /// * `beta` - Sigmoid sharpness (nonnegative) of the connection probability.
 /// * `r` - Distance at which the connection probability is 0.5 for the probabilistic model.
-///     Threshold when `beta` is `None`.
+///   Threshold when `beta` is `None`.
 /// * `seed` - An optional seed to use for the random number generator.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes.
+///   for newly created nodes.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 ///
 /// # Example
 /// ```rust

--- a/rustworkx-core/src/generators/random_graph.rs
+++ b/rustworkx-core/src/generators/random_graph.rs
@@ -58,9 +58,9 @@ use super::InvalidInputError;
 /// * `probability` - The probability of creating an edge between two nodes as a float.
 /// * `seed` - An optional seed to use for the random number generator.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes.
+///   for newly created nodes.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 ///
 /// # Example
 /// ```rust
@@ -211,9 +211,9 @@ where
 /// * `num_edges` - The number of edges to create in the graph.
 /// * `seed` - An optional seed to use for the random number generator.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes.
+///   for newly created nodes.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 ///
 /// # Example
 /// ```rust

--- a/rustworkx-core/src/generators/star_graph.rs
+++ b/rustworkx-core/src/generators/star_graph.rs
@@ -21,19 +21,19 @@ use super::InvalidInputError;
 /// Arguments:
 ///
 /// * `num_nodes` - The number of nodes to create a star graph for. Either this or
-///     `weights` must be specified. If both this and `weights` are specified, weights
-///     will take priority and this argument will be ignored
+///   `weights` must be specified. If both this and `weights` are specified, weights
+///   will take priority and this argument will be ignored
 /// * `weights` - A `Vec` of node weight objects.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes. This is ignored if `weights` is specified.
+///   for newly created nodes. This is ignored if `weights` is specified.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 /// * `inward` - If set `true` the nodes will be directed towards the
-///     center node. This parameter is ignored if `bidirectional` is set to
-///     `true`.
+///   center node. This parameter is ignored if `bidirectional` is set to
+///   `true`.
 /// * `bidirectional` - Whether edges are added bidirectionally. If set to
-///     `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
-///     If the graph is undirected this will result in a parallel edge.
+///   `true` then for any edge `(u, v)` an edge `(v, u)` will also be added.
+///   If the graph is undirected this will result in a parallel edge.
 ///
 /// # Example
 /// ```rust

--- a/rustworkx-core/src/line_graph.rs
+++ b/rustworkx-core/src/line_graph.rs
@@ -26,9 +26,9 @@ use petgraph::visit::{Data, EdgeCount, EdgeRef, IntoEdges, IntoNodeIdentifiers};
 ///
 /// * `input_graph` - The input graph `G`.
 /// * `default_node_weight` - A callable that will return the weight to use
-///     for newly created nodes.
+///   for newly created nodes.
 /// * `default_edge_weight` - A callable that will return the weight object
-///     to use for newly created edges.
+///   to use for newly created edges.
 ///
 /// Returns the constructed line graph `L(G)`, and the map from the edges of `L(G)` to
 /// the vertices of `G`.

--- a/rustworkx-core/src/max_weight_matching.rs
+++ b/rustworkx-core/src/max_weight_matching.rs
@@ -820,14 +820,14 @@ fn verify_optimum(
 ///
 /// * `graph` - The undirected graph to compute the maximum weight matching for
 /// * `max_cardinality` - If set to true compute the maximum-cardinality matching
-///     with maximum weight among all maximum-cardinality matchings
+///   with maximum weight among all maximum-cardinality matchings
 /// * `weight_fn` - A callback function that will be give a edge reference and
-///     expected to return a `i128` representing the weight of the edge
+///   expected to return a `i128` representing the weight of the edge
 /// * `verify_optimum_flag`: If true an prior to returning an additional routine
-///     to verify the optimal solution was found will be run after computing
-///     the maximum weight matching. If it's true and the found matching is not
-///     an optimal solution this function will panic. This option should
-///     normally be only set true during testing.
+///   to verify the optimal solution was found will be run after computing
+///   the maximum weight matching. If it's true and the found matching is not
+///   an optimal solution this function will panic. This option should
+///   normally be only set true during testing.
 ///
 /// # Example
 /// ```rust

--- a/rustworkx-core/src/token_swapper.rs
+++ b/rustworkx-core/src/token_swapper.rs
@@ -407,8 +407,8 @@ where
 /// * `trials` - Optional number of trials. If None, defaults to 4.
 /// * `seed` - Optional integer seed. If None, the internal rng will be initialized from system entropy.
 /// * `parallel_threshold` - Optional integer for the number of nodes in the graph that will
-///     trigger the use of parallel threads. If the number of nodes in the graph is less than this value
-///     it will run in a single thread. The default value is 50.
+///   trigger the use of parallel threads. If the number of nodes in the graph is less than this value
+///   it will run in a single thread. The default value is 50.
 ///
 /// It returns a list of tuples representing the swaps to perform. The result will be an
 /// `Err(MapNotPossible)` if the `token_swapper()` function can't find a mapping.

--- a/rustworkx-core/src/traversal/dfs_edges.rs
+++ b/rustworkx-core/src/traversal/dfs_edges.rs
@@ -44,10 +44,10 @@ use petgraph::visit::{
 ///
 /// * `graph` - the graph to run on
 /// * `source` - the optional node index to use as the starting node for the
-///     depth-first search. If specified the edge list will only return edges
-///     in the components reachable from this index. If this is not specified
-///     then a source will be chosen arbitrarily and repeated until all
-///     components of the graph are searched
+///   depth-first search. If specified the edge list will only return edges
+///   in the components reachable from this index. If this is not specified
+///   then a source will be chosen arbitrarily and repeated until all
+///   components of the graph are searched
 ///
 /// # Example
 /// ```rust


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Mostly about https://rust-lang.github.io/rust-clippy/master/index.html#doc_overindented_list_items

There was also https://rust-lang.github.io/rust-clippy/master/index.html#manual_div_ceil
