### PR TITLE
Allow multiple targets for rustworkx.all_simple_paths

### DIFF
--- a/releasenotes/notes/expose-all-simple-path-multiple-targets-767f818daeeb5a41.yaml
+++ b/releasenotes/notes/expose-all-simple-path-multiple-targets-767f818daeeb5a41.yaml
@@ -1,0 +1,18 @@
+---
+features:
+  - |
+    The :func:`~rustworkx.all_simple_paths` function now supports multiple
+    target nodes passed as an iterable. You can now pass either a single target
+    node (int) or multiple target nodes (iterable of ints) to find all simple
+    paths from a source node to any of the specified targets. For example::
+
+        import rustworkx as rx
+
+        graph = rx.generators.path_graph(4)
+        # Multiple targets - new functionality
+        paths = rx.all_simple_paths(graph, 0, [2, 3])
+        # paths: [[0, 1, 2], [0, 1, 2, 3]]
+
+    This enhancement maintains backward compatibility while providing more
+    flexibility for pathfinding operations in both :class:`~.PyGraph` and
+    :class:`~.PyDiGraph` objects.

--- a/rustworkx/__init__.py
+++ b/rustworkx/__init__.py
@@ -263,7 +263,7 @@ def all_simple_paths(graph, from_, to, min_depth=None, cutoff=None):
     :param graph: The graph to find the path in. Can either be a
         class:`~rustworkx.PyGraph` or :class:`~rustworkx.PyDiGraph`
     :param int from_: The node index to find the paths from
-    :param int to: The node index to find the paths to
+    :param int | Iterable[int] to: The node index(es) to find the paths to
     :param int min_depth: The minimum depth of the path to include in the
         output list of paths. By default all paths are included regardless of
         depth, setting to 0 will behave like the default.

--- a/rustworkx/__init__.pyi
+++ b/rustworkx/__init__.pyi
@@ -13,7 +13,7 @@ import sys
 import numpy as np
 import numpy.typing as npt
 
-from typing import Generic, Any, Callable, overload
+from typing import Generic, Any, Callable, Iterable, overload
 from collections.abc import Iterator, Sequence
 
 if sys.version_info >= (3, 13):
