### PR TITLE
Adding quickcheck for barbell graphs

### DIFF
--- a/rustworkx-core/tests/quickcheck/barbell_graph.rs
+++ b/rustworkx-core/tests/quickcheck/barbell_graph.rs
@@ -1,5 +1,4 @@
 use petgraph::graph::UnGraph;
-use petgraph::visit::EdgeRef;
 use quickcheck::{quickcheck, TestResult};
 use rustworkx_core::generators::barbell_graph;
 

--- a/rustworkx-core/tests/quickcheck/barbell_graph.rs
+++ b/rustworkx-core/tests/quickcheck/barbell_graph.rs
@@ -1,0 +1,44 @@
+use petgraph::graph::UnGraph;
+use petgraph::visit::EdgeRef;
+use quickcheck::{quickcheck, TestResult};
+use rustworkx_core::generators::barbell_graph;
+
+#[test]
+fn prop_barbell_graph_structure() {
+    fn prop(mesh_size: usize, path_size: usize) -> TestResult {
+        let mesh_size = mesh_size % 32 + 2;
+        let path_size = path_size % 32;
+
+        let graph = match barbell_graph::<UnGraph<(), ()>, (), _, _, ()>(
+            Some(mesh_size),
+            Some(path_size),
+            None,
+            None,
+            || (),
+            || (),
+        ) {
+            Ok(g) => g,
+            Err(_) => return TestResult::error("Failed to generate barbell graph"),
+        };
+
+        // Expected node count
+        let expected_nodes = 2 * mesh_size + path_size;
+        if graph.node_count() != expected_nodes {
+            return TestResult::failed();
+        }
+
+        // Expected edge count
+        let mesh_edges = mesh_size * (mesh_size - 1) / 2;
+        let path_edges = if path_size > 0 { path_size - 1 } else { 0 };
+        let connectors = if path_size > 0 { 2 } else { 1 };
+        let expected_edges = 2 * mesh_edges + path_edges + connectors;
+
+        if graph.edge_count() != expected_edges {
+            return TestResult::failed();
+        }
+
+        TestResult::passed()
+    }
+
+    quickcheck(prop as fn(usize, usize) -> TestResult);
+}

--- a/rustworkx-core/tests/quickcheck/main.rs
+++ b/rustworkx-core/tests/quickcheck/main.rs
@@ -1,2 +1,3 @@
+mod barbell_graph;
 mod grid_graph;
 mod lollipop_graph;


### PR DESCRIPTION
This QuickCheck test verifies structural properties of barbell_graph.

It ensures the total number of nodes is 2 × mesh_size + path_size.

It checks the number of edges matches the expected sum of two cliques, path edges, and connectors.

