### PR TITLE
Added property checks for lollipop graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +111,16 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "log",
+ "regex",
+]
 
 [[package]]
 name = "equivalent"
@@ -250,6 +269,12 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "matrixmultiply"
@@ -528,6 +553,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f71ee38b42f8459a88d3362be6f9b841ad2d5421844f61eb1c59c11bff3ac14a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +705,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +780,8 @@ dependencies = [
  "num-traits",
  "petgraph",
  "priority-queue",
+ "quickcheck",
+ "quickcheck_macros",
  "rand 0.9.1",
  "rand_distr",
  "rand_pcg",

--- a/rustworkx-core/Cargo.toml
+++ b/rustworkx-core/Cargo.toml
@@ -25,3 +25,9 @@ rand_distr.workspace = true
 rand_pcg.workspace = true
 rayon.workspace = true
 rayon-cond = "0.4"
+quickcheck = "1.0"
+quickcheck_macros = "1.0"
+
+[[test]]
+name = "quickcheck_special_graph"
+path = "tests/quickcheck/special_graph.rs"

--- a/rustworkx-core/tests/quickcheck/special_graph.rs
+++ b/rustworkx-core/tests/quickcheck/special_graph.rs
@@ -1,0 +1,44 @@
+use petgraph::graph::UnGraph;
+use quickcheck::{quickcheck, TestResult};
+use rustworkx_core::generators::lollipop_graph;
+
+#[test]
+fn prop_lollipop_graph_structure() {
+    fn prop(mesh_size: usize, path_size: usize) -> TestResult {
+        // Constrain input space for sanity
+        let mesh_size = mesh_size % 64;
+        let path_size = path_size % 64;
+
+        if mesh_size + path_size == 0 {
+            return TestResult::discard();
+        }
+        if mesh_size <= 1 {
+            return TestResult::discard();
+        }
+
+        let graph = match lollipop_graph::<UnGraph<(), ()>, (), _, _, ()>(
+            Some(mesh_size),
+            Some(path_size),
+            None,
+            None,
+            || (),
+            || (),
+        ) {
+            Ok(g) => g,
+            Err(_) => return TestResult::error("Unexpected error in graph generation"),
+        };
+
+        let expected_nodes = mesh_size + path_size;
+        let mesh_edges = mesh_size * (mesh_size - 1) / 2;
+        let path_edges = path_size.saturating_sub(1);
+        let connector = if path_size > 0 { 1 } else { 0 };
+        let expected_edges = mesh_edges + path_edges + connector;
+
+        let node_match = graph.node_count() == expected_nodes;
+        let edge_match = graph.edge_count() == expected_edges;
+
+        TestResult::from_bool(node_match && edge_match)
+    }
+
+    quickcheck(prop as fn(usize, usize) -> TestResult);
+}


### PR DESCRIPTION
Added a test using QuickCheck to verify that the lollipop_graph generator produces graphs with the correct number of nodes and edges based on the input sizes of the mesh and path.

Updated the Cargo.toml to add dependecies and test target.

