### PR TITLE
Update cibuildwheel to 2.23.2 in order to unblock i686 builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.21.3
+          python -m pip install cibuildwheel==2.23.2
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -105,7 +105,7 @@ jobs:
           platforms: all
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.21.3
+          python -m pip install cibuildwheel==2.23.2
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -143,7 +143,7 @@ jobs:
           platforms: all
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.21.3
+          python -m pip install cibuildwheel==2.23.2
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -176,7 +176,7 @@ jobs:
         run: rustup default stable-i686-pc-windows-msvc
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.21.3
+          python -m pip install cibuildwheel==2.23.2
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Closes #1432 

In short, this incorporates https://github.com/pypa/cibuildwheel/issues/2305 which fixes our issue in i686 builds

Test build: https://github.com/IvanIsCoding/rustworkx/actions/runs/14562751655

