### PR TITLE
Fix pickling of graphs with contracted nodes

### DIFF
--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -3007,6 +3007,7 @@ impl PyDiGraph {
             }
             (None, true) => self.graph.contract_nodes(nodes, obj, check_cycle)?,
         };
+        self.node_removed = true;
         Ok(res.index())
     }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1899,6 +1899,7 @@ impl PyGraph {
             }
             (None, true) => self.graph.contract_nodes(nodes, obj),
         };
+        self.node_removed = true;
         Ok(res.index())
     }
 

--- a/tests/digraph/test_pickle.py
+++ b/tests/digraph/test_pickle.py
@@ -46,18 +46,18 @@ class TestPickleDiGraph(unittest.TestCase):
         g.add_node("A")  # Node 0
         g.add_node("B")  # Node 1
         g.add_node("C")  # Node 2
-        
+
         # Contract nodes 0 and 1 into a new node
         contracted_idx = g.contract_nodes([0, 1], "AB")
         g.add_edge(2, contracted_idx, "C -> AB")
-        
+
         # Verify initial state
         self.assertEqual([2, contracted_idx], g.node_indices())
         self.assertEqual([(2, contracted_idx)], g.edge_list())
-        
+
         # Test pickle/unpickle
         gprime = pickle.loads(pickle.dumps(g))
-        
+
         # Verify the unpickled graph matches
         self.assertEqual(g.node_indices(), gprime.node_indices())
         self.assertEqual(g.edge_list(), gprime.edge_list())

--- a/tests/digraph/test_pickle.py
+++ b/tests/digraph/test_pickle.py
@@ -39,3 +39,26 @@ class TestPickleDiGraph(unittest.TestCase):
         self.assertEqual([1, 2, 3], gprime.node_indices())
         self.assertEqual(["B", "C", "D"], gprime.nodes())
         self.assertEqual({1: (1, 2, "B -> C"), 3: (3, 1, "D -> B")}, dict(gprime.edge_index_map()))
+
+    def test_contracted_nodes_pickle(self):
+        """Test pickle/unpickle of directed graphs with contracted nodes (issue #1503)"""
+        g = rx.PyDiGraph()
+        g.add_node("A")  # Node 0
+        g.add_node("B")  # Node 1
+        g.add_node("C")  # Node 2
+        
+        # Contract nodes 0 and 1 into a new node
+        contracted_idx = g.contract_nodes([0, 1], "AB")
+        g.add_edge(2, contracted_idx, "C -> AB")
+        
+        # Verify initial state
+        self.assertEqual([2, contracted_idx], g.node_indices())
+        self.assertEqual([(2, contracted_idx)], g.edge_list())
+        
+        # Test pickle/unpickle
+        gprime = pickle.loads(pickle.dumps(g))
+        
+        # Verify the unpickled graph matches
+        self.assertEqual(g.node_indices(), gprime.node_indices())
+        self.assertEqual(g.edge_list(), gprime.edge_list())
+        self.assertEqual(g.nodes(), gprime.nodes())

--- a/tests/graph/test_pickle.py
+++ b/tests/graph/test_pickle.py
@@ -39,3 +39,46 @@ class TestPickleGraph(unittest.TestCase):
         self.assertEqual([1, 2, 3], gprime.node_indices())
         self.assertEqual(["B", "C", "D"], gprime.nodes())
         self.assertEqual({1: (1, 2, "B -> C"), 3: (3, 1, "D -> B")}, dict(gprime.edge_index_map()))
