### PR TITLE
Changed matplotlib.py so that draw_edges() accepts connectionstyle arguments besides arcs

### DIFF
--- a/releasenotes/notes/fix-connectionstyles-bug-25a3cab6e6932daa.yaml
+++ b/releasenotes/notes/fix-connectionstyles-bug-25a3cab6e6932daa.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed an issue where using function ``draw_edges()`` in 
+    ~/rustworkx/visualization/matplotlib.py will always attempt to use 
+    connectionstyle arc3 even if a different connectionstyle argument is 
+    input by the user. Now, `draw_edges()` can accept different connectionstyle arguments. 
+    If connectionstyle arc3 is used, the previous `draw_edges()` behavior is still used.
+    Refer to `#1497 <https://github.com/Qiskit/rustworkx/issues/1497>`__ for more details.

--- a/rustworkx/visualization/matplotlib.py
+++ b/rustworkx/visualization/matplotlib.py
@@ -731,7 +731,7 @@ def draw_edges(
             mutation_scale=mutation_scale,
             color=arrow_color,
             linewidth=line_width,
-            connectionstyle=f"{connectionstyle}, rad = {rad}",
+            connectionstyle=f"{connectionstyle}, rad = {rad}" if connectionstyle=="arc3" else f"{connectionstyle}",
             linestyle=style,
             zorder=1,
         )  # arrows go behind nodes

--- a/tests/visualization/test_mpl.py
+++ b/tests/visualization/test_mpl.py
@@ -204,3 +204,15 @@ class TestMPLDraw(unittest.TestCase):
         plt.close("all")
         mpl_draw(graph, pos=[graph.get_node_data(n) for n in range(len(graph))])
         _save_images(plt.gcf(), "test_hexagonal_lattice_directed.png")
+
+    def test_connectionstyles(self):
+        G = rustworkx.generators.directed_path_graph(25)
+        mpl_draw(G, connectionstyle='bar')
+        _save_images(plt.gcf(), "test_connectionstyle_bar.png")
+        plt.clf()
+        mpl_draw(G, connectionstyle='angle, angleA=30, angleB=150, rad=1.3')
+        _save_images(plt.gcf(), "test_connectionstyle_angle.png")
+        plt.clf()
+        mpl_draw(G, connectionstyle='angle3, angleA=20, angleB=60')
+        _save_images(plt.gcf(), "test_connectionstyle_angle3.png")
+        plt.clf()


### PR DESCRIPTION
Fixed an issue where using function ``draw_edges()`` in ~/rustworkx/visualization/matplotlib.py will always attempt to use connectionstyle arc3 even if a different connectionstyle argument is input by the user. Now, `draw_edges()` can accept different connectionstyle arguments. If connectionstyle arc3 is used, the previous `draw_edges()` behavior is still used.
Refer to `#1497 <https://github.com/Qiskit/rustworkx/issues/1497>`__ for more details.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ X] I ran rustfmt locally
- [ X] I have added the tests to cover my changes.
- [ X] I have updated the documentation accordingly.
- [ X] I have read the CONTRIBUTING document.
-->
