### PR TITLE
Fix #840: Add GraphML serializer

### DIFF
--- a/rustworkx/rustworkx.pyi
+++ b/rustworkx/rustworkx.pyi
@@ -68,6 +68,20 @@ class ColoringStrategy:
     Saturation: Any
     IndependentSet: Any
 
+@final
+class Domain:
+    Node: Domain
+    Edge: Domain
+    Graph: Domain
+    All: Domain
+
+@final
+class Type:
+    Boolean: Type
+    Int: Type
+    Float: Type
+    Long: Type
+
 # Cartesian product
 
 def digraph_cartesian_product(
@@ -680,11 +694,23 @@ def directed_random_bipartite_graph(
 
 # Read Write
 
+def read_graphml_with_keys(
+    path: str,
+    /,
+    compression: str | None = ...,
+) -> tuple[list[tuple[str, Domain, str, Type, Any]], list[PyGraph | PyDiGraph]]: ...
 def read_graphml(
     path: str,
     /,
     compression: str | None = ...,
 ) -> list[PyGraph | PyDiGraph]: ...
+def write_graphml(
+    graphs: list[PyGraph | PyDiGraph],
+    keys: list[tuple[str, Domain, str, Type, Any]],
+    path: str,
+    /,
+    compression: str | None = ...,
+) -> None: ...
 def digraph_node_link_json(
     graph: PyDiGraph[_S, _T],
     /,

--- a/src/graphml.rs
+++ b/src/graphml.rs
@@ -12,26 +12,29 @@
 
 #![allow(clippy::borrow_as_ptr)]
 
+use std::borrow::{Borrow, Cow};
 use std::convert::From;
 use std::ffi::OsStr;
 use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, BufWriter};
 use std::iter::FromIterator;
 use std::num::{ParseFloatError, ParseIntError};
 use std::path::Path;
 use std::str::ParseBoolError;
 
 use flate2::bufread::GzDecoder;
-use hashbrown::HashMap;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use hashbrown::{HashMap, HashSet};
 use indexmap::IndexMap;
 
-use quick_xml::events::{BytesStart, Event};
+use quick_xml::events::{BytesDecl, BytesStart, BytesText, Event};
 use quick_xml::name::QName;
 use quick_xml::Error as XmlError;
-use quick_xml::Reader;
+use quick_xml::{Reader, Writer};
 
 use petgraph::algo;
-use petgraph::{Directed, Undirected};
+use petgraph::{Directed, EdgeType, Undirected};
 
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
@@ -46,6 +49,7 @@ pub enum Error {
     NotFound(String),
     UnSupported(String),
     InvalidDoc(String),
+    IO(String),
 }
 
 impl From<XmlError> for Error {
@@ -76,6 +80,13 @@ impl From<ParseFloatError> for Error {
     }
 }
 
+impl From<std::io::Error> for Error {
+    #[inline]
+    fn from(e: std::io::Error) -> Error {
+        Error::IO(format!("Input/output error: {}", e))
+    }
+}
+
 impl From<Error> for PyErr {
     #[inline]
     fn from(error: Error) -> PyErr {
@@ -84,7 +95,8 @@ impl From<Error> for PyErr {
             | Error::ParseValue(msg)
             | Error::NotFound(msg)
             | Error::UnSupported(msg)
-            | Error::InvalidDoc(msg) => PyException::new_err(msg),
+            | Error::InvalidDoc(msg)
+            | Error::IO(msg) => PyException::new_err(msg),
         }
     }
 }
@@ -112,15 +124,32 @@ fn xml_attribute<'a>(element: &'a BytesStart<'a>, key: &[u8]) -> Result<String, 
         })
 }
 
