### PR TITLE
fix: Expose can_contract_without_cycle as public API and fixes

### DIFF
--- a/rustworkx-core/src/graph_ext/mod.rs
+++ b/rustworkx-core/src/graph_ext/mod.rs
@@ -77,8 +77,8 @@ pub mod contraction;
 pub mod multigraph;
 
 pub use contraction::{
-    ContractNodesDirected, ContractNodesSimpleDirected, ContractNodesSimpleUndirected,
-    ContractNodesUndirected,
+    can_contract_without_cycle, ContractNodesDirected, ContractNodesSimpleDirected,
+    ContractNodesSimpleUndirected, ContractNodesUndirected,
 };
 pub use multigraph::{HasParallelEdgesDirected, HasParallelEdgesUndirected};
 


### PR DESCRIPTION
## Expose can_contract_without_cycle as a public API for node contraction feasibility

**Closes #1009**

### Summary

This PR exposes a function to check if a set of nodes in a directed graph can be contracted without introducing a cycle, as requested in  #1009

### Details

- Renamed the internal `can_contract` function to `can_contract_without_cycle` for clarity and consistency with the suggested API name.
- Made `can_contract_without_cycle` a public function and added a detailed docstring with usage examples.
- Updated all internal references to use the new function name.
- Re-exported `can_contract_without_cycle` in `graph_ext/mod.rs` so it is available as part of the public API (`rustworkx_core::graph_ext::can_contract_without_cycle`).
- Fixed the doctest for `can_contract_without_cycle` to construct the `IndexSet` with `foldhash::fast::RandomState`, matching the function signature.