### PR TITLE
Pin GitHub Actions to SHAs and add step-security/harden-runner

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,33 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# Dependabot version updates.
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Cooldown waits 7 days after a release before opening an update PR, giving the
+# community time to surface regressions. Minor/patch updates are grouped to
+# reduce churn; major updates are opened individually so each is reviewed on
+# its own merit.
 
 version: 2
 updates:
-  - package-ecosystem: "cargo" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: cargo
+    directory: /
     schedule:
-      interval: "daily"
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/docs_dev.yml
+++ b/.github/workflows/docs_dev.yml
@@ -12,11 +12,15 @@ jobs:
     if: github.repository_owner == 'Qiskit'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - name: Harden the runner
+      uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+      with:
+        egress-policy: audit
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: '3.12'
     - name: Install dependencies
@@ -27,12 +31,12 @@ jobs:
       run: |
         tools/build_documentation_dev.sh
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
       with:
         name: html_docs
         path: docs/build/html
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453  # v4.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages

--- a/.github/workflows/docs_release.yml
+++ b/.github/workflows/docs_release.yml
@@ -13,11 +13,15 @@ jobs:
     if: github.repository_owner == 'Qiskit'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - name: Harden the runner
+      uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+      with:
+        egress-policy: audit
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: '3.12'
     - name: Install dependencies
@@ -28,12 +32,12 @@ jobs:
       run: |
         tools/build_documentation_release.sh
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
       with:
         name: html_docs
         path: release_docs/
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453  # v4.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,11 @@ jobs:
     name: Build, rustfmt, and python lint
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+          disable-sudo: true
       - name: Print Concurrency Group
         env:
           CONCURRENCY_GROUP: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
@@ -22,13 +27,13 @@ jobs:
           echo -e "\033[31;1;4mConcurrency Group\033[0m"
           echo -e "$CONCURRENCY_GROUP\n"
         shell: bash
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
       - run: |
           pip install -U --group lint
-      - uses: dtolnay/rust-toolchain@1.92 # TODO: unpin clippy
+      - uses: dtolnay/rust-toolchain@b5826f8eb73f40ac7c19ef631dce17a9680f8129  # 1.92, TODO: unpin clippy
         with:
           components: rustfmt, clippy
       - name: Test Build
@@ -49,7 +54,7 @@ jobs:
         run: cargo doc -p rustworkx-core
         env:
           RUSTDOCFLAGS: '-D warnings'
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: rustworkx_core_docs
           path: target/doc/rustworkx_core
@@ -81,15 +86,19 @@ jobs:
             platform: { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" }
             msrv: "Beta"
     steps:
-      - uses: actions/checkout@v4
+      - name: Harden the runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.platform.python-architecture }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf  # 1.94.1 (matrix overrides via with.toolchain)
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.platform.rust-target }}
@@ -110,14 +119,19 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - name: Harden the runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+          disable-sudo: true
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf  # 1.94.1
       - name: 'Install dependencies'
         run: |
           python -m pip install -U --group testinfra
@@ -129,13 +143,18 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Harden the runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+          disable-sudo: true
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf  # 1.94.1
         with:
           components: llvm-tools-preview
       - name: Download grcov
@@ -159,12 +178,12 @@ jobs:
           set -e
           mv tests/rustworkx*profraw .
           ./grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o ./coveralls.lcov
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage
           path: coveralls.lcov
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e  # v2.3.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           format: lcov
@@ -175,15 +194,19 @@ jobs:
     name: Build Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Harden the runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf  # 1.94.1
       - name: Install binary deps
         run: sudo apt-get install -y graphviz
       - name: Install deps
@@ -191,7 +214,7 @@ jobs:
           pip install -U --group testinfra
       - name: Build Docs
         run: nox -e docs
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: html_docs
           path: docs/build/html

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,8 +9,13 @@ jobs:
     name: Publish rustworkx-core
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Harden the runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+          disable-sudo: true
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf  # 1.94.1
       - name: Run cargo publish
         run: |
           cd rustworkx-core