-#[derive(Clone, Copy)]
-enum Domain {
+#[pyclass(eq)]
+#[derive(Clone, Copy, PartialEq)]
+pub enum Domain {
     Node,
     Edge,
     Graph,
     All,
 }
 
-enum Type {
+impl TryFrom<&[u8]> for Domain {
+    type Error = ();
+
+    fn try_from(value: &[u8]) -> Result<Self, ()> {
+        match value {
+            b"node" => Ok(Domain::Node),
+            b"edge" => Ok(Domain::Edge),
+            b"graph" => Ok(Domain::Graph),
+            b"all" => Ok(Domain::All),
+            _ => Err(()),
+        }
+    }
+}
+
+#[pyclass(eq)]
+#[derive(Clone, Copy, PartialEq)]
+pub enum Type {
     Boolean,
     Int,
     Float,
@@ -129,7 +158,20 @@ enum Type {
     Long,
 }
 
-#[derive(Clone)]
+impl Into<&'static str> for Type {
+    fn into(self) -> &'static str {
+        match self {
+            Type::Boolean => "boolean",
+            Type::Int => "int",
+            Type::Float => "float",
+            Type::Double => "double",
+            Type::String => "string",
+            Type::Long => "long",
+        }
+    }
+}
+
+#[derive(Clone, PartialEq)]
 enum Value {
     Boolean(bool),
     Int(isize),
@@ -138,6 +180,27 @@ enum Value {
     String(String),
     Long(isize),
     UnDefined,
+}
+
+impl Value {
+    fn serialize(&self) -> Option<Cow<str>> {
+        match self {
+            Value::Boolean(val) => Some(Cow::from(val.to_string())),
+            Value::Int(val) => Some(Cow::from(val.to_string())),
+            Value::Float(val) => Some(Cow::from(val.to_string())),
+            Value::Double(val) => Some(Cow::from(val.to_string())),
+            Value::String(val) => Some(Cow::from(val)),
+            Value::Long(val) => Some(Cow::from(val.to_string())),
+            Value::UnDefined => None,
+        }
+    }
+
+    fn to_id(&self) -> PyResult<&str> {
+        match self {
+            Value::String(value_str) => Ok(value_str),
+            _ => Err(PyException::new_err("Expected string value for id")),
+        }
+    }
 }
 
 impl<'py> IntoPyObject<'py> for Value {
@@ -155,6 +218,41 @@ impl<'py> IntoPyObject<'py> for Value {
             Value::Long(val) => Ok(val.into_pyobject(py)?.into_any()),
             Value::UnDefined => Ok(py.None().into_bound(py)),
         }
+    }
+}
+
+impl Value {
+    fn from_pyobject<'py>(ob: &Bound<'py, PyAny>, ty: Type) -> PyResult<Self> {
+        let value = match ty {
+            Type::Boolean => Value::Boolean(ob.extract::<bool>()?),
+            Type::Int => Value::Int(ob.extract::<isize>()?),
+            Type::Float => Value::Float(ob.extract::<f32>()?),
+            Type::Double => Value::Double(ob.extract::<f64>()?),
+            Type::String => Value::String(ob.extract::<String>()?),
+            Type::Long => Value::Long(ob.extract::<isize>()?),
+        };
+        Ok(value)
+    }
+}
+
+impl<'py> FromPyObject<'py> for Value {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        if let Ok(value) = ob.extract::<bool>() {
+            return Ok(Value::Boolean(value));
+        }
+        if let Ok(value) = ob.extract::<isize>() {
+            return Ok(Value::Int(value));
+        }
+        if let Ok(value) = ob.extract::<f32>() {
+            return Ok(Value::Float(value));
+        }
+        if let Ok(value) = ob.extract::<f64>() {
+            return Ok(Value::Double(value));
+        }
+        if let Ok(value) = ob.extract::<String>() {
+            return Ok(Value::String(value));
+        }
+        Ok(Value::UnDefined)
     }
 }
 
