### PR TITLE
Fix `cargo clippy` not covering `rustworkx-core` tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,9 +43,9 @@ jobs:
       - name: Check stray release notes
         run: python tools/find_stray_release_notes.py
       - name: rustworkx-core Rust Tests
-        run: pushd rustworkx-core && cargo test && popd
+        run: cargo test --workspace
       - name: rustworkx-core Docs
-        run: pushd rustworkx-core && cargo doc && popd
+        run: cargo doc -p rustworkx-core
         env:
           RUSTDOCFLAGS: '-D warnings'
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Rust Format
         run: cargo fmt --all -- --check
       - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Black Codestyle Format
         run: black --check --diff retworkx rustworkx retworkx tests
       - name: Python Lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,10 +228,16 @@ what CI is checking.
 ##### Lint
 
 An additional step is to run [clippy](https://github.com/rust-lang/rust-clippy)
-on your changes. You can run it by running:
+on your changes. You can execute it by running:
 
 ```bash
 cargo clippy
+```
+
+If you want a more detailed feedback identical to CI, run instead:
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
 ```
 
 #### Python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,10 +203,8 @@ https://doc.rust-lang.org/book/ch11-01-writing-tests.html
 
 The rustworkx-core tests can be run with:
 ```
-cargo test
+cargo test --workspace
 ```
-
-from the `rustworkx-core` directory.
 
 ### Style
 
@@ -273,10 +271,9 @@ you can view locally in a web browser.
 To build the rustworkx-core documentation you will use rust-doc. You can do this
 by running:
 ```
-cargo doc
+cargo doc -p rustworkx-core
 ```
-from the `rustworkx-core` directory (which is the root of the `rustworkx-core`
-crate. After it's built the compiled documentation will be located in
+After it's built the compiled documentation will be located in
 `target/doc/rustworkx_core` (which is off the repo root not the `rustworkx-core`
 dir)
 
@@ -284,7 +281,7 @@ You can build and open the documentation directly in your configured default
 web browser by running:
 
 ```
-cargo doc --open
+cargo doc -p rustworkx-core --open
 ```
 
 ### Type Annotations

--- a/rustworkx-core/src/bipartite_coloring.rs
+++ b/rustworkx-core/src/bipartite_coloring.rs
@@ -979,9 +979,9 @@ mod test_bipartite_coloring {
 
     #[test]
     fn test_bipartite_random_graphs_undirected() {
-        for num_l_nodes in vec![5, 10, 15, 20] {
-            for num_r_nodes in vec![5, 10, 15, 20] {
-                for probability in vec![0.1, 0.3, 0.5, 0.7, 0.9] {
+        for num_l_nodes in [5, 10, 15, 20] {
+            for num_r_nodes in [5, 10, 15, 20] {
+                for probability in [0.1, 0.3, 0.5, 0.7, 0.9] {
                     let graph: petgraph::graph::UnGraph<(), ()> = random_bipartite_graph(
                         num_l_nodes,
                         num_r_nodes,
@@ -1013,9 +1013,9 @@ mod test_bipartite_coloring {
 
     #[test]
     fn test_bipartite_random_graphs_directed() {
-        for num_l_nodes in vec![5, 10, 15, 20] {
-            for num_r_nodes in vec![5, 10, 15, 20] {
-                for probability in vec![0.1, 0.3, 0.5, 0.7, 0.9] {
+        for num_l_nodes in [5, 10, 15, 20] {
+            for num_r_nodes in [5, 10, 15, 20] {
+                for probability in [0.1, 0.3, 0.5, 0.7, 0.9] {
                     let graph: petgraph::graph::DiGraph<(), ()> = random_bipartite_graph(
                         num_l_nodes,
                         num_r_nodes,

--- a/rustworkx-core/src/bipartite_coloring.rs
+++ b/rustworkx-core/src/bipartite_coloring.rs
@@ -969,8 +969,8 @@ mod test_bipartite_coloring {
                 if n > 2 * k {
                     let graph: petgraph::graph::UnGraph<(), ()> =
                         petersen_graph(n, k, || (), || ()).unwrap();
-                        if let Ok(_) = bipartite_edge_color(&graph) {
-                            panic!("This should error")
+                    if bipartite_edge_color(&graph).is_ok() {
+                        panic!("This should error")
                     }
                 }
             }

--- a/rustworkx-core/src/bipartite_coloring.rs
+++ b/rustworkx-core/src/bipartite_coloring.rs
@@ -969,9 +969,8 @@ mod test_bipartite_coloring {
                 if n > 2 * k {
                     let graph: petgraph::graph::UnGraph<(), ()> =
                         petersen_graph(n, k, || (), || ()).unwrap();
-                    match bipartite_edge_color(&graph) {
-                        Ok(_) => panic!("This should error"),
-                        Err(_) => (),
+                        if let Ok(_) = bipartite_edge_color(&graph) {
+                            panic!("This should error")
                     }
                 }
             }

--- a/rustworkx-core/src/coloring.rs
+++ b/rustworkx-core/src/coloring.rs
@@ -1017,7 +1017,7 @@ mod test_node_coloring {
         let graph = Graph::<(), (), Undirected>::new_undirected();
         let preset_color_fn = |_| Ok::<Option<usize>, Infallible>(None);
 
-        for strategy in vec![
+        for strategy in [
             ColoringStrategy::Degree,
             ColoringStrategy::Saturation,
             ColoringStrategy::IndependentSet,
@@ -1308,7 +1308,7 @@ mod test_node_coloring {
             path_graph(Some(7), None, || (), || (), false).unwrap();
         let preset_color_fn = |_| Ok::<Option<usize>, Infallible>(None);
 
-        for strategy in vec![
+        for strategy in [
             ColoringStrategy::Degree,
             ColoringStrategy::Saturation,
             ColoringStrategy::IndependentSet,
@@ -1326,7 +1326,7 @@ mod test_node_coloring {
             cycle_graph(Some(15), None, || (), || (), false).unwrap();
         let preset_color_fn = |_| Ok::<Option<usize>, Infallible>(None);
 
-        for strategy in vec![
+        for strategy in [
             ColoringStrategy::Degree,
             ColoringStrategy::Saturation,
             ColoringStrategy::IndependentSet,
@@ -1344,7 +1344,7 @@ mod test_node_coloring {
             heavy_hex_graph(7, || (), || (), false).unwrap();
         let preset_color_fn = |_| Ok::<Option<usize>, Infallible>(None);
 
-        for strategy in vec![
+        for strategy in [
             ColoringStrategy::Degree,
             ColoringStrategy::Saturation,
             ColoringStrategy::IndependentSet,
@@ -1362,7 +1362,7 @@ mod test_node_coloring {
             complete_graph(Some(10), None, || (), || ()).unwrap();
         let preset_color_fn = |_| Ok::<Option<usize>, Infallible>(None);
 
-        for strategy in vec![
+        for strategy in [
             ColoringStrategy::Degree,
             ColoringStrategy::Saturation,
             ColoringStrategy::IndependentSet,

--- a/rustworkx-core/src/connectivity/johnson_simple_cycles.rs
+++ b/rustworkx-core/src/connectivity/johnson_simple_cycles.rs
@@ -489,7 +489,7 @@ mod test_longest_path {
             );
             let mut cycles_iter = johnson_simple_cycles(&graph, None);
             let mut res = 0;
-            while let Some(_) = cycles_iter.next(&graph) {
+            while cycles_iter.next(&graph).is_some() {
                 res += 1;
             }
             assert_eq!(res, 3 * k);
@@ -523,7 +523,7 @@ mod test_longest_path {
             );
             let mut cycles_iter = johnson_simple_cycles(&graph, None);
             let mut res = 0;
-            while let Some(_) = cycles_iter.next(&graph) {
+            while cycles_iter.next(&graph).is_some() {
                 res += 1;
             }
             assert_eq!(res, 3 * k);

--- a/rustworkx-core/src/dag_algo.rs
+++ b/rustworkx-core/src/dag_algo.rs
@@ -1418,7 +1418,7 @@ mod test_collect_runs {
         let mut runs = collect_runs(&graph, |_| -> Result<bool, ()> { Ok(true) }).expect("Some");
 
         let run = runs.next();
-        assert!(run == None);
+        assert!(run.is_none());
 
         let runs = collect_runs(&graph, |_| -> Result<bool, ()> { Ok(true) }).expect("Some");
 

--- a/rustworkx-core/src/generators/hexagonal_lattice_graph.rs
+++ b/rustworkx-core/src/generators/hexagonal_lattice_graph.rs
@@ -380,7 +380,7 @@ mod tests {
 
     fn check_expected_edges_directed<T>(
         graph: &petgraph::graph::DiGraph<T, ()>,
-        expected_edges: &Vec<(usize, usize)>,
+        expected_edges: &[(usize, usize)],
     ) {
         assert_eq!(graph.edge_count(), expected_edges.len());
 
@@ -394,7 +394,7 @@ mod tests {
 
     fn check_expected_edges_undirected(
         graph: &petgraph::graph::UnGraph<(), ()>,
-        expected_edges: &Vec<(usize, usize)>,
+        expected_edges: &[(usize, usize)],
     ) {
         assert_eq!(graph.edge_count(), expected_edges.len());
 
@@ -409,12 +409,12 @@ mod tests {
         let edge_set: HashSet<(usize, usize)> = graph
             .edge_references()
             .map(|edge| (edge.source().index(), edge.target().index()))
-            .map(|e| sorted_pair(e))
+            .map(&sorted_pair)
             .collect();
         let expected_set: HashSet<(usize, usize)> = expected_edges
             .iter()
-            .map(|&e| e)
-            .map(|e| sorted_pair(e))
+            .copied()
+            .map(&sorted_pair)
             .collect();
         assert_eq!(edge_set, expected_set);
     }

--- a/rustworkx-core/src/generators/hexagonal_lattice_graph.rs
+++ b/rustworkx-core/src/generators/hexagonal_lattice_graph.rs
@@ -388,7 +388,7 @@ mod tests {
             .edge_references()
             .map(|edge| (edge.source().index(), edge.target().index()))
             .collect();
-        let expected_set: HashSet<(usize, usize)> = expected_edges.iter().map(|&e| e).collect();
+        let expected_set: HashSet<(usize, usize)> = expected_edges.iter().copied().collect();
         assert_eq!(edge_set, expected_set);
     }
 
@@ -411,11 +411,8 @@ mod tests {
             .map(|edge| (edge.source().index(), edge.target().index()))
             .map(&sorted_pair)
             .collect();
-        let expected_set: HashSet<(usize, usize)> = expected_edges
-            .iter()
-            .copied()
-            .map(&sorted_pair)
-            .collect();
+        let expected_set: HashSet<(usize, usize)> =
+            expected_edges.iter().copied().map(&sorted_pair).collect();
         assert_eq!(edge_set, expected_set);
     }
 

--- a/rustworkx-core/src/generators/random_graph.rs
+++ b/rustworkx-core/src/generators/random_graph.rs
@@ -1029,10 +1029,10 @@ mod tests {
         assert_eq!(g.node_count(), 3);
         assert_eq!(g.edge_count(), 6);
         for (u, v) in [(1, 1), (1, 2), (2, 1), (2, 2), (0, 1), (0, 2)] {
-            assert_eq!(g.contains_edge(u.into(), v.into()), true);
+            assert!(g.contains_edge(u.into(), v.into()));
         }
-        assert_eq!(g.contains_edge(1.into(), 0.into()), false);
-        assert_eq!(g.contains_edge(2.into(), 0.into()), false);
+        assert!(!g.contains_edge(1.into(), 0.into()));
+        assert!(!g.contains_edge(2.into(), 0.into()));
     }
 
     #[test]
@@ -1049,9 +1049,9 @@ mod tests {
         assert_eq!(g.node_count(), 3);
         assert_eq!(g.edge_count(), 5);
         for (u, v) in [(1, 1), (1, 2), (2, 2), (0, 1), (0, 2)] {
-            assert_eq!(g.contains_edge(u.into(), v.into()), true);
+            assert!(g.contains_edge(u.into(), v.into()));
         }
-        assert_eq!(g.contains_edge(0.into(), 0.into()), false);
+        assert!(!g.contains_edge(0.into(), 0.into()));
     }
 
     #[test]
@@ -1068,12 +1068,12 @@ mod tests {
         assert_eq!(g.node_count(), 3);
         assert_eq!(g.edge_count(), 4);
         for (u, v) in [(1, 2), (2, 1), (0, 1), (0, 2)] {
-            assert_eq!(g.contains_edge(u.into(), v.into()), true);
+            assert!(g.contains_edge(u.into(), v.into()));
         }
-        assert_eq!(g.contains_edge(1.into(), 0.into()), false);
-        assert_eq!(g.contains_edge(2.into(), 0.into()), false);
+        assert!(!g.contains_edge(1.into(), 0.into()));
+        assert!(!g.contains_edge(2.into(), 0.into()));
         for u in 0..2 {
-            assert_eq!(g.contains_edge(u.into(), u.into()), false);
+            assert!(!g.contains_edge(u.into(), u.into()));
         }
     }
 
@@ -1091,10 +1091,10 @@ mod tests {
         assert_eq!(g.node_count(), 3);
         assert_eq!(g.edge_count(), 3);
         for (u, v) in [(1, 2), (0, 1), (0, 2)] {
-            assert_eq!(g.contains_edge(u.into(), v.into()), true);
+            assert!(g.contains_edge(u.into(), v.into()));
         }
         for u in 0..2 {
-            assert_eq!(g.contains_edge(u.into(), u.into()), false);
+            assert!(!g.contains_edge(u.into(), u.into()));
         }
     }
 

--- a/rustworkx-core/src/generators/random_graph.rs
+++ b/rustworkx-core/src/generators/random_graph.rs
@@ -334,7 +334,7 @@ where
 /// use rustworkx_core::generators::sbm_random_graph;
 ///
 /// let g = sbm_random_graph::<petgraph::graph::DiGraph<(), ()>, (), _, _, ()>(
-///     &vec![1, 2],
+///     &[1, 2],
 ///     &ndarray::arr2(&[[0., 1.], [0., 1.]]).view(),
 ///     true,
 ///     Some(10),
@@ -1018,7 +1018,7 @@ mod tests {
     #[test]
     fn test_sbm_directed_complete_blocks_loops() {
         let g = sbm_random_graph::<petgraph::graph::DiGraph<(), ()>, (), _, _, ()>(
-            &vec![1, 2],
+            &[1, 2],
             &ndarray::arr2(&[[0., 1.], [0., 1.]]).view(),
             true,
             Some(10),
@@ -1038,7 +1038,7 @@ mod tests {
     #[test]
     fn test_sbm_undirected_complete_blocks_loops() {
         let g = sbm_random_graph::<petgraph::graph::UnGraph<(), ()>, (), _, _, ()>(
-            &vec![1, 2],
+            &[1, 2],
             &ndarray::arr2(&[[0., 1.], [1., 1.]]).view(),
             true,
             Some(10),
@@ -1057,7 +1057,7 @@ mod tests {
     #[test]
     fn test_sbm_directed_complete_blocks_noloops() {
         let g = sbm_random_graph::<petgraph::graph::DiGraph<(), ()>, (), _, _, ()>(
-            &vec![1, 2],
+            &[1, 2],
             &ndarray::arr2(&[[0., 1.], [0., 1.]]).view(),
             false,
             Some(10),
@@ -1080,7 +1080,7 @@ mod tests {
     #[test]
     fn test_sbm_undirected_complete_blocks_noloops() {
         let g = sbm_random_graph::<petgraph::graph::UnGraph<(), ()>, (), _, _, ()>(
-            &vec![1, 2],
+            &[1, 2],
             &ndarray::arr2(&[[0., 1.], [1., 1.]]).view(),
             false,
             Some(10),
@@ -1101,7 +1101,7 @@ mod tests {
     #[test]
     fn test_sbm_bad_array_rows_error() {
         match sbm_random_graph::<petgraph::graph::DiGraph<(), ()>, (), _, _, ()>(
-            &vec![1, 2],
+            &[1, 2],
             &ndarray::arr2(&[[0., 1.], [1., 1.], [1., 1.]]).view(),
             true,
             Some(10),
@@ -1116,7 +1116,7 @@ mod tests {
 
     fn test_sbm_bad_array_cols_error() {
         match sbm_random_graph::<petgraph::graph::DiGraph<(), ()>, (), _, _, ()>(
-            &vec![1, 2],
+            &[1, 2],
             &ndarray::arr2(&[[0., 1., 1.], [1., 1., 1.]]).view(),
             true,
             Some(10),
@@ -1131,7 +1131,7 @@ mod tests {
     #[test]
     fn test_sbm_asymmetric_array_error() {
         match sbm_random_graph::<petgraph::graph::UnGraph<(), ()>, (), _, _, ()>(
-            &vec![1, 2],
+            &[1, 2],
             &ndarray::arr2(&[[0., 1.], [0., 1.]]).view(),
             true,
             Some(10),
@@ -1146,7 +1146,7 @@ mod tests {
     #[test]
     fn test_sbm_invalid_probability_error() {
         match sbm_random_graph::<petgraph::graph::UnGraph<(), ()>, (), _, _, ()>(
-            &vec![1, 2],
+            &[1, 2],
             &ndarray::arr2(&[[0., 1.], [0., -1.]]).view(),
             true,
             Some(10),
@@ -1161,7 +1161,7 @@ mod tests {
     #[test]
     fn test_sbm_empty_error() {
         match sbm_random_graph::<petgraph::graph::DiGraph<(), ()>, (), _, _, ()>(
-            &vec![],
+            &[],
             &ndarray::arr2(&[[]]).view(),
             true,
             Some(10),

--- a/rustworkx-core/src/generators/random_graph.rs
+++ b/rustworkx-core/src/generators/random_graph.rs
@@ -1355,10 +1355,7 @@ mod tests {
     }
     #[test]
     fn test_hyperbolic_dist_inf() {
-        assert_eq!(
-            hyperbolic_distance(&[f64::INFINITY, 0.], &[0., 0.]).is_nan(),
-            true
-        );
+        assert!(hyperbolic_distance(&[f64::INFINITY, 0.], &[0., 0.]).is_nan());
     }
 
     #[test]

--- a/rustworkx-core/src/line_graph.rs
+++ b/rustworkx-core/src/line_graph.rs
@@ -104,7 +104,6 @@ where
 }
 
 #[cfg(test)]
-
 mod test_line_graph {
     use crate::line_graph::line_graph;
     use crate::petgraph::visit::EdgeRef;

--- a/rustworkx-core/src/traversal/mod.rs
+++ b/rustworkx-core/src/traversal/mod.rs
@@ -267,7 +267,7 @@ mod test_bfs_ancestry {
     #[test]
     fn test_bfs_predecessors_digraph() {
         let graph: DiGraph<(), ()> =
-            DiGraph::from_edges(&[(0, 1), (1, 2), (1, 3), (2, 4), (3, 4), (4, 5)]);
+            DiGraph::from_edges([(0, 1), (1, 2), (1, 3), (2, 4), (3, 4), (4, 5)]);
         let predecessors: Vec<(usize, Vec<usize>)> = bfs_predecessors(&graph, NodeIndex::new(3))
             .map(|(x, succ)| (x.index(), succ.iter().map(|y| y.index()).collect()))
             .collect();
@@ -280,7 +280,7 @@ mod test_bfs_ancestry {
     #[test]
     fn test_bfs_successors() {
         let graph: DiGraph<(), ()> =
-            DiGraph::from_edges(&[(0, 1), (1, 2), (1, 3), (2, 4), (3, 4), (4, 5)]);
+            DiGraph::from_edges([(0, 1), (1, 2), (1, 3), (2, 4), (3, 4), (4, 5)]);
         let successors: Vec<(usize, Vec<usize>)> = bfs_successors(&graph, NodeIndex::new(3))
             .map(|(x, succ)| (x.index(), succ.iter().map(|y| y.index()).collect()))
             .collect();
@@ -293,7 +293,7 @@ mod test_bfs_ancestry {
     #[test]
     fn test_no_predecessors() {
         let graph: StableDiGraph<(), ()> =
-            StableDiGraph::from_edges(&[(0, 1), (1, 2), (1, 3), (2, 4), (3, 4), (4, 5)]);
+            StableDiGraph::from_edges([(0, 1), (1, 2), (1, 3), (2, 4), (3, 4), (4, 5)]);
         let predecessors: Vec<(usize, Vec<usize>)> = bfs_predecessors(&graph, NodeIndex::new(0))
             .map(|(x, succ)| (x.index(), succ.iter().map(|y| y.index()).collect()))
             .collect();
@@ -303,7 +303,7 @@ mod test_bfs_ancestry {
     #[test]
     fn test_no_successors() {
         let graph: StableDiGraph<(), ()> =
-            StableDiGraph::from_edges(&[(0, 1), (1, 2), (1, 3), (2, 4), (3, 4), (4, 5)]);
+            StableDiGraph::from_edges([(0, 1), (1, 2), (1, 3), (2, 4), (3, 4), (4, 5)]);
         let successors: Vec<(usize, Vec<usize>)> = bfs_successors(&graph, NodeIndex::new(5))
             .map(|(x, succ)| (x.index(), succ.iter().map(|y| y.index()).collect()))
             .collect();
@@ -320,7 +320,7 @@ mod test_ancestry {
     #[test]
     fn test_ancestors_digraph() {
         let graph: DiGraph<(), ()> =
-            DiGraph::from_edges(&[(0, 1), (1, 2), (1, 3), (2, 4), (3, 4), (4, 5)]);
+            DiGraph::from_edges([(0, 1), (1, 2), (1, 3), (2, 4), (3, 4), (4, 5)]);
         let ancestors: Vec<usize> = ancestors(&graph, NodeIndex::new(3))
             .map(|x| x.index())
             .collect();
@@ -330,7 +330,7 @@ mod test_ancestry {
     #[test]
     fn test_descendants() {
         let graph: DiGraph<(), ()> =
-            DiGraph::from_edges(&[(0, 1), (1, 2), (1, 3), (2, 4), (3, 4), (4, 5)]);
+            DiGraph::from_edges([(0, 1), (1, 2), (1, 3), (2, 4), (3, 4), (4, 5)]);
         let descendants: Vec<usize> = descendants(&graph, NodeIndex::new(3))
             .map(|x| x.index())
             .collect();


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Right now, if one runs `cargo clippy --all-targets` inside the `rustwork-core` directory, it will find lints from clippy. Sure, they are for tests, but they are still lints.

To address that, in this PR I:
* Fixed the findings from the lints
* Transitioned to running the lint with `cargo clippy --workspace` which does include the tests
* Updated `CONTRIBUTIGNG.md` and CI to stop having to run commands inside the `rustworkx-core` directory. For most cases, `cargo` provides commands that work with all workspace crates at the root