### PR TITLE
Split `hashbrown` dependency between Python-space and `rustworkx-core`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ indexmap = { version = ">=1.9, <3", features = ["rayon"] }
 ndarray = { version = "0.16.1", features = ["rayon"] }
 num-traits = "0.2"
 petgraph = "0.8"
-hashbrown = { version = ">=0.13, <0.16", features = ["rayon"] }
 numpy = "0.26"
 rand = "0.9"
 rand_distr = "0.5"
@@ -45,7 +44,6 @@ crate-type = ["cdylib"]
 [dependencies]
 foldhash.workspace = true
 fixedbitset.workspace = true
-hashbrown.workspace = true
 indexmap.workspace = true
 ndarray.workspace = true
 ndarray-stats = "0.6.0"
@@ -67,6 +65,10 @@ flate2 = "1.0.35"
 pest = "2.8"
 pest_derive = "2.8"
 nalgebra-sparse = { version = "=0.10", features = ["io"] }
+
+[dependencies.hashbrown]
+version = "0.15.0"  # Implicitly required to match PyO3's and `petgraph`'s via cross-API use.
+features = ["rayon"]
 
 [dependencies.pyo3]
 version = "0.26"

--- a/rustworkx-core/Cargo.toml
+++ b/rustworkx-core/Cargo.toml
@@ -14,7 +14,6 @@ license.workspace = true
 [dependencies]
 foldhash.workspace = true
 fixedbitset.workspace = true
-hashbrown.workspace = true
 indexmap.workspace = true
 ndarray.workspace = true
 num-traits.workspace = true
@@ -25,6 +24,13 @@ rand_distr.workspace = true
 rand_pcg.workspace = true
 rayon.workspace = true
 rayon-cond = "0.4"
+
+[dependencies.hashbrown]
+# The version here should allow a decent range, because it's used in the public API, meaning
+# downstream crates have to implicitly match us.  The range must at least be compatible with the
+# `rustworkx` Python component.
+version = ">=0.15,<0.17"
+features = ["rayon"]
 
 [dev-dependencies]
 quickcheck = "1.0"


### PR DESCRIPTION
`rustworkx-core` exposes `hashbrown` types in its own public API, which requires downstream crates match their resolved `hashbrown` versions to the one used by `rustworkx-core` in its API (up to potentially using a re-export of `hashbrown` from `rustworkx-core`, but one isn't provided, and it's not really scalable for `rustworkx-core` to claim it dictates the version of such a commonly used package).

The Python-space `rustworkx` package passes `hashbrown` types between PyO3 and `petgraph` interfaces, so requires hard matches to the resolved versions used by those libraries, but that's a tighter constraint.

These separate concerns motivate splitting the allowed bounds on `hashbrown`, so that downstream Rust-space consumers of `rustworkx-core` can use newer versions of `hashbrown` without being held back by the Python-space package.  For example, with this commit, Qiskit can now upgrade its internal use to `hashbrown 0.16.1`, including extracting those objects from (a newer) PyO3 and passing them to `rustworkx-core`.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
