### PR TITLE
Fix Clippy Lints for Rust 1.88

### DIFF
--- a/rustworkx-core/fuzz/fuzz_targets/test_fuzz_contraction.rs
+++ b/rustworkx-core/fuzz/fuzz_targets/test_fuzz_contraction.rs
@@ -1,5 +1,4 @@
 #![no_main]
-#![allow(clippy::uninlined_format_args)]
 
 use arbitrary::{Arbitrary, Unstructured};
 use libfuzzer_sys::fuzz_target;

--- a/rustworkx-core/fuzz/fuzz_targets/test_fuzz_contraction.rs
+++ b/rustworkx-core/fuzz/fuzz_targets/test_fuzz_contraction.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![allow(clippy::uninlined_format_args)]
 
 use arbitrary::{Arbitrary, Unstructured};
 use libfuzzer_sys::fuzz_target;

--- a/rustworkx-core/fuzz/fuzz_targets/test_fuzz_contraction.rs
+++ b/rustworkx-core/fuzz/fuzz_targets/test_fuzz_contraction.rs
@@ -65,7 +65,7 @@ fn fuzz_contract_nodes(input: ContractFuzzInput) {
             // Expected error — no-op
         }
         Err(err) => {
-            panic!("Unexpected error during node contraction: {:?}", err);
+            panic!("Unexpected error during node contraction: {err:?}");
         }
     }
 }

--- a/rustworkx-core/src/bipartite_coloring.rs
+++ b/rustworkx-core/src/bipartite_coloring.rs
@@ -666,7 +666,7 @@ mod test_bipartite_coloring {
                 .map(|edge| *colors.get(&edge.id()).unwrap())
                 .collect();
             if node_colors.len() != node_degree {
-                panic!("Node {:?} does not have correct number of colors.", node);
+                panic!("Node {node:?} does not have correct number of colors.");
             }
         }
 
@@ -708,7 +708,7 @@ mod test_bipartite_coloring {
                 .map(|edge| *colors.get(&edge.id()).unwrap())
                 .collect();
             if node_colors.len() != node_degree {
-                panic!("Node {:?} does not have correct number of colors.", node);
+                panic!("Node {node:?} does not have correct number of colors.");
             }
         }
 

--- a/rustworkx-core/src/dag_algo.rs
+++ b/rustworkx-core/src/dag_algo.rs
@@ -59,7 +59,7 @@ impl<E: Error> Display for TopologicalSortError<E> {
                 write!(f, "At least one initial node is reachable from another")
             }
             TopologicalSortError::KeyError(ref e) => {
-                write!(f, "The key callback failed with: {:?}", e)
+                write!(f, "The key callback failed with: {e:?}")
             }
         }
     }