@@ -25,8 +30,13 @@ jobs:
       id-token: write
     needs: ["upload_shared_wheels"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Harden the runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+          disable-sudo: true
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         name: Install Python
         with:
           python-version: '3.12'
@@ -34,12 +44,12 @@ jobs:
         run: pip install -U setuptools-rust build
       - name: Build sdist
         run: python -m build --sdist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           path: ./dist/*
           name: sdist-rustworkx
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -49,19 +59,24 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-15-intel, macos-14, ubuntu-24.04-arm]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Harden the runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+          disable-sudo: true
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         name: Install Python
         with:
           python-version: '3.12'
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf  # 1.94.1
       - name: Install cibuildwheel
         run: |
           python -m pip install -U --group releaseinfra
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           path: ./wheelhouse/*.whl
           name: shared-wheel-builds-${{ matrix.os }}
@@ -73,13 +88,18 @@ jobs:
       id-token: write
     needs: ["build_wheels", "build-win32-wheels"]
     steps:
-      - uses: actions/download-artifact@v4
+      - name: Harden the runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+          disable-sudo: true
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           pattern: shared-wheel-builds-*
           merge-multiple: true
           path: deploy
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           packages-dir: deploy
   build_wheels_ppc64le:
@@ -93,14 +113,19 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Harden the runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+          disable-sudo: true
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         name: Install Python
         with:
           python-version: '3.12'
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf  # 1.94.1
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7  # v2.2.0
         with:
           platforms: all
       - name: Install cibuildwheel
@@ -112,12 +137,12 @@ jobs:
         env:
           CIBW_SKIP: pp* cp314t* *win32 *musl*
           CIBW_ARCHS_LINUX: ppc64le
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           path: ./wheelhouse/*.whl
           name: wheel-builds-ppc64le
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           packages-dir: wheelhouse/
   build_wheels_s390x:
@@ -131,14 +156,19 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Harden the runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+          disable-sudo: true
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         name: Install Python
         with:
           python-version: '3.12'
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf  # 1.94.1
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7  # v2.2.0
         with:
           platforms: all
       - name: Install cibuildwheel
@@ -150,12 +180,12 @@ jobs:
         env:
           CIBW_SKIP: pp* cp314t* *win32 *musl*
           CIBW_ARCHS_LINUX: s390x
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           path: ./wheelhouse/*.whl
           name: wheel-builds-s390x
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           packages-dir: wheelhouse/
   build-win32-wheels:
@@ -163,13 +193,18 @@ jobs:
     runs-on: windows-latest
     environment: release
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Harden the runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+          disable-sudo: true
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         name: Install Python
         with:
           python-version: '3.12'
           architecture: 'x86'
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf  # 1.94.1
         with:
           targets: i686-pc-windows-msvc
       - name: Force win32 rust
@@ -182,7 +217,7 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_SKIP: pp* cp314t* *amd64 *musl*
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           path: ./wheelhouse/*.whl
           name: shared-wheel-builds-win32


### PR DESCRIPTION
## Summary

Hardens the GitHub Actions CI by:

- Replacing every action `@v*`/`@stable`/`@master`/`@release/v1` floating ref with a verified SHA pin plus a version comment (catches tag-rewrite supply-chain attacks).
- Adding `step-security/harden-runner@<sha>` (audit mode) as the first step of every job in every workflow (14 jobs across `main.yml`, `wheels.yml`, `docs_dev.yml`, `docs_release.yml`).
- Adding `disable-sudo: true` to the 10 jobs that do not need sudo. The 4 jobs that install graphviz/pandoc via `sudo apt-get` keep the default.
- Pinning `dtolnay/rust-toolchain@stable` and `@master` references to Rust 1.94.1. The existing `@1.92` pin in `build_lint` (carrying a `TODO: unpin clippy` note) is preserved at 1.92, only its SHA is now pinned.
- Extending `.github/dependabot.yml` so the new SHA pins do not go stale: adds the `github-actions` ecosystem, switches both ecosystems to weekly with a 7-day cooldown, and groups minor/patch updates. Majors continue to open as individual PRs for review.

Every SHA in the diff was verified to resolve to a real commit in its source repo via `gh api repos/<owner>/<repo>/commits/<sha>`.

## Why this matters

In March 2025, two consecutive supply chain attacks struck widely-used GitHub Actions. `reviewdog/action-setup@v1` was compromised on March 11, 2025; secrets exfiltrated from that incident were then used a few days later to compromise `tj-actions/changed-files` on March 14, 2025. In both cases the attacker rewrote existing version tags, so any workflow consuming floating refs like `@v1` or `@v45` silently picked up the malicious code on its next run and leaked CI/CD secrets. Workflows pinned to full commit SHAs were unaffected.

That attack pattern is the specific class of risk this PR removes. SHA pins make the action ref immutable from the consumer side - retagging at the source no longer changes what runs here. `step-security/harden-runner` provides defense in depth on top of that: even if a pinned dependency were itself published with malicious code, audit mode logs the unexpected egress and block mode prevents secrets from leaving the runner.

This change brings the repo in line with:

- OpenSSF Scorecard's `Pinned-Dependencies` check, which requires dependencies be set to a specific hash rather than a mutable version range.
- GitHub's own [security hardening guide for Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions), which states that "pinning an action to a full-length commit SHA is currently the only way to use an action as an immutable release."

## Out of scope

### Major version bumps

The pinned actions are intentionally kept at their current major. Several are significantly behind latest:

| Action | Pinned in this PR | Latest | Behind by |
|---|---|---|---|
| `actions/checkout` | v4.3.1 | v6.0.2 | 2 majors |
| `actions/setup-python` | v5.6.0 | v6.2.0 | 1 major |
| `actions/download-artifact` | v4.3.0 | v8.0.1 | 4 majors |
| `actions/upload-artifact` | v4.6.2 | v7.0.1 | 3 majors |
| `actions/upload-pages-artifact` | v3.0.1 | v5.0.0 | 2 majors |
| `docker/setup-qemu-action` | v2.2.0 | v4.0.0 | 2 majors |

These will arrive as individual Dependabot PRs (one per major bump) once this lands, so each can be reviewed on its own merits without bundling breakage risk into the hardening change. The `upload-artifact` / `download-artifact` v4 → v5+ transition in particular changed artifact merge semantics and needs careful validation against `wheels.yml`.

### Pre-existing bugs noted but not fixed

`actionlint` flagged two pre-existing references to `${{ matrix.python-version }}` in non-matrix jobs (`coverage`, `docs` in `main.yml`). These render as empty strings in step names today. Out of scope for this PR.

## Follow-up: install the Step Security GitHub App and move audit → block

`harden-runner` is currently in `egress-policy: audit`, which logs outbound traffic without blocking. To get full value, the maintainers need to:

1. **Install the StepSecurity app** at https://github.com/apps/stepsecurity for the `Qiskit` organization. This gives access to the dashboard at https://app.stepsecurity.io where audit logs are aggregated and a recommended allowlist is generated.
2. **Let several CI runs complete** post-merge (a release tag run is especially useful, since `wheels.yml` only fires on tags) to populate a complete egress profile.
3. **Review the audit dashboard** and copy the suggested `allowed-endpoints` list for each workflow.
4. **Flip `egress-policy: audit` → `egress-policy: block`** in the workflows, supplying the endpoint allowlist:

   ```yaml
   - name: Harden the runner
     uses: step-security/harden-runner@<same-sha>
     with:
       egress-policy: block
       allowed-endpoints: >
         api.github.com:443
         github.com:443
         pypi.org:443
         files.pythonhosted.org:443
         static.crates.io:443
         # ...etc from dashboard
   ```

5. **Consider extending `disable-sudo: true`** to `tests`, `docs`, and the two doc-deploy jobs by moving the `graphviz`/`pandoc` install onto a pre-built image or pre-installed runner image, eliminating the last 4 sudo callouts.

Without step 1, harden-runner still works (audit logs land in the job summary), but the maintainer experience for tightening the policy is significantly worse.

## Test plan

- [x] `actions/checkout` `actions/setup-python` `actions/upload-artifact` `actions/download-artifact` `actions/upload-pages-artifact` SHAs resolve to expected commits (verified locally; CI re-verifies on first run).
- [x] `main.yml` jobs (`build_lint`, `tests`, `tests_stubs`, `coverage`, `docs`) succeed on this branch.
- [ ] `docs_dev.yml` succeeds on a push to `main` (post-merge).
- [ ] `wheels.yml` succeeds end-to-end on the next release tag, including `disable-sudo: true` on builder jobs.
- [ ] Dependabot opens a `github-actions` PR within 7 days of next eligible upstream release.

## References

- StepSecurity, "Harden-Runner detection: tj-actions/changed-files action is compromised" (2025-03-14) - https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
- StepSecurity, "reviewdog GitHub Actions are compromised" (2025-03-17) - https://www.stepsecurity.io/blog/reviewdog-github-actions-are-compromised
- OpenSSF Scorecard, "Pinned-Dependencies" check - https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
- GitHub Docs, "Security hardening for GitHub Actions: Using third-party actions" - https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