+
+    def test_contracted_nodes_pickle(self):
+        """Test pickle/unpickle of graphs with contracted nodes (issue #1503)"""
+        g = rx.PyGraph()
+        g.add_node("A")  # Node 0
+        g.add_node("B")  # Node 1
+        g.add_node("C")  # Node 2
+        
+        # Contract nodes 0 and 1 into a new node
+        contracted_idx = g.contract_nodes([0, 1], "AB")
+        g.add_edge(2, contracted_idx, "C -> AB")
+        
+        # Verify initial state
+        self.assertEqual([2, contracted_idx], g.node_indices())
+        self.assertEqual([(2, contracted_idx)], g.edge_list())
+        
+        # Test pickle/unpickle
+        gprime = pickle.loads(pickle.dumps(g))
+        
+        # Verify the unpickled graph matches
+        self.assertEqual(g.node_indices(), gprime.node_indices())
+        self.assertEqual(g.edge_list(), gprime.edge_list())
+        self.assertEqual(g.nodes(), gprime.nodes())
+
+    def test_contracted_nodes_with_weights_pickle(self):
+        """Test pickle/unpickle of graphs with contracted nodes and edge weights"""
+        g = rx.PyGraph()
+        g.add_nodes_from(["Node0", "Node1", "Node2", "Node3"])
+        g.add_edges_from([(0, 2, "edge_0_2"), (1, 3, "edge_1_3")])
+        
+        # Contract multiple nodes
+        contracted_idx = g.contract_nodes([0, 1], "Contracted_0_1") 
+        g.add_edge(contracted_idx, 2, "contracted_to_2")
+        g.add_edge(3, contracted_idx, "3_to_contracted")
+        
+        # Test pickle/unpickle
+        gprime = pickle.loads(pickle.dumps(g))
+        
+        # Verify complete graph state is preserved
+        self.assertEqual(g.node_indices(), gprime.node_indices())
+        self.assertEqual(g.edge_list(), gprime.edge_list())
+        self.assertEqual(g.nodes(), gprime.nodes())
+        self.assertEqual(dict(g.edge_index_map()), dict(gprime.edge_index_map()))

--- a/tests/graph/test_pickle.py
+++ b/tests/graph/test_pickle.py
@@ -46,18 +46,18 @@ class TestPickleGraph(unittest.TestCase):
         g.add_node("A")  # Node 0
         g.add_node("B")  # Node 1
         g.add_node("C")  # Node 2
-        
+
         # Contract nodes 0 and 1 into a new node
         contracted_idx = g.contract_nodes([0, 1], "AB")
         g.add_edge(2, contracted_idx, "C -> AB")
-        
+
         # Verify initial state
         self.assertEqual([2, contracted_idx], g.node_indices())
         self.assertEqual([(2, contracted_idx)], g.edge_list())
-        
+
         # Test pickle/unpickle
         gprime = pickle.loads(pickle.dumps(g))
-        
+
         # Verify the unpickled graph matches
         self.assertEqual(g.node_indices(), gprime.node_indices())
         self.assertEqual(g.edge_list(), gprime.edge_list())
@@ -68,15 +68,15 @@ class TestPickleGraph(unittest.TestCase):
         g = rx.PyGraph()
         g.add_nodes_from(["Node0", "Node1", "Node2", "Node3"])
         g.add_edges_from([(0, 2, "edge_0_2"), (1, 3, "edge_1_3")])
-        
+
         # Contract multiple nodes
-        contracted_idx = g.contract_nodes([0, 1], "Contracted_0_1") 
+        contracted_idx = g.contract_nodes([0, 1], "Contracted_0_1")
         g.add_edge(contracted_idx, 2, "contracted_to_2")
         g.add_edge(3, contracted_idx, "3_to_contracted")
-        
+
         # Test pickle/unpickle
         gprime = pickle.loads(pickle.dumps(g))
-        
+
         # Verify complete graph state is preserved
         self.assertEqual(g.node_indices(), gprime.node_indices())
         self.assertEqual(g.edge_list(), gprime.edge_list())


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->
Fixes https://github.com/Qiskit/rustworkx/issues/1503. Node contraction removes the contracted nodes but `self.node_removed` wasn't being set. Serialisation works differently depending on the flag. The failure reported in the issue was down to the wrong value of this flag.