### PR TITLE
Fix dominance tests

### DIFF
--- a/tests/digraph/test_dominance.py
+++ b/tests/digraph/test_dominance.py
@@ -113,9 +113,7 @@ class TestImmediateDominators(unittest.TestCase):
         nx_graph = nx.DiGraph()
         nx_graph.add_edges_from(graph.edge_list())
         # subset check
-        self.assertGreaterEqual(
-            result.items(), nx.immediate_dominators(nx_graph, 1).items()
-        )
+        self.assertGreaterEqual(result.items(), nx.immediate_dominators(nx_graph, 1).items())
 
         # Test postdominance.
         graph.reverse()


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

This solves CI errors like this:
```
    AssertionError: {2: 1, 6: 2, 4: 2, 3: 2, 5: 2} != {1: 1, 2: 1, 3: 2, 4: 2, 5: 2, 6: 2}
- {2: 1, 3: 2, 4: 2, 5: 2, 6: 2}
+ {1: 1, 2: 1, 3: 2, 4: 2, 5: 2, 6: 2}
```

NetworkX changed the behaviour, I settled for checking if a dictionary is a subset of another. That let's us ignore that `1:1` is no longer on the NetworkX result.

This is required to unblock #1509 
