### PR TITLE
perf: Use BufWriter when writing json

### DIFF
--- a/src/digraph.rs
+++ b/src/digraph.rs
@@ -2431,8 +2431,17 @@ impl PyDiGraph {
     ) -> PyResult<Option<Bound<'py, PyString>>> {
         match filename {
             Some(filename) => {
-                let mut file = File::create(filename)?;
-                build_dot(py, &self.graph, &mut file, graph_attr, node_attr, edge_attr)?;
+                let file = File::create(filename)?;
+                let mut buf_writer = BufWriter::new(file);
+                build_dot(
+                    py,
+                    &self.graph,
+                    &mut buf_writer,
+                    graph_attr,
+                    node_attr,
+                    edge_attr,
+                )?;
+                buf_writer.flush()?;
                 Ok(None)
             }
             None => {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1320,8 +1320,17 @@ impl PyGraph {
     ) -> PyResult<Option<Bound<'py, PyString>>> {
         match filename {
             Some(filename) => {
-                let mut file = File::create(filename)?;
-                build_dot(py, &self.graph, &mut file, graph_attr, node_attr, edge_attr)?;
+                let file = File::create(filename)?;
+                let mut buf_writer = BufWriter::new(file);
+                build_dot(
+                    py,
+                    &self.graph,
+                    &mut buf_writer,
+                    graph_attr,
+                    node_attr,
+                    edge_attr,
+                )?;
+                buf_writer.flush()?;
                 Ok(None)
             }
             None => {

--- a/src/graphml.rs
+++ b/src/graphml.rs
@@ -16,7 +16,7 @@ use std::borrow::{Borrow, Cow};
 use std::convert::From;
 use std::ffi::OsStr;
 use std::fs::File;
-use std::io::{BufRead, BufReader, BufWriter};
+use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::iter::{FromIterator, Iterator};
 use std::num::{ParseFloatError, ParseIntError};
 use std::path::Path;
@@ -1157,11 +1157,13 @@ impl GraphML {
             let gzip_encoder = GzEncoder::new(buf_writer, Compression::default());
             let mut writer = Writer::new(gzip_encoder);
             self.write_graph_to_writer(&mut writer)?;
-            writer.into_inner().finish()?;
+            writer.into_inner().finish()?.flush()?;
         } else {
             let file = File::create(path)?;
-            let mut writer = Writer::new(file);
+            let buf_writer = BufWriter::new(file);
+            let mut writer = Writer::new(buf_writer);
             self.write_graph_to_writer(&mut writer)?;
+            writer.into_inner().flush()?;
         }
         Ok(())
     }

--- a/src/json/node_link_data.rs
+++ b/src/json/node_link_data.rs
@@ -13,6 +13,7 @@
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::BufWriter;
+use std::io::Write as _;
 
 use hashbrown::HashMap;
 use indexmap::IndexSet;
@@ -223,11 +224,16 @@ pub fn node_link_data<Ty: EdgeType>(
         },
         Some(filename) => {
             let file = File::create(filename)?;
-            let buffer = BufWriter::with_capacity(64 * 1024, file);
-            match serde_json::to_writer(buffer, &output_struct) {
-                Ok(_) => Ok(None),
+            let mut buffer = BufWriter::with_capacity(64 * 1024, file);
+            let res = match serde_json::to_writer(&mut buffer, &output_struct) {
+                Ok(_) => {
+                    buffer.flush()?;
+                    Ok(None)
+                }
                 Err(e) => Err(JSONSerializationError::new_err(format!("JSON Error: {e}"))),
-            }
+            }?;
+
+            Ok(res)
         }
     }
 }

--- a/src/json/node_link_data.rs
+++ b/src/json/node_link_data.rs
@@ -224,7 +224,7 @@ pub fn node_link_data<Ty: EdgeType>(
         },
         Some(filename) => {
             let file = File::create(filename)?;
-            let mut buffer = BufWriter::with_capacity(64 * 1024, file);
+            let mut buffer = BufWriter::new(file);
             let res = match serde_json::to_writer(&mut buffer, &output_struct) {
                 Ok(_) => {
                     buffer.flush()?;

--- a/src/json/node_link_data.rs
+++ b/src/json/node_link_data.rs
@@ -12,6 +12,7 @@
 
 use std::collections::BTreeMap;
 use std::fs::File;
+use std::io::BufWriter;
 
 use hashbrown::HashMap;
 use indexmap::IndexSet;
@@ -222,7 +223,8 @@ pub fn node_link_data<Ty: EdgeType>(
         },
         Some(filename) => {
             let file = File::create(filename)?;
-            match serde_json::to_writer(file, &output_struct) {
+            let buffer = BufWriter::with_capacity(64 * 1024, file);
+            match serde_json::to_writer(buffer, &output_struct) {
                 Ok(_) => Ok(None),
                 Err(e) => Err(JSONSerializationError::new_err(format!("JSON Error: {e}"))),
             }


### PR DESCRIPTION
The current `node_link_data` function does not buffer its serialized JSON before writing it to a file; because of this, every emitted JSON token will trigger a syscall. This PR adds a `BufWriter` to mitigate this.

I benchmarked the performance difference on a MacBook Pro M1. The default capacity BufWriter was ~400 times faster than without the buffer, and increasing the buffer size to 64 KiB gives another 15% speed increase over the default buffer (~460 times faster).