@@ -200,6 +298,7 @@ enum Direction {
 }
 
 struct Graph {
+    id: Option<String>,
     dir: Direction,
     nodes: Vec<Node>,
     edges: Vec<Edge>,
@@ -207,11 +306,12 @@ struct Graph {
 }
 
 impl Graph {
-    fn new<'a, I>(dir: Direction, default_attrs: I) -> Self
+    fn new<'a, I>(id: Option<String>, dir: Direction, default_attrs: I) -> Self
     where
         I: Iterator<Item = &'a Key>,
     {
         Self {
+            id,
             dir,
             nodes: Vec::new(),
             edges: Vec::new(),
@@ -273,9 +373,13 @@ impl<'py> IntoPyObject<'py> for Graph {
     type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+    fn into_pyobject(mut self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         macro_rules! make_graph {
             ($graph:ident) => {
+                // Write the graph id from GraphML doc into the graph data payload.
+                if let Some(id) = self.id {
+                    self.attributes.insert(String::from("id"), Value::String(id.clone()));
+                }
                 let mut mapping = HashMap::with_capacity(self.nodes.len());
                 for mut node in self.nodes {
                     // Write the node id from GraphML doc into the node data payload
@@ -340,6 +444,172 @@ impl<'py> IntoPyObject<'py> for Graph {
     }
 }
 
+struct GraphElementInfo {
+    attributes: HashMap<String, Value>,
+    id: Option<String>,
+}
+
+impl Default for GraphElementInfo {
+    fn default() -> Self {
+        Self {
+            attributes: HashMap::new(),
+            id: None,
+        }
+    }
+}
+
+struct GraphElementInfos<Index> {
+    vec: Vec<(Index, GraphElementInfo)>,
+    id_taken: HashSet<String>,
+}
+
+impl<Index: std::cmp::Eq + std::hash::Hash> GraphElementInfos<Index> {
+    fn new() -> Self {
+        Self {
+            vec: vec![],
+            id_taken: HashSet::new(),
+        }
+    }
+
+    fn insert<'py>(
+        &mut self,
+        py: Python<'py>,
+        index: Index,
+        weight: Option<&Py<PyAny>>,
+    ) -> PyResult<()> {
+        let element_info = weight
+            .and_then(|data| {
+                data.extract::<std::collections::HashMap<String, Value>>(py)
+                    .ok()
+                    .map(|mut attributes| -> PyResult<GraphElementInfo> {
+                        let id = attributes
+                            .remove_entry("id")
+                            .map(|(id, value)| -> PyResult<Option<String>> {
+                                let value_str = value.to_id()?;
+                                if self.id_taken.contains(value_str) {
+                                    attributes.insert(id, value);
+                                    Ok(None)
+                                } else {
+                                    self.id_taken.insert(value_str.to_string());
+                                    Ok(Some(value_str.to_string()))
+                                }
+                            })
+                            .unwrap_or_else(|| Ok(None))?;
+                        Ok(GraphElementInfo {
+                            attributes: attributes.into_iter().collect(),
+                            id,
+                        })
+                    })
+            })
+            .unwrap_or_else(|| Ok(GraphElementInfo::default()))?;
+        self.vec.push((index, element_info));
+        Ok(())
+    }
+}
+
+impl Graph {
+    fn try_from_stable<'py, Ty: EdgeType>(
+        py: Python<'py>,
+        dir: Direction,
+        pygraph: &StablePyGraph<Ty>,
+        attrs: &PyObject,
+    ) -> PyResult<Self> {
+        let mut attrs: Option<std::collections::HashMap<String, Value>> = attrs.extract(py).ok();
+        let id = attrs
+            .as_mut()
+            .and_then(|attributes| {
+                attributes
+                    .remove("id")
+                    .map(|v| v.to_id().map(|id| id.to_string()))
+            })
+            .transpose()?;
+        let mut graph = Graph::new(id, dir, std::iter::empty());
+        if let Some(attributes) = attrs {
+            graph.attributes.extend(attributes);
+        }
+        let mut node_infos = GraphElementInfos::new();
+        for node_index in pygraph.node_indices() {
+            node_infos.insert(py, node_index, pygraph.node_weight(node_index))?;
+        }
+        let mut edge_infos = GraphElementInfos::new();
+        for edge_index in pygraph.edge_indices() {
+            edge_infos.insert(py, edge_index, pygraph.edge_weight(edge_index))?;
+        }
+        let mut node_ids = HashMap::new();
+        let mut fresh_index_counter = 0;
+        for (node_index, element_info) in node_infos.vec {
+            let id = element_info.id.unwrap_or_else(|| loop {
+                let id = format!("n{fresh_index_counter}");
+                fresh_index_counter += 1;
+                if node_infos.id_taken.contains(&id) {
+                    continue;
+                }
+                node_infos.id_taken.insert(id.clone());
+                break id;
+            });
+            graph.nodes.push(Node {
+                id: id.clone(),
+                data: element_info.attributes,
+            });
+            node_ids.insert(node_index, id);
+        }
+        for (edge_index, element_info) in edge_infos.vec {
+            if let Some((source, target)) = pygraph.edge_endpoints(edge_index) {
+                let source = node_ids
+                    .get(&source)
+                    .ok_or(PyException::new_err("Missing source"))?;
+                let target = node_ids
+                    .get(&target)
+                    .ok_or(PyException::new_err("Missing target"))?;
+                graph.edges.push(Edge {
+                    id: element_info.id,
+                    source: source.clone(),
+                    target: target.clone(),
+                    data: element_info.attributes,
+                });
+            }
+        }
+        Ok(graph)
+    }
+}
+
+impl<'py> TryFrom<&Bound<'py, PyGraph>> for Graph {
+    type Error = PyErr;
+
+    fn try_from(value: &Bound<'py, PyGraph>) -> PyResult<Self> {
+        let pygraph = value.borrow();
+        return Graph::try_from_stable(
+            value.py(),
+            Direction::UnDirected,
+            &pygraph.graph,
+            &pygraph.attrs,
+        );
+    }
+}
+
+impl<'py> TryFrom<&Bound<'py, PyDiGraph>> for Graph {
+    type Error = PyErr;
+
+    fn try_from(value: &Bound<'py, PyDiGraph>) -> PyResult<Self> {
+        let pygraph = value.borrow();
+        return Graph::try_from_stable(
+            value.py(),
+            Direction::Directed,
+            &pygraph.graph,
+            &pygraph.attrs,
+        );
+    }
+}
+
+impl<'py> FromPyObject<'py> for Graph {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        match ob.downcast::<PyGraph>() {
+            Ok(graph) => Graph::try_from(graph),
+            Err(_) => Graph::try_from(ob.downcast::<PyDiGraph>()?),
+        }
+    }
+}
+
 enum State {
     Start,
     Graph,
@@ -386,6 +656,23 @@ impl Default for GraphML {
     }
 }
 
+/// Given maps from ids to keys, return a map from key name to ids and keys.
+fn build_key_name_map<'a>(
+    key_for_items: &'a IndexMap<String, Key>,
+    key_for_all: &'a IndexMap<String, Key>,
+) -> HashMap<String, (&'a String, &'a Key)> {
+    // `key_for_items` is iterated before `key_for_all` since last
+    // items take precedence in the collected map. Similarly,
+    // the map `for_all` take precedence over kind-specific maps in
+    // `last_node_set_data`, `last_edge_set_data` and
+    // `last_graph_set_attribute`.
+    key_for_all
+        .iter()
+        .chain(key_for_items.iter())
+        .map(|(id, key)| (key.name.clone(), (id, key)))
+        .collect()
+}
+
 impl GraphML {
     fn create_graph<'a>(&mut self, element: &'a BytesStart<'a>) -> Result<(), Error> {
         let dir = match xml_attribute(element, b"edgedefault")?.as_bytes() {
@@ -399,6 +686,7 @@ impl GraphML {
         };
 
         self.graphs.push(Graph::new(
+            xml_attribute(element, b"id").ok(),
             dir,
             self.key_for_graph.values().chain(self.key_for_all.values()),
         ));
@@ -428,6 +716,24 @@ impl GraphML {
         Ok(())
     }
 
+    fn get_keys(&self, domain: Domain) -> &IndexMap<String, Key> {
+        match domain {
+            Domain::Node => &self.key_for_nodes,
+            Domain::Edge => &self.key_for_edges,
+            Domain::Graph => &self.key_for_graph,
+            Domain::All => &self.key_for_all,
+        }
+    }
+
+    fn get_keys_mut(&mut self, domain: Domain) -> &mut IndexMap<String, Key> {
+        match domain {
+            Domain::Node => &mut self.key_for_nodes,
+            Domain::Edge => &mut self.key_for_edges,
+            Domain::Graph => &mut self.key_for_graph,
+            Domain::All => &mut self.key_for_all,
+        }
+    }
+
     fn add_graphml_key<'a>(&mut self, element: &'a BytesStart<'a>) -> Result<Domain, Error> {
         let id = xml_attribute(element, b"id")?;
         let ty = match xml_attribute(element, b"attr.type")?.as_bytes() {
@@ -450,38 +756,18 @@ impl GraphML {
             ty,
             default: Value::UnDefined,
         };
-
-        match xml_attribute(element, b"for")?.as_bytes() {
-            b"node" => {
-                self.key_for_nodes.insert(id, key);
-                Ok(Domain::Node)
-            }
-            b"edge" => {
-                self.key_for_edges.insert(id, key);
-                Ok(Domain::Edge)
-            }
-            b"graph" => {
-                self.key_for_graph.insert(id, key);
-                Ok(Domain::Graph)
-            }
-            b"all" => {
-                self.key_for_all.insert(id, key);
-                Ok(Domain::All)
-            }
-            _ => Err(Error::InvalidDoc(format!(
-                "Invalid 'for' attribute in key with id={}.",
-                id,
-            ))),
-        }
+        let domain: Domain = xml_attribute(element, b"for")?
+            .as_bytes()
+            .try_into()
+            .map_err(|()| {
+                Error::InvalidDoc(format!("Invalid 'for' attribute in key with id={}.", id,))
+            })?;
+        self.get_keys_mut(domain).insert(id, key);
+        Ok(domain)
     }
 
     fn last_key_set_value(&mut self, val: String, domain: Domain) -> Result<(), Error> {
-        let elem = match domain {
-            Domain::Node => self.key_for_nodes.last_mut(),
-            Domain::Edge => self.key_for_edges.last_mut(),
-            Domain::Graph => self.key_for_graph.last_mut(),
-            Domain::All => self.key_for_all.last_mut(),
-        };
+        let elem = self.get_keys_mut(domain).last_mut();
 
         if let Some((_, key)) = elem {
             key.set_value(val)?;
@@ -715,6 +1001,141 @@ impl GraphML {
 
         graph
     }
+
+    fn write_data<W: std::io::Write>(
+        writer: &mut Writer<W>,
+        keys: &HashMap<String, (&String, &Key)>,
+        data: &HashMap<String, Value>,
+    ) -> Result<(), Error> {
+        for (key_name, value) in data {
+            let (id, key) = keys
+                .get(key_name)
+                .ok_or_else(|| Error::NotFound(format!("Unknown key {key_name}")))?;
+            if key.default == *value {
+                continue;
+            }
+            let mut elem = BytesStart::new("data");
+            elem.push_attribute(("key", id.as_str()));
+            writer.write_event(Event::Start(elem.borrow()))?;
+            if let Some(contents) = value.serialize() {
+                writer.write_event(Event::Text(BytesText::new(contents.borrow())))?;
+            }
+            writer.write_event(Event::End(elem.to_end()))?;
+        }
+        Ok(())
+    }
+
+    fn write_elem_data<W: std::io::Write>(
+        writer: &mut Writer<W>,
+        keys: &HashMap<String, (&String, &Key)>,
+        elem: BytesStart,
+        data: &HashMap<String, Value>,
+    ) -> Result<(), Error> {
+        if data.is_empty() {
+            writer.write_event(Event::Empty(elem))?;
+            return Ok(());
+        }
+        writer.write_event(Event::Start(elem.borrow()))?;
+        Self::write_data(writer, keys, data)?;
+        writer.write_event(Event::End(elem.to_end()))?;
+        Ok(())
+    }
+
+    fn write_keys<W: std::io::Write>(
+        writer: &mut Writer<W>,
+        key_for: &str,
+        map: &IndexMap<String, Key>,
+    ) -> Result<(), quick_xml::Error> {
+        for (id, key) in map {
+            let mut elem = BytesStart::new("key");
+            elem.push_attribute(("id", id.as_str()));
+            elem.push_attribute(("for", key_for));
+            elem.push_attribute(("attr.name", key.name.as_str()));
+            let ty: &str = key.ty.into();
+            elem.push_attribute(("attr.type", ty));
+            writer.write_event(Event::Start(elem.borrow()))?;
+            if let Some(contents) = key.default.serialize() {
+                let elem = BytesStart::new("default");
+                writer.write_event(Event::Start(elem.borrow()))?;
+                writer.write_event(Event::Text(BytesText::new(contents.borrow())))?;
+                writer.write_event(Event::End(elem.to_end()))?;
+            };
+            writer.write_event(Event::End(elem.to_end()))?;
+        }
+        Ok(())
+    }
+
+    fn write_graph_to_writer<W: std::io::Write>(
+        &self,
+        writer: &mut Writer<W>,
+    ) -> Result<(), Error> {
+        writer.write_event(Event::Decl(BytesDecl::new("1.0", Some("UTF-8"), None)))?;
+        let mut elem = BytesStart::new("graphml");
+        elem.push_attribute(("xmlns", "http://graphml.graphdrawing.org/xmlns"));
+        elem.push_attribute(("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance"));
+        elem.push_attribute((
+            "xsi:schemaLocation",
+            "http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd",
+        ));
+        writer.write_event(Event::Start(elem.borrow()))?;
+        Self::write_keys(writer, "node", &self.key_for_nodes)?;
+        Self::write_keys(writer, "edge", &self.key_for_edges)?;
+        Self::write_keys(writer, "graph", &self.key_for_graph)?;
+        Self::write_keys(writer, "all", &self.key_for_all)?;
+        let graph_keys: HashMap<String, (&String, &Key)> =
+            build_key_name_map(&self.key_for_graph, &self.key_for_all);
+        let node_keys: HashMap<String, (&String, &Key)> =
+            build_key_name_map(&self.key_for_nodes, &self.key_for_all);
+        let edge_keys: HashMap<String, (&String, &Key)> =
+            build_key_name_map(&self.key_for_edges, &self.key_for_all);
+        for graph in self.graphs.iter() {
+            let mut elem = BytesStart::new("graph");
+            if let Some(id) = &graph.id {
+                elem.push_attribute(("id", id.as_str()));
+            }
+            let edgedefault = match graph.dir {
+                Direction::Directed => "directed",
+                Direction::UnDirected => "undirected",
+            };
+            elem.push_attribute(("edgedefault", edgedefault));
+            writer.write_event(Event::Start(elem.borrow()))?;
+            Self::write_data(writer, &graph_keys, &graph.attributes)?;
+            for node in &graph.nodes {
+                let mut elem = BytesStart::new("node");
+                elem.push_attribute(("id", node.id.as_str()));
+                Self::write_elem_data(writer, &node_keys, elem, &node.data)?;
+            }
+            for edge in &graph.edges {
+                let mut elem = BytesStart::new("edge");
+                if let Some(id) = &edge.id {
+                    elem.push_attribute(("id", id.as_str()));
+                }
+                elem.push_attribute(("source", edge.source.as_str()));
+                elem.push_attribute(("target", edge.target.as_str()));
+                Self::write_elem_data(writer, &edge_keys, elem, &edge.data)?;
+            }
+            writer.write_event(Event::End(elem.to_end()))?;
+        }
+        writer.write_event(Event::End(elem.to_end()))?;
+        Ok(())
+    }
+
+    fn to_file(&self, path: impl AsRef<Path>, compression: &str) -> Result<(), Error> {
+        let extension = path.as_ref().extension().unwrap_or(OsStr::new(""));
+        if extension.eq("graphmlz") || extension.eq("gz") || compression.eq("gzip") {
+            let file = File::create(path)?;
+            let buf_writer = BufWriter::new(file);
+            let gzip_encoder = GzEncoder::new(buf_writer, Compression::default());
+            let mut writer = Writer::new(gzip_encoder);
+            self.write_graph_to_writer(&mut writer)?;
+            writer.into_inner().finish()?;
+        } else {
+            let file = File::create(path)?;
+            let mut writer = Writer::new(file);
+            self.write_graph_to_writer(&mut writer)?;
+        }
+        Ok(())
+    }
 }
 
 /// Read a list of graphs from a file in GraphML format.
@@ -755,4 +1176,64 @@ pub fn read_graphml<'py>(
     }
 
     Ok(out)
+}
+
+/// Read a list of graphs from a file in GraphML format and return the pair containing the list of key definitions and the graph.
+///
+/// Each key definition is a tuple: id, domain, name of the key, type, default value.
+#[pyfunction]
+#[pyo3(signature=(path, compression=None),text_signature = "(path, /, compression=None)")]
+pub fn read_graphml_with_keys<'py>(
+    py: Python<'py>,
+    path: &str,
+    compression: Option<String>,
+) -> PyResult<(
+    Vec<(String, Domain, String, Type, Bound<'py, PyAny>)>,
+    Vec<Bound<'py, PyAny>>,
+)> {
+    let graphml = GraphML::from_file(path, &compression.unwrap_or_default())?;
+
+    let mut keys = Vec::new();
+    for domain in [Domain::Node, Domain::Edge, Domain::Graph, Domain::All] {
+        for (id, key) in graphml.get_keys(domain) {
+            let default = key.default.clone().into_pyobject(py)?.into_any();
+            keys.push((id.clone(), domain, key.name.clone(), key.ty, default));
+        }
+    }
+
+    let mut out = Vec::new();
+    for graph in graphml.graphs {
+        out.push(graph.into_pyobject(py)?)
+    }
+
+    Ok((keys, out))
+}
+
+/// Write a list of graphs to a file in GraphML format given the list of key definitions.
+#[pyfunction]
+#[pyo3(signature=(graphs, keys, path, compression=None),text_signature = "(graphs, keys, path, /, compression=None)")]
+pub fn write_graphml<'py>(
+    py: Python<'py>,
+    graphs: Vec<Py<PyAny>>,
+    keys: Vec<(String, Domain, String, Type, Py<PyAny>)>,
+    path: &str,
+    compression: Option<String>,
+) -> PyResult<()> {
+    let mut graphml = GraphML::default();
+    for (id, domain, name, ty, default) in keys {
+        let bound_default = default.bind(py);
+        let default = if bound_default.is_none() {
+            Value::UnDefined
+        } else {
+            Value::from_pyobject(bound_default, ty)?
+        };
+        graphml
+            .get_keys_mut(domain)
+            .insert(id, Key { name, ty, default });
+    }
+    for graph in graphs {
+        graphml.graphs.push(Graph::extract_bound(graph.bind(py))?)
+    }
+    graphml.to_file(path, &compression.unwrap_or_default())?;
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -669,6 +669,8 @@ fn rustworkx(py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(connected_subgraphs))?;
     m.add_wrapped(wrap_pyfunction!(is_planar))?;
     m.add_wrapped(wrap_pyfunction!(read_graphml))?;
+    m.add_wrapped(wrap_pyfunction!(read_graphml_with_keys))?;
+    m.add_wrapped(wrap_pyfunction!(write_graphml))?;
     m.add_wrapped(wrap_pyfunction!(digraph_node_link_json))?;
     m.add_wrapped(wrap_pyfunction!(graph_node_link_json))?;
     m.add_wrapped(wrap_pyfunction!(from_node_link_json_file))?;
@@ -702,6 +704,8 @@ fn rustworkx(py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<iterators::ProductNodeMap>()?;
     m.add_class::<iterators::BiconnectedComponents>()?;
     m.add_class::<ColoringStrategy>()?;
+    m.add_class::<Domain>()?;
+    m.add_class::<Type>()?;
     m.add_wrapped(wrap_pymodule!(generators::generators))?;
     Ok(())
 }


### PR DESCRIPTION
This commit adds a GraphML serializer:

```python
def write_graphml(
    graphs: list[PyGraph | PyDiGraph],
    keys: list[tuple[str, Domain, str, Type, Any]],
    path: str,
    /,
    compression: str | None = ...,
) -> None: ...
```

`keys` is a list of tuples: id, domain, name of the key, type, and default value. This commit also introduces the
`read_graphml_with_keys` function, which returns the key definitions in the same format, along with the list of parsed graphs.

The implementation preserves the ids of graphs, nodes, and edges when possible. If some ids conflict, fresh ids are generated in the written GraphML file. The `read_graphml` function has also been updated to store the graph id in the graph attributes, just like node and edge ids are stored in the corresponding attributes.

The `write_graphml` function supports gzip compression, as does `read_graphml`.

Note that the JSON node-link serializer (the other part of #840) was already implemented in #1091.

Compared to #1462:

- Keys are passed explicitly instead of being inferred (which allows to use the types `float` and `int`, and to use default values);

- Attributes for graphs, nodes, and edges are taken from the weight of elements, instead of relying on callbacks. This allows write_graphml to act as a proper reciprocal of read_graphml. Round-trip tests have been added.

- IDs are taken from attributes when possible, instead of being generated from indices.

- Multiple graphs can be written to the same file.

- Gzip compression is supported.

- Tests have been added.

Regarding @IvanIsCoding's
comment (https://github.com/Qiskit/rustworkx/pull/1462#issuecomment-2951935390), about using https://github.com/jonasbb/petgraph-graphml:

- Rustworkx's `graphml.rs` introduces an internal `Graph` data structure, which is used for `read_graphml`. It is natural to have `write_graphml` rely on the same data structure.

- `petgraph-graphml` generates ids from indices, which prevents us from preserving ids accross the `read_graphml`/`write_graphml` round trip.