@@ -420,12 +420,11 @@ where
             self.first_iter = false;
             for node in &self.cur_layer {
                 if self.graph.to_index(*node) >= self.graph.node_bound() {
-                    panic!("Node {:#?} is not present in the graph.", node);
+                    panic!("Node {node:#?} is not present in the graph.");
                 }
                 if self.cycle_check.contains(node) {
                     return Some(Err(LayersError(format!(
-                        "An invalid first layer was provided: {:#?} appears more than once.",
-                        node
+                        "An invalid first layer was provided: {node:#?} appears more than once."
                     ))));
                 }
                 self.cycle_check.insert(*node);
@@ -436,7 +435,7 @@ where
         } else {
             for node in &self.cur_layer {
                 if self.graph.to_index(*node) >= self.graph.node_bound() {
-                    panic!("Node {:#?} is not present in the graph.", node);
+                    panic!("Node {node:#?} is not present in the graph.");
                 }
                 let children = self
                     .graph

--- a/rustworkx-core/src/err.rs
+++ b/rustworkx-core/src/err.rs
@@ -52,7 +52,7 @@ fn fmt_dag_would_cycle(f: &mut Formatter<'_>) -> std::fmt::Result {
 }
 
 fn fmt_merge_error<E: Error>(f: &mut Formatter<'_>, inner: &E) -> std::fmt::Result {
-    write!(f, "The merge callback failed with: {:?}", inner)
+    write!(f, "The merge callback failed with: {inner:?}")
 }
 
 /// Error returned by Layers function when an index is not part of the graph.

--- a/rustworkx-core/src/lib.rs
+++ b/rustworkx-core/src/lib.rs
@@ -82,8 +82,6 @@
 //!
 //! <https://www.rustworkx.org/release_notes.html>
 
-#![allow(clippy::uninlined_format_args)]
-
 use std::convert::Infallible;
 
 /// A convenient type alias that by default assumes no error can happen.

--- a/rustworkx-core/src/lib.rs
+++ b/rustworkx-core/src/lib.rs
@@ -82,6 +82,8 @@
 //!
 //! <https://www.rustworkx.org/release_notes.html>
 
+#![allow(clippy::uninlined_format_args)]
+
 use std::convert::Infallible;
 
 /// A convenient type alias that by default assumes no error can happen.

--- a/rustworkx-core/src/shortest_path/dijkstra.rs
+++ b/rustworkx-core/src/shortest_path/dijkstra.rs
@@ -191,7 +191,7 @@ mod tests {
         g.add_edge(b, f, 15);
         g.add_edge(c, f, 11);
         g.add_edge(e, f, 6);
-        println!("{:?}", g);
+        println!("{g:?}");
         let scores: Result<DictMap<NodeIndex, usize>> =
             dijkstra(&g, a, None, |e| Ok(*e.weight()), None);
         let exp_scores: DictMap<NodeIndex, usize> =
@@ -220,7 +220,7 @@ mod tests {
         g.add_edge(b, f, 15);
         g.add_edge(c, f, 11);
         g.add_edge(e, f, 6);
-        println!("{:?}", g);
+        println!("{g:?}");
 
         let scores: Result<DictMap<NodeIndex, usize>> =
             dijkstra(&g, a, Some(c), |e| Ok(*e.weight()), None);

--- a/rustworkx-core/src/shortest_path/single_source_all_shortest_paths.rs
+++ b/rustworkx-core/src/shortest_path/single_source_all_shortest_paths.rs
@@ -369,9 +369,7 @@ mod tests {
                 for &n in path {
                     assert!(
                         seen.insert(n),
-                        "Path {:?} contains repeated node {:?}",
-                        path,
-                        n
+                        "Path {path:?} contains repeated node {n:?}"
                     );
                 }
             }

--- a/rustworkx-core/tests/graph_ext/contraction.rs
+++ b/rustworkx-core/tests/graph_ext/contraction.rs
@@ -253,7 +253,7 @@ where
                 assert_eq!(*seen.entry('e').or_insert(e), e);
                 assert_eq!(*seen.entry('m').or_insert(m), m);
             }
-            (_, _, w) => panic!("Unexpected edge weight: {}", w),
+            (_, _, w) => panic!("Unexpected edge weight: {w}"),
         }
     }
 

--- a/src/centrality.rs
+++ b/src/centrality.rs
@@ -748,8 +748,7 @@ pub fn graph_eigenvector_centrality(
                 .collect(),
         }),
         None => Err(FailedToConverge::new_err(format!(
-            "Function failed to converge on a solution in {} iterations",
-            max_iter
+            "Function failed to converge on a solution in {max_iter} iterations"
         ))),
     }
 }
@@ -836,8 +835,7 @@ pub fn digraph_eigenvector_centrality(
                 .collect(),
         }),
         None => Err(FailedToConverge::new_err(format!(
-            "Function failed to converge on a solution in {} iterations",
-            max_iter
+            "Function failed to converge on a solution in {max_iter} iterations"
         ))),
     }
 }
@@ -966,8 +964,7 @@ pub fn graph_katz_centrality(
                 .collect(),
         }),
         None => Err(FailedToConverge::new_err(format!(
-            "Function failed to converge on a solution in {} iterations",
-            max_iter
+            "Function failed to converge on a solution in {max_iter} iterations"
         ))),
     }
 }