@@ -325,7 +325,7 @@ def adjacency_matrix(
 def all_simple_paths(
     graph: PyGraph | PyDiGraph,
     from_: int,
-    to: int,
+    to: int | Iterable[int],
     min_depth: int | None = ...,
     cutoff: int | None = ...,
 ) -> list[list[int]]: ...

--- a/rustworkx/__init__.pyi
+++ b/rustworkx/__init__.pyi
@@ -13,8 +13,8 @@ import sys
 import numpy as np
 import numpy.typing as npt
 
-from typing import Generic, Any, Callable, Iterable, overload
-from collections.abc import Iterator, Sequence
+from typing import Generic, Any, Callable, overload
+from collections.abc import Iterable, Iterator, Sequence
 
 if sys.version_info >= (3, 13):
     from typing import TypeVar

--- a/rustworkx/rustworkx.pyi
+++ b/rustworkx/rustworkx.pyi
@@ -285,7 +285,7 @@ def local_complement(
 def digraph_all_simple_paths(
     graph: PyDiGraph,
     origin: int,
-    to: int,
+    to: int | Iterable[int],
     /,
     min_depth: int | None = ...,
     cutoff: int | None = ...,
@@ -293,7 +293,7 @@ def digraph_all_simple_paths(
 def graph_all_simple_paths(
     graph: PyGraph,
     origin: int,
-    to: int,
+    to: int | Iterable[int],
     /,
     min_depth: int | None = ...,
     cutoff: int | None = ...,

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -1075,15 +1075,16 @@ pub fn digraph_all_simple_paths(
                 "The input index for 'to' is not a valid node index",
             ));
         }
-        let result: Vec<Vec<usize>> = algo::all_simple_paths::<Vec<_>, _, foldhash::fast::RandomState>(
-            &graph.graph,
-            from_index,
-            to_index,
-            min_intermediate_nodes,
-            cutoff_petgraph,
-        )
-        .map(|v: Vec<NodeIndex>| v.into_iter().map(|i| i.index()).collect())
-        .collect();
+        let result: Vec<Vec<usize>> =
+            algo::all_simple_paths::<Vec<_>, _, foldhash::fast::RandomState>(
+                &graph.graph,
+                from_index,
+                to_index,
+                min_intermediate_nodes,
+                cutoff_petgraph,
+            )
+            .map(|v: Vec<NodeIndex>| v.into_iter().map(|i| i.index()).collect())
+            .collect();
         return Ok(result);
     }
 

--- a/tests/digraph/test_all_simple_paths.py
+++ b/tests/digraph/test_all_simple_paths.py
@@ -131,6 +131,45 @@ class TestDAGAllSimplePaths(unittest.TestCase):
         dag.add_node(1)
         self.assertRaises(TypeError, rustworkx.digraph_all_simple_paths, (dag, 0, 1))
 
+    def test_all_simple_paths_multiple_targets(self):
+        graph = rustworkx.generators.directed_path_graph(4)
+        graph.add_edge(1, 3, None)
+        paths = rustworkx.digraph_all_simple_paths(graph, 0, [2, 3])
+        expected = [[0, 1, 2], [0, 1, 2, 3], [0, 1, 3]]
+        self.assertEqual(len(expected), len(paths))
+        for i in expected:
+            self.assertIn(i, paths)
+
+    def test_all_simple_paths_multiple_targets_iterables(self):
+        graph = rustworkx.generators.directed_path_graph(4)
+        graph.add_edge(1, 3, None)
+        paths = rustworkx.digraph_all_simple_paths(graph, 0, iter([2, 3]))
+        expected = [[0, 1, 2], [0, 1, 2, 3], [0, 1, 3]]
+        self.assertEqual(len(expected), len(paths))
+        for i in expected:
+            self.assertIn(i, paths)
+
+    def test_all_simple_paths_multiple_targets_invalid_type(self):
+        graph = rustworkx.generators.directed_path_graph(4)
+        with self.assertRaises(TypeError):
+            rustworkx.digraph_all_simple_paths(graph, 0, [2, "a"])
+
+    def test_all_simple_paths_multiple_targets_invalid_index(self):
+        graph = rustworkx.generators.directed_path_graph(4)
+        paths = rustworkx.digraph_all_simple_paths(graph, 0, [3, 100])
+        expected = [[0, 1, 2, 3]]
+        self.assertEqual(expected, paths)
+
+    def test_all_simple_paths_on_nontrivial_graph(self):
+        graph = rustworkx.PyDiGraph()
+        graph.add_nodes_from(range(6))
+        graph.add_edges_from_no_data([(0, 1), (0, 5), (1, 2), (1, 5), (2, 3), (3, 4), (4, 5)])
+        paths = rustworkx.digraph_all_simple_paths(graph, 0, [2, 3])
+        expected = [[0, 1, 2], [0, 1, 2, 3]]
+        self.assertEqual(len(expected), len(paths))
+        for i in expected:
+            self.assertIn(i, paths)
+
 
 class TestDiGraphAllSimplePathsAllPairs(unittest.TestCase):
     def setUp(self):

--- a/tests/graph/test_all_simple_paths.py
+++ b/tests/graph/test_all_simple_paths.py
@@ -232,6 +232,54 @@ class TestGraphAllSimplePaths(unittest.TestCase):
         dag.add_node(1)
         self.assertRaises(TypeError, rustworkx.graph_all_simple_paths, (dag, 0, 1))
 
+    def test_all_simple_paths_multiple_targets(self):
+        graph = rustworkx.generators.path_graph(4)
+        graph.add_edge(1, 3, None)
+        paths = rustworkx.graph_all_simple_paths(graph, 0, [2, 3])
+        expected = [[0, 1, 2], [0, 1, 3], [0, 1, 2, 3], [0, 1, 3, 2]]
+        self.assertEqual(len(expected), len(paths))
+        for i in expected:
+            self.assertIn(i, paths)
+
+    def test_all_simple_paths_multiple_targets_iterables(self):
+        graph = rustworkx.generators.path_graph(4)
+        graph.add_edge(1, 3, None)
+        paths = rustworkx.graph_all_simple_paths(graph, 0, iter([2, 3]))
+        expected = [[0, 1, 2], [0, 1, 3], [0, 1, 2, 3], [0, 1, 3, 2]]
+        self.assertEqual(len(expected), len(paths))
+        for i in expected:
+            self.assertIn(i, paths)
+
+    def test_all_simple_paths_multiple_targets_invalid_type(self):
+        graph = rustworkx.generators.path_graph(4)
+        with self.assertRaises(TypeError):
+            rustworkx.graph_all_simple_paths(graph, 0, [2, "a"])
+
+    def test_all_simple_paths_multiple_targets_invalid_index(self):
+        graph = rustworkx.generators.path_graph(4)
+        paths = rustworkx.graph_all_simple_paths(graph, 0, [3, 100])
+        expected = [[0, 1, 2, 3]]
+        self.assertEqual(expected, paths)
+
+    def test_all_simple_paths_on_nontrivial_graph(self):
+        graph = rustworkx.PyGraph()
+        graph.add_nodes_from(range(6))
+        graph.add_edges_from_no_data([(0, 1), (0, 5), (1, 2), (1, 5), (2, 3), (3, 4), (4, 5)])
+        paths = rustworkx.graph_all_simple_paths(graph, 0, [2, 3])
+        expected = [
+            [0, 1, 2],
+            [0, 1, 2, 3],
+            [0, 1, 5, 4, 3],
+            [0, 1, 5, 4, 3, 2],
+            [0, 5, 1, 2],
+            [0, 5, 1, 2, 3],
+            [0, 5, 4, 3],
+            [0, 5, 4, 3, 2],
+        ]
+        self.assertEqual(len(expected), len(paths))
+        for i in expected:
+            self.assertIn(i, paths)
+
 
 class TestGraphAllSimplePathsAllPairs(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR enables multiple target being passed as iterable[int] to `rustworkx.all_simple_paths` as mentioned in #1487, the return type stays the same, similar to `networkx`'s implementation.

To ensure backward capabilities, the implementation for single target handling stays the same.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
