### PR TITLE
Adding Quickcheck for cycle graph

### DIFF
--- a/rustworkx-core/tests/quickcheck/cycle_graph.rs
+++ b/rustworkx-core/tests/quickcheck/cycle_graph.rs
@@ -1,0 +1,111 @@
+use petgraph::graph::{DiGraph, UnGraph};
+use petgraph::visit::EdgeRef;
+use quickcheck::{quickcheck, TestResult};
+use rustworkx_core::generators::cycle_graph;
+use std::collections::HashSet;
+
+#[test]
+fn prop_cycle_graph_directed() {
+    fn prop(n: usize) -> TestResult {
+        let n = (n % 100).max(2);
+        let g = match cycle_graph::<DiGraph<(), ()>, (), _, _, ()>(
+            Some(n),
+            None,
+            || (),
+            || (),
+            false,
+        ) {
+            Ok(g) => g,
+            Err(_) => return TestResult::error("Unexpected error in directed cycle_graph"),
+        };
+
+        if g.node_count() != n || g.edge_count() != n {
+            return TestResult::failed();
+        }
+
+        // Expected edges in circular fashion 0→1, 1→2, ... n-1→0
+        let expected_edges: HashSet<_> = (0..n).map(|i| (i, (i + 1) % n)).collect();
+
+        let actual_edges: HashSet<_> = g
+            .edge_references()
+            .map(|e| (e.source().index(), e.target().index()))
+            .collect();
+
+        TestResult::from_bool(expected_edges == actual_edges)
+    }
+
+    quickcheck(prop as fn(usize) -> TestResult);
+}
+
+#[test]
+fn prop_cycle_graph_bidirectional() {
+    fn prop(n: usize) -> TestResult {
+        let n = (n % 100).max(2);
+        let g =
+            match cycle_graph::<DiGraph<(), ()>, (), _, _, ()>(Some(n), None, || (), || (), true) {
+                Ok(g) => g,
+                Err(_) => {
+                    return TestResult::error("Unexpected error in bidirectional cycle_graph")
+                }
+            };
+
+        if g.node_count() != n || g.edge_count() != 2 * n {
+            return TestResult::failed();
+        }
+
+        // For each directed edge, its reverse must exist
+        for edge in g.edge_references() {
+            let u = edge.source();
+            let v = edge.target();
+            if g.find_edge(v, u).is_none() {
+                return TestResult::failed();
+            }
+        }
+
+        TestResult::passed()
+    }
+
+    quickcheck(prop as fn(usize) -> TestResult);
+}
+
+#[test]
+fn prop_cycle_graph_undirected() {
+    fn prop(n: usize) -> TestResult {
+        let n = (n % 100).max(2);
+        let g = match cycle_graph::<UnGraph<(), ()>, (), _, _, ()>(
+            Some(n),
+            None,
+            || (),
+            || (),
+            false,
+        ) {
+            Ok(g) => g,
+            Err(_) => return TestResult::error("Unexpected error in undirected cycle_graph"),
+        };
+
+        if g.node_count() != n || g.edge_count() != n {
+            return TestResult::failed();
+        }
+
+        let expected_edges: HashSet<_> = (0..n)
+            .map(|i| {
+                let u = i;
+                let v = (i + 1) % n;
+                (u.min(v), u.max(v))
+            })
+            .collect();
+
+        let actual_edges: HashSet<_> = g
+            .edge_references()
+            .map(|e| {
+                let u = e.source().index();
+                let v = e.target().index();
+                (u.min(v), u.max(v))
+            })
+            .collect();
+
+        TestResult::from_bool(expected_edges == actual_edges)
+    }
+
+    quickcheck(prop as fn(usize) -> TestResult);
+}

--- a/rustworkx-core/tests/quickcheck/main.rs
+++ b/rustworkx-core/tests/quickcheck/main.rs
@@ -1,6 +1,7 @@
 mod barbell_graph;
 mod binomial_tree_graph;
 mod complete_graph;
+mod cycle_graph;
 mod full_rary_tree_graph;
 mod grid_graph;
 mod heavy_hex_graph;


### PR DESCRIPTION
We are testing the structural property of cycle graph by ensuring:

Node count is exactly n

Edge count is:

n for directed, non-bidirectional
2n for directed, bidirectional
n for undirected

All expected edges are present

In bidirectional mode: for every (u, v) edge, there’s also a (v, u) edge

