### PR TITLE
Port transitivity to rustworkx-core

### DIFF
--- a/releasenotes/notes/port-transitivity-c69b72f813e68693.yaml
+++ b/releasenotes/notes/port-transitivity-c69b72f813e68693.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add function to rustworkx-core to compute undirected and directed graph transitivity. This ports the algorithm that was implemented in rustworkx Python API.

--- a/rustworkx-core/src/lib.rs
+++ b/rustworkx-core/src/lib.rs
@@ -107,6 +107,7 @@ pub mod line_graph;
 pub mod max_weight_matching;
 pub mod planar;
 pub mod shortest_path;
+pub mod transitivity;
 pub mod traversal;
 // These modules define additional data structures
 pub mod dictmap;

--- a/rustworkx-core/src/transitivity.rs
+++ b/rustworkx-core/src/transitivity.rs
@@ -1,0 +1,290 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+use hashbrown::HashSet;
+
+use petgraph::visit::{IntoEdges, IntoNeighborsDirected, IntoNodeIdentifiers, NodeIndexable};
+use rayon::prelude::*;
+
+use std::hash::Hash;
+
+/// Counts triangles and connected triples containing `node` of the given undirected graph.
+fn graph_node_triangles<G>(graph: G, node: G::NodeId) -> (usize, usize)
+where
+    G: IntoEdges,
+    G::NodeId: Hash + Eq,
+{
+    let node_neighbors: HashSet<G::NodeId> = graph.neighbors(node).filter(|v| *v != node).collect();
+
+    let triangles: usize = node_neighbors
+        .iter()
+        .map(|&v| {
+            graph
+                .neighbors(v)
+                .filter(|&x| (x != v) && node_neighbors.contains(&x))
+                .count()
+        })
+        .sum();
+
+    let triples = match node_neighbors.len() {
+        0 => 0,
+        d => (d * (d - 1)) / 2,
+    };
+
+    (triangles / 2, triples)
+}
+
+/// Compute the transitivity of an undirected graph.
+///
+/// The transitivity of a graph is 3*number of triangles / number of connected triples, where
+/// “connected triple” means a single vertex with edges running to an unordered pair of others.
+///
+/// This function is multithreaded and will launch a thread pool with threads equal to the number
+/// of CPUs by default. You can tune the number of threads with the ``RAYON_NUM_THREADS``
+/// environment variable. For example, setting ``RAYON_NUM_THREADS=4`` would limit the thread pool
+/// to 4 threads.
+///
+/// The function implicitly assumes that there are no parallel edges or self loops. It may produce
+/// incorrect/unexpected results if the input graph has self loops or parallel edges.
+pub fn graph_transitivity<G>(graph: G) -> f64
+where
+    G: NodeIndexable + IntoEdges + IntoNodeIdentifiers + Send + Sync,
+    G::NodeId: Hash + Eq + Send + Sync,
+{
+    let nodes: Vec<_> = graph.node_identifiers().collect();
+    let (triangles, triples) = nodes
+        .par_iter()
+        .map(|node| graph_node_triangles(graph, *node))
+        .reduce(
+            || (0, 0),
+            |(sumx, sumy), (resx, resy)| (sumx + resx, sumy + resy),
+        );
+
+    match triangles {
+        0 => 0.0,
+        _ => triangles as f64 / triples as f64,
+    }
+}
+
+/// Counts triangles and triples containing `node` of the given directed graph.
+fn digraph_node_triangles<G>(graph: G, node: G::NodeId) -> (usize, usize)
+where
+    G: IntoNeighborsDirected,
+    G::NodeId: Hash + Eq,
+{
+    let out_neighbors: HashSet<G::NodeId> = graph
+        .neighbors_directed(node, petgraph::Direction::Outgoing)
+        .filter(|v| *v != node)
+        .collect();
+
+    let in_neighbors: HashSet<G::NodeId> = graph
+        .neighbors_directed(node, petgraph::Direction::Incoming)
+        .filter(|v| *v != node)
+        .collect();
+
+    let triangles: usize = out_neighbors
+        .iter()
+        .chain(in_neighbors.iter())
+        .map(|v| {
+            graph
+                .neighbors_directed(*v, petgraph::Direction::Outgoing)
+                .chain(graph.neighbors_directed(*v, petgraph::Direction::Incoming))
+                .map(|x| {
+                    ((x != *v) && out_neighbors.contains(&x)) as usize
+                        + ((x != *v) && in_neighbors.contains(&x)) as usize
+                })
+                .sum::<usize>()
+        })
+        .sum();
+
+    let d_tot = in_neighbors.len() + out_neighbors.len();
+    let d_bil = out_neighbors.intersection(&in_neighbors).count();
+    let triples = match d_tot {
+        0 => 0,
+        _ => d_tot * (d_tot - 1) - 2 * d_bil,
+    };
+
+    (triangles / 2, triples)
+}
+
+/// Compute the transitivity of a directed graph.
+///
+/// The transitivity of a directed graph is 3*number of triangles/number of all possible triangles.
+/// A triangle is a connected triple of nodes. Different edge orientations counts as different
+/// triangles.
+///
+/// This function is multithreaded and will launch a thread pool with threads equal to the number
+/// of CPUs by default. You can tune the number of threads with the ``RAYON_NUM_THREADS``
+/// environment variable. For example, setting ``RAYON_NUM_THREADS=4`` would limit the thread pool
+/// to 4 threads.
+///
+/// The function implicitly assumes that there are no parallel edges or self loops. It may produce
+/// incorrect/unexpected results if the input graph has self loops or parallel edges.
+pub fn digraph_transitivity<G>(graph: G) -> f64
+where
+    G: NodeIndexable + IntoNodeIdentifiers + IntoNeighborsDirected + Send + Sync,
+    G::NodeId: Hash + Eq + Send + Sync,
+{
+    let nodes: Vec<_> = graph.node_identifiers().collect();
+    let (triangles, triples) = nodes
+        .par_iter()
+        .map(|node| digraph_node_triangles(graph, *node))
+        .reduce(
+            || (0, 0),
+            |(sumx, sumy), (resx, resy)| (sumx + resx, sumy + resy),
+        );
+
+    match triangles {
+        0 => 0.0,
+        _ => triangles as f64 / triples as f64,
+    }
+}
+
+#[cfg(test)]
+mod test_token_swapper {
+    use petgraph::{
+        graph::{DiGraph, UnGraph},
+        Graph,
+    };
+
+    use super::{
+        digraph_node_triangles, digraph_transitivity, graph_node_triangles, graph_transitivity,
+    };
+
+    #[test]
+    fn test_node_triangles() {
+        let mut graph: UnGraph<(), ()> = Graph::with_capacity(5, 6);
+        let a = graph.add_node(());
+        let b = graph.add_node(());
+        let c = graph.add_node(());
+        let d = graph.add_node(());
+        let e = graph.add_node(());
+        graph.extend_with_edges([(a, b), (b, c), (a, c), (a, d), (c, d), (d, e)]);
+        assert_eq!(graph_node_triangles(&graph, a), (2, 3));
+    }
+
+    #[test]
+    fn test_node_triangles_disconnected() {
+        let mut graph: UnGraph<(), ()> = Graph::with_capacity(1, 0);
+        let a = graph.add_node(());
+        assert_eq!(graph_node_triangles(&graph, a), (0, 0));
+    }
+
+    #[test]
+    fn test_transitivity() {
+        let mut graph: UnGraph<(), ()> = Graph::with_capacity(5, 5);
+        let a = graph.add_node(());
+        let b = graph.add_node(());
+        let c = graph.add_node(());
+        let d = graph.add_node(());
+        let e = graph.add_node(());
+        graph.extend_with_edges([(a, b), (a, c), (a, d), (a, e), (b, c)]);
+
+        assert_eq!(graph_transitivity(&graph), 3. / 8.);
+    }
+
+    #[test]
+    fn test_transitivity_triangle() {
+        let mut graph: UnGraph<(), ()> = Graph::with_capacity(3, 3);
+        let a = graph.add_node(());
+        let b = graph.add_node(());
+        let c = graph.add_node(());
+        graph.extend_with_edges([(a, b), (a, c), (b, c)]);
+        assert_eq!(graph_transitivity(&graph), 1.0)
+    }
+
+    #[test]
+    fn test_transitivity_star() {
+        let mut graph: UnGraph<(), ()> = Graph::with_capacity(5, 4);
+        let a = graph.add_node(());
+        let b = graph.add_node(());
+        let c = graph.add_node(());
+        let d = graph.add_node(());
+        let e = graph.add_node(());
+        graph.extend_with_edges([(a, b), (a, c), (a, d), (a, e)]);
+        assert_eq!(graph_transitivity(&graph), 0.0)
+    }
+
+    #[test]
+    fn test_transitivity_empty() {
+        let graph: UnGraph<(), ()> = Graph::with_capacity(0, 0);
+        assert_eq!(graph_transitivity(&graph), 0.0)
+    }
+
+    #[test]
+    fn test_transitivity_disconnected() {
+        let mut graph: UnGraph<(), ()> = Graph::with_capacity(2, 1);
+        let a = graph.add_node(());
+        let b = graph.add_node(());
+        graph.add_node(());
+        graph.add_edge(a, b, ());
+        assert_eq!(graph_transitivity(&graph), 0.0)
+    }
+
+    #[test]
+    fn test_two_directed_node_triangles() {
+        let mut graph: DiGraph<(), ()> = Graph::with_capacity(5, 7);
+        let a = graph.add_node(());
+        let b = graph.add_node(());
+        let c = graph.add_node(());
+        let d = graph.add_node(());
+        let e = graph.add_node(());
+        // The reciprocal edge (a, c) (c, a) double the number of triangles
+        graph.extend_with_edges([(a, b), (b, c), (c, a), (a, c), (c, d), (d, a), (d, e)]);
+        assert_eq!(digraph_node_triangles(&graph, a), (4, 10));
+    }
+
+    #[test]
+    fn test_directed_node_triangles_disconnected() {
+        let mut graph: DiGraph<(), ()> = Graph::with_capacity(1, 0);
+        let a = graph.add_node(());
+        assert_eq!(graph_node_triangles(&graph, a), (0, 0));
+    }
+
+    #[test]
+    fn test_transitivity_directed() {
+        let mut graph: DiGraph<(), ()> = Graph::with_capacity(5, 4);
+        let a = graph.add_node(());
+        let b = graph.add_node(());
+        let c = graph.add_node(());
+        let d = graph.add_node(());
+        graph.add_node(());
+        graph.extend_with_edges([(a, b), (a, c), (a, d), (b, c)]);
+        assert_eq!(digraph_transitivity(&graph), 3. / 10.);
+    }
+
+    #[test]
+    fn test_transitivity_triangle_directed() {
+        let mut graph: DiGraph<(), ()> = Graph::with_capacity(3, 3);
+        let a = graph.add_node(());
+        let b = graph.add_node(());
+        let c = graph.add_node(());
+        graph.extend_with_edges([(a, b), (a, c), (b, c)]);
+        assert_eq!(digraph_transitivity(&graph), 0.5);
+    }
+
+    #[test]
+    fn test_transitivity_fulltriangle_directed() {
+        let mut graph: DiGraph<(), ()> = Graph::with_capacity(3, 6);
+        let a = graph.add_node(());
+        let b = graph.add_node(());
+        let c = graph.add_node(());
+        graph.extend_with_edges([(a, b), (b, a), (a, c), (c, a), (b, c), (c, b)]);
+        assert_eq!(digraph_transitivity(&graph), 1.0);
+    }
+
+    #[test]
+    fn test_transitivity_empty_directed() {
+        let graph: DiGraph<(), ()> = Graph::with_capacity(0, 0);
+        assert_eq!(digraph_transitivity(&graph), 0.0);
+    }
+}