@@ -1097,8 +1094,7 @@ pub fn digraph_katz_centrality(
                 .collect(),
         }),
         None => Err(FailedToConverge::new_err(format!(
-            "Function failed to converge on a solution in {} iterations",
-            max_iter
+            "Function failed to converge on a solution in {max_iter} iterations"
         ))),
     }
 }

--- a/src/dag_algo/mod.rs
+++ b/src/dag_algo/mod.rs
@@ -301,8 +301,7 @@ pub fn layers(
     for layer_node in &first_layer {
         if !dag.graph.contains_node(NodeIndex::new(*layer_node)) {
             return Err(InvalidNode::new_err(format!(
-                "An index input in 'first_layer' {} is not a valid node index in the graph",
-                layer_node
+                "An index input in 'first_layer' {layer_node} is not a valid node index in the graph"
             )));
         }
     }

--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -895,8 +895,7 @@ impl PyDiGraph {
             Some(data) => data,
             None => {
                 return Err(PyIndexError::new_err(format!(
-                    "Provided edge index {} is not present in the graph",
-                    edge_index
+                    "Provided edge index {edge_index} is not present in the graph"
                 )));
             }
         };
@@ -917,8 +916,7 @@ impl PyDiGraph {
             Some(endpoints) => (endpoints.0.index(), endpoints.1.index()),
             None => {
                 return Err(PyIndexError::new_err(format!(
-                    "Provided edge index {} is not present in the graph",
-                    edge_index
+                    "Provided edge index {edge_index} is not present in the graph"
                 )));
             }
         };
@@ -2622,7 +2620,7 @@ impl PyDiGraph {
                 .as_bytes(),
             )?;
             match weight_callable(py, &weight_fn, edge.weight(), None as Option<String>)? {
-                Some(weight) => buf_writer.write_all(format!("{}{}\n", delim, weight).as_bytes()),
+                Some(weight) => buf_writer.write_all(format!("{delim}{weight}\n").as_bytes()),
                 None => buf_writer.write_all(b"\n"),
             }?;
         }
