### PR TITLE
Add docstrings to exceptions and sort their list alphabetically

### DIFF
--- a/docs/source/api/exceptions.rst
+++ b/docs/source/api/exceptions.rst
@@ -4,16 +4,18 @@ Exceptions
 .. autosummary::
    :toctree: ../apiref
 
-   rustworkx.InvalidNode
-   rustworkx.DAGWouldCycle
-   rustworkx.NoEdgeBetweenNodes
    rustworkx.DAGHasCycle
-   rustworkx.NegativeCycle
-   rustworkx.NoSuitableNeighbors
-   rustworkx.NoPathFound
-   rustworkx.NullGraph
-   rustworkx.visit.StopSearch
-   rustworkx.visit.PruneSearch
-   rustworkx.JSONSerializationError
-   rustworkx.InvalidMapping
+   rustworkx.DAGWouldCycle
+   rustworkx.FailedToConverge
    rustworkx.GraphNotBipartite
+   rustworkx.InvalidMapping
+   rustworkx.InvalidNode
+   rustworkx.JSONDeserializationError
+   rustworkx.JSONSerializationError
+   rustworkx.NegativeCycle
+   rustworkx.NoEdgeBetweenNodes
+   rustworkx.NoPathFound
+   rustworkx.NoSuitableNeighbors
+   rustworkx.NullGraph
+   rustworkx.visit.PruneSearch
+   rustworkx.visit.StopSearch

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,36 +384,88 @@ fn generic_class_getitem(
     })
 }
 
-// The provided node is invalid.
-create_exception!(rustworkx, InvalidNode, PyException);
-// Performing this operation would result in trying to add a cycle to a DAG.
-create_exception!(rustworkx, DAGWouldCycle, PyException);
-// There is no edge present between the provided nodes.
-create_exception!(rustworkx, NoEdgeBetweenNodes, PyException);
-// The specified Directed Graph has a cycle and can't be treated as a DAG.
-create_exception!(rustworkx, DAGHasCycle, PyException);
-// No neighbors found matching the provided predicate.
-create_exception!(rustworkx, NoSuitableNeighbors, PyException);
-// Invalid operation on a null graph
-create_exception!(rustworkx, NullGraph, PyException);
-// No path was found between the specified nodes.
-create_exception!(rustworkx, NoPathFound, PyException);
-// No mapping was found for the request swapping
-create_exception!(rustworkx, InvalidMapping, PyException);
+create_exception!(
+    rustworkx,
+    InvalidNode,
+    PyException,
+    "The provided node is invalid."
+);
+create_exception!(
+    rustworkx,
+    DAGWouldCycle,
+    PyException,
+    "Performing this operation would result in trying to add a cycle to a DAG."
+);
+create_exception!(
+    rustworkx,
+    NoEdgeBetweenNodes,
+    PyException,
+    "There is no edge present between the provided nodes."
+);
+create_exception!(
+    rustworkx,
+    DAGHasCycle,
+    PyException,
+    "The specified Directed Graph has a cycle and can't be treated as a DAG."
+);
+create_exception!(
+    rustworkx,
+    NoSuitableNeighbors,
+    PyException,
+    "No neighbors found matching the provided predicate."
+);
+create_exception!(
+    rustworkx,
+    NullGraph,
+    PyException,
+    "Invalid operation on a null graph"
+);
+create_exception!(
+    rustworkx,
+    NoPathFound,
+    PyException,
+    "No path was found between the specified nodes."
+);
+create_exception!(
+    rustworkx,
+    InvalidMapping,
+    PyException,
+    "No mapping was found for the request swapping"
+);
 // Prune part of the search tree while traversing a graph.
 import_exception!(rustworkx.visit, PruneSearch);
 // Stop graph traversal.
 import_exception!(rustworkx.visit, StopSearch);
-// JSON Error
-create_exception!(rustworkx, JSONSerializationError, PyException);
-// JSON Error
-create_exception!(rustworkx, JSONDeserializationError, PyException);
-// Negative Cycle found on shortest-path algorithm
-create_exception!(rustworkx, NegativeCycle, PyException);
-// Failed to Converge on a solution
-create_exception!(rustworkx, FailedToConverge, PyException);
-// Graph is not bipartite
-create_exception!(rustworkx, GraphNotBipartite, PyException);
+create_exception!(
+    rustworkx,
+    JSONSerializationError,
+    PyException,
+    "JSON Serialization Error"
+);
+create_exception!(
+    rustworkx,
+    JSONDeserializationError,
+    PyException,
+    "JSON Deserialization Error"
+);
+create_exception!(
+    rustworkx,
+    NegativeCycle,
+    PyException,
+    "Negative Cycle found on shortest-path algorithm"
+);
+create_exception!(
+    rustworkx,
+    FailedToConverge,
+    PyException,
+    "Failed to Converge on a solution"
+);
+create_exception!(
+    rustworkx,
+    GraphNotBipartite,
+    PyException,
+    "Graph is not bipartite"
+);
 
 #[pymodule]
 fn rustworkx(py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {


### PR DESCRIPTION
The [exceptions API](https://www.rustworkx.org/api/exceptions.html) was quite empty and since PyO3 [allows](https://github.com/PyO3/pyo3/pull/2027) adding docstrings to `create_exception`, I moved the comments to docstrings and also completed and sorted alphabetically their list in the API docs.