--- a/rustworkx-core/src/transitivity.rs
+++ b/rustworkx-core/src/transitivity.rs
@@ -150,7 +150,7 @@ where
 }
 
 #[cfg(test)]
-mod test_token_swapper {
+mod test_transitivity {
     use petgraph::{
         graph::{DiGraph, UnGraph},
         Graph,

--- a/src/transitivity.rs
+++ b/src/transitivity.rs
@@ -11,36 +11,10 @@
 // under the License.
 
 use super::{digraph, graph};
-use hashbrown::HashSet;
 
 use pyo3::prelude::*;
 
-use petgraph::graph::NodeIndex;
-use rayon::prelude::*;
-
-fn _graph_triangles(graph: &graph::PyGraph, node: usize) -> (usize, usize) {
-    let mut triangles: usize = 0;
-
-    let index = NodeIndex::new(node);
-    let mut neighbors: HashSet<NodeIndex> = graph.graph.neighbors(index).collect();
-    neighbors.remove(&index);
-
-    for nodev in &neighbors {
-        triangles += graph
-            .graph
-            .neighbors(*nodev)
-            .filter(|&x| (x != *nodev) && neighbors.contains(&x))
-            .count();
-    }
-
-    let d: usize = neighbors.len();
-    let triples: usize = match d {
-        0 => 0,
-        _ => (d * (d - 1)) / 2,
-    };
-
-    (triangles / 2, triples)
-}
+use rustworkx_core::transitivity as core;
 
 /// Compute the transitivity of an undirected graph.
 ///
@@ -52,7 +26,7 @@ fn _graph_triangles(graph: &graph::PyGraph, node: usize) -> (usize, usize) {
 /// A “connected triple” means a single vertex with
 /// edges running to an unordered pair of others.
 ///
-/// This function is multithreaded and will run
+/// This function is multithreaded and will
 /// launch a thread pool with threads equal to the number of CPUs by default.
 /// You can tune the number of threads with the ``RAYON_NUM_THREADS``
 /// environment variable. For example, setting ``RAYON_NUM_THREADS=4`` would
@@ -71,73 +45,7 @@ fn _graph_triangles(graph: &graph::PyGraph, node: usize) -> (usize, usize) {
 #[pyfunction]
 #[pyo3(text_signature = "(graph, /)")]
 pub fn graph_transitivity(graph: &graph::PyGraph) -> f64 {
-    let node_indices: Vec<NodeIndex> = graph.graph.node_indices().collect();
-    let (triangles, triples) = node_indices
-        .par_iter()
-        .map(|node| _graph_triangles(graph, node.index()))
-        .reduce(
-            || (0, 0),
-            |(sumx, sumy), (resx, resy)| (sumx + resx, sumy + resy),
-        );
-
-    match triangles {
-        0 => 0.0,
-        _ => triangles as f64 / triples as f64,
-    }
-}
-
-fn _digraph_triangles(graph: &digraph::PyDiGraph, node: usize) -> (usize, usize) {
-    let mut triangles: usize = 0;
-
-    let index = NodeIndex::new(node);
-    let mut out_neighbors: HashSet<NodeIndex> = graph
-        .graph
-        .neighbors_directed(index, petgraph::Direction::Outgoing)
-        .collect();
-    out_neighbors.remove(&index);
-
-    let mut in_neighbors: HashSet<NodeIndex> = graph
-        .graph
-        .neighbors_directed(index, petgraph::Direction::Incoming)
-        .collect();
-    in_neighbors.remove(&index);
-
-    let neighbors = out_neighbors.iter().chain(in_neighbors.iter());
-
-    for nodev in neighbors {
-        triangles += graph
-            .graph
-            .neighbors_directed(*nodev, petgraph::Direction::Outgoing)
-            .chain(
-                graph
-                    .graph
-                    .neighbors_directed(*nodev, petgraph::Direction::Incoming),
-            )
-            .map(|x| {
-                let mut res: usize = 0;
-
-                if (x != *nodev) && out_neighbors.contains(&x) {
-                    res += 1;
-                }
-                if (x != *nodev) && in_neighbors.contains(&x) {
-                    res += 1;
-                }
-                res
-            })
-            .sum::<usize>();
-    }
-
-    let d_in: usize = in_neighbors.len();
-    let d_out: usize = out_neighbors.len();
-
-    let d_tot = d_out + d_in;
-    let d_bil: usize = out_neighbors.intersection(&in_neighbors).count();
-    let triples: usize = match d_tot {
-        0 => 0,
-        _ => d_tot * (d_tot - 1) - 2 * d_bil,
-    };
-
-    (triangles / 2, triples)
+    core::graph_transitivity(&graph.graph)
 }
 
 /// Compute the transitivity of a directed graph.
@@ -150,7 +58,7 @@ fn _digraph_triangles(graph: &digraph::PyDiGraph, node: usize) -> (usize, usize)
 /// A triangle is a connected triple of nodes.
 /// Different edge orientations counts as different triangles.
 ///
-/// This function is multithreaded and will run
+/// This function is multithreaded and will
 /// launch a thread pool with threads equal to the number of CPUs by default.
 /// You can tune the number of threads with the ``RAYON_NUM_THREADS``
 /// environment variable. For example, setting ``RAYON_NUM_THREADS=4`` would
@@ -172,17 +80,5 @@ fn _digraph_triangles(graph: &digraph::PyDiGraph, node: usize) -> (usize, usize)
 #[pyfunction]
 #[pyo3(text_signature = "(graph, /)")]
 pub fn digraph_transitivity(graph: &digraph::PyDiGraph) -> f64 {
-    let node_indices: Vec<NodeIndex> = graph.graph.node_indices().collect();
-    let (triangles, triples) = node_indices
-        .par_iter()
-        .map(|node| _digraph_triangles(graph, node.index()))
-        .reduce(
-            || (0, 0),
-            |(sumx, sumy), (resx, resy)| (sumx + resx, sumy + resy),
-        );
-
-    match triangles {
-        0 => 0.0,
-        _ => triangles as f64 / triples as f64,
-    }
+    core::digraph_transitivity(&graph.graph)
 }

--- a/src/transitivity.rs
+++ b/src/transitivity.rs
@@ -14,7 +14,7 @@ use super::{digraph, graph};
 
 use pyo3::prelude::*;
 
-use rustworkx_core::transitivity as core;
+use rustworkx_core::transitivity as core_transitivity;
 
 /// Compute the transitivity of an undirected graph.
 ///
@@ -45,7 +45,7 @@ use rustworkx_core::transitivity as core;
 #[pyfunction]
 #[pyo3(text_signature = "(graph, /)")]
 pub fn graph_transitivity(graph: &graph::PyGraph) -> f64 {
-    core::graph_transitivity(&graph.graph)
+    core_transitivity::graph_transitivity(&graph.graph)
 }
 
 /// Compute the transitivity of a directed graph.
@@ -80,5 +80,5 @@ pub fn graph_transitivity(graph: &graph::PyGraph) -> f64 {
 #[pyfunction]
 #[pyo3(text_signature = "(graph, /)")]
 pub fn digraph_transitivity(graph: &digraph::PyDiGraph) -> f64 {
-    core::digraph_transitivity(&graph.graph)
+    core_transitivity::digraph_transitivity(&graph.graph)
 }


### PR DESCRIPTION
This ports the undirected graph and directed graph transitivity functions to rustworkx-core (#1121).

While this is mostly a copy and paste, I changed for loops to iterators and `HashSet::remove` for a `filter` when constructing the set.

I think the functions `digraph_node_triangles` and `graph_node_triangles` that count the triangles of a vertex could be part of the public API. Implementing the [local clustering](https://en.wikipedia.org/wiki/Clustering_coefficient#Local_clustering_coefficient) is direct using these functions while it doesn't seem part of rustworkx right now.