### PR TITLE
Bump petgraph to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,12 +403,14 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "7a98c6720655620a521dcc722d0ad66cd8afd5d86e34a89ef691c50b7b24de06"
 dependencies = [
  "fixedbitset",
+ "hashbrown",
  "indexmap",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ fixedbitset = "0.5.7"
 indexmap = { version = ">=1.9, <3", features = ["rayon"] }
 ndarray = { version = "0.16.1", features = ["rayon"] }
 num-traits = "0.2"
-petgraph = "0.7"
+petgraph = "0.8"
 hashbrown = { version = ">=0.13, <0.16", features = ["rayon"] }
 numpy = "0.24"
 rand = "0.8"

--- a/releasenotes/notes/bump-petgraph-79f354e3dce1aa14.yaml
+++ b/releasenotes/notes/bump-petgraph-79f354e3dce1aa14.yaml
@@ -1,0 +1,11 @@
+---
+upgrade:
+  - |
+    The version of petgraph used in ``rustworkx-core`` has been bumped to
+    0.8.1 from 0.7.1. This means for users of ``rustworkx-core`` that are
+    passing graph objects built using petgraph to algorithm functions you need
+    to ensure you upgrade your petgraph usage accordingly. This is handled
+    correctly if you use the petgraph re-export from ``rustworkx_core::petgraph``.
+    Any API changes around the usage of petgraph will need to be reflected in
+    the upgrade of your usage however. Refer to the release documentation for
+    petgraph 0.8.0 for details.

--- a/rustworkx-core/src/graph_ext/mod.rs
+++ b/rustworkx-core/src/graph_ext/mod.rs
@@ -64,6 +64,8 @@
 //! | EdgeRemovable                 | x     |  x          |          |             |       |       |
 //! | EdgeFindable                  | x     |  x          |          |             |       |       |
 
+use std::hash::BuildHasher;
+
 use petgraph::graph::IndexType;
 use petgraph::graphmap::{GraphMap, NodeTrait};
 use petgraph::matrix_graph::{MatrixGraph, Nullable};
@@ -119,8 +121,8 @@ where
     }
 }
 
-impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType> NodeRemovable
-    for MatrixGraph<N, E, Ty, Null, Ix>
+impl<N, E, S: BuildHasher, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType> NodeRemovable
+    for MatrixGraph<N, E, S, Ty, Null, Ix>
 {
     type Output = Option<Self::NodeWeight>;
     fn remove_node(&mut self, node: Self::NodeId) -> Self::Output {

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -843,7 +843,7 @@ pub fn graph_all_simple_paths(
         Some(depth) => depth - 2,
     };
     let cutoff_petgraph: Option<usize> = cutoff.map(|depth| depth - 2);
-    let result: Vec<Vec<usize>> = algo::all_simple_paths(
+    let result: Vec<Vec<usize>> = algo::all_simple_paths::<Vec<_>, _, ahash::RandomState>(
         &graph.graph,
         from_index,
         to_index,
@@ -897,7 +897,7 @@ pub fn digraph_all_simple_paths(
         Some(depth) => depth - 2,
     };
     let cutoff_petgraph: Option<usize> = cutoff.map(|depth| depth - 2);
-    let result: Vec<Vec<usize>> = algo::all_simple_paths(
+    let result: Vec<Vec<usize>> = algo::all_simple_paths::<Vec<_>, _, ahash::RandomState>(
         &graph.graph,
         from_index,
         to_index,


### PR DESCRIPTION
This commit bumps the petgraph version used in rustworkx to the latest release 0.8.1. This is technically an api change for rustworkx-core as some of the generics (mostly around MatrixGraph) changed, but also because now when building rustworkx-core only petgraph 0.8.1 objects are accepted and older releases are no longer compatible with rustworkx-core. This is not generally an issue if you use the rustworkx-core petgraph re-export at ``rustworkx_core::petgraph``, but as 0.8.1 does contain some api changes users will need to account for those when upgrading to rustworkx-core 0.17.0.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
