### PR TITLE
Minor improvements: prevent future test failures, remove `fixtures`, and more

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,14 +72,13 @@ testinfra = [
 ]
 test = [
   "setuptools-rust",
-  "fixtures",
   "testtools>=2.5.0",
-  "networkx>=2.5",
+  "networkx>=3.2",
   "stestr>=4.1",
 ]
 lint = [
     "black~=24.8",
-    "ruff~=0.6",
+    "ruff==0.11.9",
     "setuptools-rust",
     "typos~=1.28",
 ]
@@ -106,7 +105,7 @@ releaseinfra = [
 
 [tool.black]
 line-length = 100
-target-version = ['py39', 'py310', 'py311', 'py312']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
 
 [tool.ruff]
 line-length = 105 # more lenient than black due to long function signatures

--- a/rustworkx-core/src/generators/random_graph.rs
+++ b/rustworkx-core/src/generators/random_graph.rs
@@ -41,7 +41,7 @@ use super::InvalidInputError;
 ///
 /// Raises an error if
 ///
-/// This algorithm is based on the implementation of networkx functon
+/// This algorithm is based on the implementation of networkx function
 /// <https://github.com/networkx/networkx/blob/networkx-2.4/networkx/generators/random_graphs.py>
 ///
 /// A. Steger and N. Wormald,

--- a/tests/digraph/test_node_link_json.py
+++ b/tests/digraph/test_node_link_json.py
@@ -174,7 +174,11 @@ class TestNodeLinkJSON(unittest.TestCase):
 
     def test_round_trip_networkx(self):
         graph = nx.generators.path_graph(5, create_using=nx.DiGraph)
-        node_link_str = json.dumps(nx.node_link_data(graph, edges="links"))
+        try:
+            node_link_str = json.dumps(nx.node_link_data(graph, edges="links"))
+        except TypeError:
+            # TODO: Remove this once we no longer need to support Python 3.9
+            node_link_str = json.dumps(nx.node_link_data(graph))
         new = rustworkx.parse_node_link_json(node_link_str)
         self.assertIsInstance(new, rustworkx.PyDiGraph)
         self.assertEqual(new.num_nodes(), graph.number_of_nodes())

--- a/tests/digraph/test_node_link_json.py
+++ b/tests/digraph/test_node_link_json.py
@@ -174,7 +174,7 @@ class TestNodeLinkJSON(unittest.TestCase):
 
     def test_round_trip_networkx(self):
         graph = nx.generators.path_graph(5, create_using=nx.DiGraph)
-        node_link_str = json.dumps(nx.node_link_data(graph))
+        node_link_str = json.dumps(nx.node_link_data(graph, edges="links"))
         new = rustworkx.parse_node_link_json(node_link_str)
         self.assertIsInstance(new, rustworkx.PyDiGraph)
         self.assertEqual(new.num_nodes(), graph.number_of_nodes())

--- a/tests/graph/test_node_link_json.py
+++ b/tests/graph/test_node_link_json.py
@@ -174,7 +174,7 @@ class TestNodeLinkJSON(unittest.TestCase):
 
     def test_round_trip_networkx(self):
         graph = nx.generators.path_graph(5)
-        node_link_str = json.dumps(nx.node_link_data(graph))
+        node_link_str = json.dumps(nx.node_link_data(graph, edges="links"))
         new = rustworkx.parse_node_link_json(node_link_str)
         self.assertIsInstance(new, rustworkx.PyGraph)
         self.assertEqual(new.num_nodes(), graph.number_of_nodes())

--- a/tests/graph/test_node_link_json.py
+++ b/tests/graph/test_node_link_json.py
@@ -174,7 +174,11 @@ class TestNodeLinkJSON(unittest.TestCase):
 
     def test_round_trip_networkx(self):
         graph = nx.generators.path_graph(5)
-        node_link_str = json.dumps(nx.node_link_data(graph, edges="links"))
+        try:
+            node_link_str = json.dumps(nx.node_link_data(graph, edges="links"))
+        except TypeError:
+            # TODO: Remove this once we no longer need to support Python 3.9
+            node_link_str = json.dumps(nx.node_link_data(graph))
         new = rustworkx.parse_node_link_json(node_link_str)
         self.assertIsInstance(new, rustworkx.PyGraph)
         self.assertEqual(new.num_nodes(), graph.number_of_nodes())


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

This PR is a collection of minor things:
* Removes the `fixtures` test dependency. I don't know when we stopped using it but it seems it can go
* Fixes a warning from NetworkX that I noticed in https://github.com/Qiskit/rustworkx/pull/1440#issuecomment-2858445887.  Our tests would start failing with NetworkX 3.6.
* Fixes a typo that makes `nox -elint` fail
* Pins `ruff`. Right now, we have `ruff~=0.6`. But `ruff` has not achieved a major version yet, so this is essentially running the latest version!


