### PR TITLE
Adding fuzz targets for special graphs

### DIFF
--- a/rustworkx-core/fuzz/Cargo.toml
+++ b/rustworkx-core/fuzz/Cargo.toml
@@ -34,3 +34,17 @@ path = "fuzz_targets/test_fuzz_bellman_ford.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "test_fuzz_heavy_hex_graph"
+path = "fuzz_targets/test_fuzz_heavy_hex_graph.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "test_fuzz_lollipop_graph"
+path = "fuzz_targets/test_fuzz_lollipop_graph.rs"
+test = false
+doc = false
+bench = false

--- a/rustworkx-core/fuzz/fuzz_targets/test_fuzz_heavy_hex_graph.rs
+++ b/rustworkx-core/fuzz/fuzz_targets/test_fuzz_heavy_hex_graph.rs
@@ -1,0 +1,28 @@
+#![no_main]
+
+use arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use rustworkx_core::generators::heavy_hex_graph;
+use rustworkx_core::petgraph::graph::UnGraph;
+
+#[derive(Debug, Arbitrary)]
+struct HeavyHexInput {
+    d: usize,
+    bidirectional: bool,
+}
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(input) = HeavyHexInput::arbitrary(&mut Unstructured::new(data)) {
+        fuzz_heavy_hex_graph(input);
+    }
+});
+
+fn fuzz_heavy_hex_graph(input: HeavyHexInput) {
+    let d = input.d % 21 | 1;
+    let _ = heavy_hex_graph::<UnGraph<(), ()>, (), _, _, ()>(
+        d,
+        || (),
+        || (),
+        input.bidirectional,
+    );
+}

--- a/rustworkx-core/fuzz/fuzz_targets/test_fuzz_lollipop_graph.rs
+++ b/rustworkx-core/fuzz/fuzz_targets/test_fuzz_lollipop_graph.rs
@@ -1,0 +1,52 @@
+#![no_main]
+
+use arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use rustworkx_core::generators::lollipop_graph;
+use rustworkx_core::petgraph::graph::UnGraph;
+
+#[derive(Debug, Arbitrary)]
+struct LollipopInput {
+    num_mesh_nodes: Option<usize>,
+    num_path_nodes: Option<usize>,
+    mesh_weights: Option<Vec<u8>>,
+    path_weights: Option<Vec<u8>>,
+}
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(input) = LollipopInput::arbitrary(&mut Unstructured::new(data)) {
+        fuzz_lollipop_graph(input);
+    }
+});
+
+fn fuzz_lollipop_graph(input: LollipopInput) {
+    if let Some(n) = input.num_mesh_nodes {
+        if n > 512 {
+            return;
+        }
+    }
+    if let Some(n) = input.num_path_nodes {
+        if n > 512 {
+            return;
+        }
+    }
+    if let Some(ref w) = input.mesh_weights {
+        if w.len() > 512 {
+            return;
+        }
+    }
+    if let Some(ref w) = input.path_weights {
+        if w.len() > 512 {
+            return;
+        }
+    }
+
+    let _ = lollipop_graph::<UnGraph<u8, ()>, u8, _, _, ()>(
+        input.num_mesh_nodes,
+        input.num_path_nodes,
+        input.mesh_weights.clone(),
+        input.path_weights.clone(),
+        || 0,
+        || (),
+    );
+}


### PR DESCRIPTION
Added Fuzz targets for heavy-hex graph and lollipop graph to test their robustness for various inputs.
