### PR TITLE
Add random regular graph generator to rustworkx

### DIFF
--- a/releasenotes/notes/random-regular-graph-ac9033651888a461.yaml
+++ b/releasenotes/notes/random-regular-graph-ac9033651888a461.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Added a new function, :func:`.random_regular_graph` for generating random
+    undirected regular graphs.

--- a/rustworkx/__init__.pyi
+++ b/rustworkx/__init__.pyi
@@ -159,6 +159,7 @@ from .rustworkx import max_weight_matching as max_weight_matching
 from .rustworkx import is_matching as is_matching
 from .rustworkx import is_maximal_matching as is_maximal_matching
 from .rustworkx import is_planar as is_planar
+from .rustworkx import random_regular_graph as random_regular_graph
 from .rustworkx import directed_gnm_random_graph as directed_gnm_random_graph
 from .rustworkx import undirected_gnm_random_graph as undirected_gnm_random_graph
 from .rustworkx import directed_gnp_random_graph as directed_gnp_random_graph

--- a/rustworkx/rustworkx.pyi
+++ b/rustworkx/rustworkx.pyi
@@ -656,6 +656,12 @@ def is_planar(graph: PyGraph, /) -> bool: ...
 
 # Random Graph
 
+def random_regular_graph(
+    num_nodes: int,
+    degree: int,
+    /,
+    seed: int | None = ...,
+) -> PyGraph: ...
 def directed_gnm_random_graph(
     num_nodes: int,
     num_edges: int,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,6 +612,7 @@ fn rustworkx(py: Python<'_>, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(graph_line_graph))?;
     m.add_wrapped(wrap_pyfunction!(graph_tensor_product))?;
     m.add_wrapped(wrap_pyfunction!(digraph_tensor_product))?;
+    m.add_wrapped(wrap_pyfunction!(random_regular_graph))?;
     m.add_wrapped(wrap_pyfunction!(directed_gnp_random_graph))?;
     m.add_wrapped(wrap_pyfunction!(undirected_gnp_random_graph))?;
     m.add_wrapped(wrap_pyfunction!(directed_gnm_random_graph))?;

--- a/src/random_graph.rs
+++ b/src/random_graph.rs
@@ -32,7 +32,22 @@ use rand_pcg::Pcg64;
 
 use rustworkx_core::generators as core_generators;
 
-// TODO: docs
+/// Return a random undirected :math:`d`-regular graph on :math:`n` nodes.
+///
+/// A regular graph is a graph where each node has the same number of neighbors,
+/// i.e., the same degree :math:`d`.  The product :math:`n d` must be even.
+/// The resulting graph has no self-loops or parallel edges.
+///
+/// This implementation is based on the networkx function ``random_regular_graph`` [1]_.
+///
+/// :param int num_nodes: The number of nodes to create in the graph
+/// :param int degree: The degree that every node will have
+/// :param int seed: An optional seed to use for the random number generator
+///
+/// :return: A PyGraph object
+/// :rtype: PyGraph
+///
+/// .. [1] https://github.com/networkx/networkx/blob/networkx-2.4/networkx/generators/random_graphs.py#L495
 #[pyfunction]
 #[pyo3(text_signature = "(num_nodes, degree, /, seed=None)", signature = (num_nodes, degree, seed=None))]
 pub fn random_regular_graph(

--- a/src/random_graph.rs
+++ b/src/random_graph.rs
@@ -35,7 +35,7 @@ use rustworkx_core::generators as core_generators;
 /// Return a random undirected :math:`d`-regular graph on :math:`n` nodes.
 ///
 /// A regular graph is a graph where each node has the same number of neighbors,
-/// i.e., the same degree :math:`d`.  The product :math:`n d` must be even.
+/// i.e., the same degree :math:`d`. The product :math:`n d` must be even.
 /// The resulting graph has no self-loops or parallel edges.
 ///
 /// This implementation is based on the networkx function ``random_regular_graph`` [1]_.

--- a/src/random_graph.rs
+++ b/src/random_graph.rs
@@ -32,6 +32,38 @@ use rand_pcg::Pcg64;
 
 use rustworkx_core::generators as core_generators;
 
+// TODO: docs
+#[pyfunction]
+#[pyo3(text_signature = "(num_nodes, degree, /, seed=None)", signature = (num_nodes, degree, seed=None))]
+pub fn random_regular_graph(
+    py: Python,
+    num_nodes: usize,
+    degree: usize,
+    seed: Option<u64>,
+) -> PyResult<graph::PyGraph> {
+    let default_fn = || py.None();
+    let mut graph: StablePyGraph<Undirected> = match core_generators::random_regular_graph(
+        num_nodes, degree, seed, default_fn, default_fn,
+    ) {
+        Ok(graph) => graph,
+        Err(_) => {
+            return Err(PyValueError::new_err("num_nodes or degree invalid input"));
+        }
+    };
+    // Core function does not put index into node payload, so for backwards compat
+    // in the python interface, we do it here.
+    let nodes: Vec<NodeIndex> = graph.node_indices().collect();
+    for node in nodes.iter() {
+        graph[*node] = node.index().into_py_any(py)?;
+    }
+    Ok(graph::PyGraph {
+        graph,
+        node_removed: false,
+        multigraph: true,
+        attrs: py.None(),
+    })
+}
+
 /// Return a :math:`G_{np}` directed random graph, also known as an
 /// Erdős-Rényi graph or a binomial graph.
 ///

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -18,6 +18,51 @@ import numpy as np
 import rustworkx
 
 
+class TestRandomRegularGraph(unittest.TestCase):
+    def test_random_regular_degrees1(self):
+        graph = rustworkx.random_regular_graph(20, 4)
+        self.assertEqual(len(graph), 20)
+        for i in range(20):
+            self.assertEqual(graph.degree(i), 4)
+
+    def test_random_regular_degrees2(self):
+        graph = rustworkx.random_regular_graph(22, 7)
+        self.assertEqual(len(graph), 22)
+        for i in range(22):
+            self.assertEqual(graph.degree(i), 7)
+
+    def test_random_regular_empty(self):
+        graph = rustworkx.random_regular_graph(20, 0)
+        self.assertEqual(len(graph), 20)
+        self.assertEqual(len(graph.edges()), 0)
+
+    def test_random_regular_complete(self):
+        graph = rustworkx.random_regular_graph(10, 9)
+        self.assertEqual(len(graph), 10)
+        self.assertEqual(len(graph.edges()), 45)
+
+    def test_random_regular_same_seed(self):
+        # with other arguments equal, same seed results in same graph
+        graph_1 = rustworkx.random_regular_graph(20, 4, seed=123)
+        graph_2 = rustworkx.random_regular_graph(20, 4, seed=123)
+        self.assertEqual(graph_1.edge_list(), graph_2.edge_list())
+
+    def test_random_regular_invalid_num_nodes(self):
+        with self.assertRaises(ValueError):
+            rustworkx.random_regular_graph(0, 5)
+
+    def test_random_regular_invalid_degree(self):
+        with self.assertRaises(OverflowError):
+            rustworkx.random_regular_graph(20, -1)
+        with self.assertRaises(ValueError):
+            rustworkx.random_regular_graph(20, 20)
+
+    def test_random_regular_incompat(self):
+        with self.assertRaises(ValueError):
+            # at least one of `num_nodes` and `degree` must be even
+            rustworkx.random_regular_graph(13, 5)
+
+
 class TestGNPRandomGraph(unittest.TestCase):
     def test_random_gnp_directed_1(self):
         graph = rustworkx.directed_gnp_random_graph(15, 0.7, seed=20)


### PR DESCRIPTION
The `random_regular_graph` generator was already merged into rustworkx-core in #1423. This PR adds the function to rustworkx.
Closes #1391.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