@@ -2875,8 +2873,7 @@ impl PyDiGraph {
         let node_index: NodeIndex = NodeIndex::new(node);
         if self.graph.node_weight(node_index).is_none() {
             return Err(PyIndexError::new_err(format!(
-                "Specified node {} is not in this graph",
-                node
+                "Specified node {node} is not in this graph"
             )));
         }
         // Copy nodes from other to self
@@ -2927,8 +2924,7 @@ impl PyDiGraph {
                     Some(new_index) => NodeIndex::new(*new_index),
                     None => {
                         return Err(PyIndexError::new_err(format!(
-                            "No mapped index {} found",
-                            old_index
+                            "No mapped index {old_index} found"
                         )))
                     }
                 },
@@ -2943,8 +2939,7 @@ impl PyDiGraph {
                     Some(new_index) => NodeIndex::new(*new_index),
                     None => {
                         return Err(PyIndexError::new_err(format!(
-                            "No mapped index {} found",
-                            old_index
+                            "No mapped index {old_index} found"
                         )))
                     }
                 },

--- a/src/dot_utils.rs
+++ b/src/dot_utils.rs
@@ -38,7 +38,7 @@ where
     writeln!(file, "{} {{", TYPE[graph.is_directed() as usize])?;
     if let Some(graph_attr_map) = graph_attrs {
         for (key, value) in graph_attr_map.iter() {
-            writeln!(file, "{}={} ;", key, value)?;
+            writeln!(file, "{key}={value} ;")?;
         }
     }
 
@@ -88,12 +88,12 @@ fn attr_map_to_string<'a>(
         .iter()
         .map(|(key, value)| {
             if ATTRS_TO_ESCAPE.contains(&key.as_str()) {
-                format!("{}=\"{}\"", key, value)
+                format!("{key}=\"{value}\"")
             } else {
-                format!("{}={}", key, value)
+                format!("{key}={value}")
             }
         })
         .collect::<Vec<String>>()
         .join(", ");
-    Ok(format!("[{}]", attr_string))
+    Ok(format!("[{attr_string}]"))
 }

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -955,8 +955,7 @@ pub fn binomial_tree_graph(
 ) -> PyResult<graph::PyGraph> {
     if order >= MAX_ORDER {
         return Err(PyOverflowError::new_err(format!(
-            "An order of {} exceeds the max allowable size",
-            order
+            "An order of {order} exceeds the max allowable size"
         )));
     }
     let default_fn = || py.None();
@@ -1022,8 +1021,7 @@ pub fn directed_binomial_tree_graph(
 ) -> PyResult<digraph::PyDiGraph> {
     if order >= MAX_ORDER {
         return Err(PyOverflowError::new_err(format!(
-            "An order of {} exceeds the max allowable size",
-            order
+            "An order of {order} exceeds the max allowable size"
         )));
     }
     let default_fn = || py.None();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -694,8 +694,7 @@ impl PyGraph {
             Some(data) => data,
             None => {
                 return Err(PyIndexError::new_err(format!(
-                    "Provided edge index {} is not present in the graph",
-                    edge_index
+                    "Provided edge index {edge_index} is not present in the graph"
                 )));
             }
         };
@@ -716,8 +715,7 @@ impl PyGraph {
             Some(endpoints) => (endpoints.0.index(), endpoints.1.index()),
             None => {
                 return Err(PyIndexError::new_err(format!(
-                    "Provided edge index {} is not present in the graph",
-                    edge_index
+                    "Provided edge index {edge_index} is not present in the graph"
                 )));
             }
         };
@@ -1508,7 +1506,7 @@ impl PyGraph {
                 .as_bytes(),
             )?;
             match weight_callable(py, &weight_fn, edge.weight(), None as Option<String>)? {
-                Some(weight) => buf_writer.write_all(format!("{}{}\n", delim, weight).as_bytes()),
+                Some(weight) => buf_writer.write_all(format!("{delim}{weight}\n").as_bytes()),
                 None => buf_writer.write_all(b"\n"),
             }?;
         }
@@ -1771,8 +1769,7 @@ impl PyGraph {
         let node_index = NodeIndex::new(node);
         if self.graph.node_weight(node_index).is_none() {
             return Err(PyIndexError::new_err(format!(
-                "Specified node {} is not in this graph",
-                node
+                "Specified node {node} is not in this graph"
             )));
         }
 
@@ -1829,8 +1826,7 @@ impl PyGraph {
                     Some(new_index) => NodeIndex::new(*new_index),
                     None => {
                         return Err(PyIndexError::new_err(format!(
-                            "No mapped index {} found",
-                            old_index
+                            "No mapped index {old_index} found"
                         )))
                     }
                 },
@@ -1845,8 +1841,7 @@ impl PyGraph {
                     Some(new_index) => NodeIndex::new(*new_index),
                     None => {
                         return Err(PyIndexError::new_err(format!(
-                            "No mapped index {} found",
-                            old_index
+                            "No mapped index {old_index} found"
                         )))
                     }
                 },

--- a/src/graphml.rs
+++ b/src/graphml.rs
@@ -58,35 +58,35 @@ pub enum Error {
 impl From<XmlError> for Error {
     #[inline]
     fn from(e: XmlError) -> Error {
-        Error::Xml(format!("Xml document not well-formed: {}", e))
+        Error::Xml(format!("Xml document not well-formed: {e}"))
     }
 }
 
 impl From<ParseBoolError> for Error {
     #[inline]
     fn from(e: ParseBoolError) -> Error {
-        Error::ParseValue(format!("Failed conversion to 'bool': {}", e))
+        Error::ParseValue(format!("Failed conversion to 'bool': {e}"))
     }
 }
 
 impl From<ParseIntError> for Error {
     #[inline]
     fn from(e: ParseIntError) -> Error {
-        Error::ParseValue(format!("Failed conversion to 'int' or 'long': {}", e))
+        Error::ParseValue(format!("Failed conversion to 'int' or 'long': {e}"))
     }
 }
 
 impl From<ParseFloatError> for Error {
     #[inline]
     fn from(e: ParseFloatError) -> Error {
-        Error::ParseValue(format!("Failed conversion to 'float' or 'double': {}", e))
+        Error::ParseValue(format!("Failed conversion to 'float' or 'double': {e}"))
     }
 }
 
 impl From<std::io::Error> for Error {
     #[inline]
     fn from(e: std::io::Error) -> Error {
-        Error::IO(format!("Input/output error: {}", e))
+        Error::IO(format!("Input/output error: {e}"))
     }
 }
 
@@ -773,8 +773,7 @@ impl GraphML {
             b"long" => Type::Long,
             _ => {
                 return Err(Error::InvalidDoc(format!(
-                    "Invalid 'attr.type' attribute in key with id={}.",
-                    id,
+                    "Invalid 'attr.type' attribute in key with id={id}.",
                 )));
             }
         };
@@ -788,7 +787,7 @@ impl GraphML {
             .as_bytes()
             .try_into()
             .map_err(|()| {
-                Error::InvalidDoc(format!("Invalid 'for' attribute in key with id={}.", id,))
+                Error::InvalidDoc(format!("Invalid 'for' attribute in key with id={id}.",))
             })?;
         self.get_keys_mut(domain).insert(id, key);
         Ok(domain)
@@ -810,7 +809,7 @@ impl GraphML {
             None => self
                 .key_for_nodes
                 .get(key)
-                .ok_or_else(|| Error::NotFound(format!("Key '{}' for nodes not found.", key)))?,
+                .ok_or_else(|| Error::NotFound(format!("Key '{key}' for nodes not found.")))?,
         };
 
         if let Some(graph) = self.graphs.last_mut() {
@@ -826,7 +825,7 @@ impl GraphML {
             None => self
                 .key_for_edges
                 .get(key)
-                .ok_or_else(|| Error::NotFound(format!("Key '{}' for edges not found.", key)))?,
+                .ok_or_else(|| Error::NotFound(format!("Key '{key}' for edges not found.")))?,
         };
 
         if let Some(graph) = self.graphs.last_mut() {
@@ -842,7 +841,7 @@ impl GraphML {
             None => self
                 .key_for_graph
                 .get(key)
-                .ok_or_else(|| Error::NotFound(format!("Key '{}' for graph not found.", key)))?,
+                .ok_or_else(|| Error::NotFound(format!("Key '{key}' for graph not found.")))?,
         };
 
         if let Some(graph) = self.graphs.last_mut() {

--- a/src/json/mod.rs
+++ b/src/json/mod.rs
@@ -58,8 +58,7 @@ pub fn from_node_link_json_file<'py>(
         Ok(v) => v,
         Err(e) => {
             return Err(JSONDeserializationError::new_err(format!(
-                "JSON Deserialization Error {}",
-                e
+                "JSON Deserialization Error {e}"
             )));
         }
     };
@@ -136,8 +135,7 @@ pub fn parse_node_link_json<'py>(
         Ok(v) => v,
         Err(e) => {
             return Err(JSONDeserializationError::new_err(format!(
-                "JSON Deserialization Error {}",
-                e
+                "JSON Deserialization Error {e}"
             )));
         }
     };

--- a/src/json/node_link_data.rs
+++ b/src/json/node_link_data.rs
@@ -168,8 +168,7 @@ pub fn node_link_data<Ty: EdgeType>(
         None => match serde_json::to_string(&output_struct) {
             Ok(v) => Ok(Some(v)),
             Err(e) => Err(JSONSerializationError::new_err(format!(
-                "JSON Error: {}",
-                e
+                "JSON Error: {e}"
             ))),
         },
         Some(filename) => {
@@ -177,8 +176,7 @@ pub fn node_link_data<Ty: EdgeType>(
             match serde_json::to_writer(file, &output_struct) {
                 Ok(_) => Ok(None),
                 Err(e) => Err(JSONSerializationError::new_err(format!(
-                    "JSON Error: {}",
-                    e
+                    "JSON Error: {e}"
                 ))),
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
+#![allow(clippy::uninlined_format_args)]
+
 mod bisimulation;
 mod cartesian_product;
 mod centrality;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,6 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-#![allow(clippy::uninlined_format_args)]
-
 mod bisimulation;
 mod cartesian_product;
 mod centrality;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ pub struct RxPyErr {
 pub type RxPyResult<T> = Result<T, RxPyErr>;
 
 fn map_dag_would_cycle<E: std::error::Error>(value: E) -> PyErr {
-    DAGWouldCycle::new_err(format!("{}", value))
+    DAGWouldCycle::new_err(format!("{value}"))
 }
 
 impl From<ContractError> for RxPyErr {
@@ -152,7 +152,7 @@ impl From<TopologicalSortError<PyErr>> for RxPyErr {
         RxPyErr {
             pyerr: match value {
                 TopologicalSortError::CycleOrBadInitialState => {
-                    PyValueError::new_err(format!("{}", value))
+                    PyValueError::new_err(format!("{value}"))
                 }
                 TopologicalSortError::KeyError(e) => e,
             },

--- a/src/link_analysis.rs
+++ b/src/link_analysis.rs
@@ -210,8 +210,7 @@ pub fn pagerank(
     // Convert to custom return type
     if !has_converged {
         return Err(FailedToConverge::new_err(format!(
-            "Function failed to converge on a solution in {} iterations",
-            max_iter
+            "Function failed to converge on a solution in {max_iter} iterations"
         )));
     }
 
@@ -359,8 +358,7 @@ pub fn hits(
     // Convert to custom return type
     if !has_converged {
         return Err(FailedToConverge::new_err(format!(
-            "Function failed to converge on a solution in {} iterations",
-            max_iter
+            "Function failed to converge on a solution in {max_iter} iterations"
         )));
     }
 

--- a/src/shortest_path/num_shortest_path.rs
+++ b/src/shortest_path/num_shortest_path.rs
@@ -31,8 +31,7 @@ pub fn num_shortest_paths_unweighted<Ty: EdgeType>(
     let node_index = NodeIndex::new(source);
     if graph.node_weight(node_index).is_none() {
         return Err(PyIndexError::new_err(format!(
-            "No node found for index {}",
-            source
+            "No node found for index {source}"
         )));
     }
     let mut bfs = Bfs::new(graph, node_index);

--- a/src/steiner_tree.rs
+++ b/src/steiner_tree.rs
@@ -133,8 +133,7 @@ pub fn steiner_tree(
         let index = NodeIndex::new(*n);
         if graph.graph.node_weight(index).is_none() {
             return Err(PyValueError::new_err(format!(
-                "Provided terminal node index {} is not present in graph",
-                n
+                "Provided terminal node index {n} is not present in graph"
             )));
         }
         terminal_n.push(index);

--- a/src/traversal/mod.rs
+++ b/src/traversal/mod.rs
@@ -255,8 +255,7 @@ pub fn ancestors(graph: &digraph::PyDiGraph, node: usize) -> PyResult<HashSet<us
     let index = NodeIndex::new(node);
     if !graph.graph.contains_node(index) {
         return Err(PyIndexError::new_err(format!(
-            "Node source index \"{}\" out of graph bound",
-            node
+            "Node source index \"{node}\" out of graph bound"
         )));
     }
     Ok(core_ancestors(&graph.graph, index)
@@ -298,8 +297,7 @@ pub fn descendants(graph: &digraph::PyDiGraph, node: usize) -> PyResult<HashSet<
     let index = NodeIndex::new(node);
     if !graph.graph.contains_node(index) {
         return Err(PyIndexError::new_err(format!(
-            "Node source index \"{}\" out of graph bound",
-            node
+            "Node source index \"{node}\" out of graph bound"
         )));
     }
     Ok(core_descendants(&graph.graph, index)


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Related to #1471 

Right now, the lints are disabled. This PR actually fixes them. Most of the fixes were automated following commands along the lines of:
```
cargo clippy --fix --lib -p rustworkx 
```