### PR TITLE
Improve all simple paths multi-target performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ fixedbitset = "0.5.7"
 indexmap = { version = ">=1.9, <3", features = ["rayon"] }
 ndarray = { version = "0.16.1", features = ["rayon"] }
 num-traits = "0.2"
-petgraph = "0.8.3"
+petgraph = "0.8"
 hashbrown = { version = ">=0.13, <0.16", features = ["rayon"] }
 numpy = "0.26"
 rand = "0.9"

--- a/releasenotes/notes/replace-api-for-all-simple-paths-0c44a6c18dbdaaf4.yaml
+++ b/releasenotes/notes/replace-api-for-all-simple-paths-0c44a6c18dbdaaf4.yaml
@@ -1,5 +1,4 @@
-upgrade:
+other:
   - |
-    The underlying implementation for all simple paths with multiple targets is
-    replaced with a new implementation from petgraph to improve performance.
-    This does not affect existing functionality.
+    Avoid unnecessary hashing operations in `rustworkx.all_simple_paths` with
+    multiple targets, improving performance for the use case.

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -968,7 +968,7 @@ impl<'py> FromPyObject<'py> for TargetNodes {
         if let Ok(int) = ob.extract::<usize>() {
             Ok(Self::Single(NodeIndex::new(int)))
         } else {
-            let mut target_set: HashSet<NodeIndex, foldhash::fast::RandomState> = HashSet::new();
+            let mut target_set: HashSet<NodeIndex> = HashSet::new();
             for target in ob.try_iter()? {
                 let target_index = NodeIndex::new(target?.extract::<usize>()?);
                 target_set.insert(target_index);


### PR DESCRIPTION
- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes. (reusing previous test)
- [x] I have updated the documentation accordingly. (not necessary)
- [x] I have read the CONTRIBUTING document.

This PR continues the work from https://github.com/Qiskit/rustworkx/pull/1488.

Now that multiple-target support for `all_simple_paths` has been added to `petgraph` (see [all_simple_path_multi](https://docs.rs/petgraph/latest/petgraph/algo/simple_paths/fn.all_simple_paths_multi.html) and https://github.com/petgraph/petgraph/pull/865), this PR simply update the underlying implementation from `rustworkx_core::connectivity::all_simple_paths_multiple_targets` to `petgraph::algo::all_simple_paths_multi`.

This avoids the need to flatten `DictMap` into a `Vec` and results in better performance and cleaner code.