### PR TITLE
Bump rand crates to 0.10.x releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,10 +93,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -833,18 +853,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -853,6 +863,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
+ "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
@@ -868,16 +879,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,36 +889,27 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.9.4",
+ "rand 0.10.1",
 ]
 
 [[package]]
 name = "rand_pcg"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b48ac3f7ffaab7fac4d2376632268aa5f89abdb55f7ebf8f4d11fffccb2320f7"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core 0.9.5",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1019,7 +1011,7 @@ dependencies = [
  "petgraph",
  "pyo3",
  "quick-xml",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rand_distr",
  "rand_pcg",
  "rayon",
@@ -1044,7 +1036,7 @@ dependencies = [
  "priority-queue",
  "quickcheck",
  "quickcheck_macros",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rand_distr",
  "rand_pcg",
  "rayon",
@@ -1125,7 +1117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ ndarray = { version = "0.16.1", features = ["rayon"] }
 num-traits = "0.2"
 petgraph = "0.8"
 numpy = "0.26"
-rand = "0.9"
-rand_distr = "0.5"
-rand_pcg = "0.9"
+rand = "0.10"
+rand_distr = "0.6"
+rand_pcg = "0.10"
 rayon = "1.10"
 
 [lib]

--- a/rustworkx-core/src/generators/random_graph.rs
+++ b/rustworkx-core/src/generators/random_graph.rs
@@ -25,6 +25,7 @@ use petgraph::visit::{
 use petgraph::{Incoming, Outgoing};
 
 use rand::prelude::*;
+use rand::rngs::SysRng;
 use rand_distr::{Distribution, Uniform};
 use rand_pcg::Pcg64;
 
@@ -97,7 +98,7 @@ where
     }
     let mut rng: Pcg64 = match seed {
         Some(seed) => Pcg64::seed_from_u64(seed),
-        None => Pcg64::from_os_rng(),
+        None => Pcg64::try_from_rng(&mut SysRng).unwrap(),
     };
 
     if (num_nodes * degree) % 2 != 0 {
@@ -262,7 +263,7 @@ where
     }
     let mut rng: Pcg64 = match seed {
         Some(seed) => Pcg64::seed_from_u64(seed),
-        None => Pcg64::from_os_rng(),
+        None => Pcg64::try_from_rng(&mut SysRng).unwrap(),
     };
     let mut graph = G::with_capacity(num_nodes, num_nodes);
     let directed = graph.is_directed();
@@ -432,7 +433,7 @@ where
 
     let mut rng: Pcg64 = match seed {
         Some(seed) => Pcg64::seed_from_u64(seed),
-        None => Pcg64::from_os_rng(),
+        None => Pcg64::try_from_rng(&mut SysRng).unwrap(),
     };
     let mut graph = G::with_capacity(num_nodes, num_edges);
     let directed = graph.is_directed();
@@ -549,7 +550,7 @@ where
     }
     let mut rng: Pcg64 = match seed {
         Some(seed) => Pcg64::seed_from_u64(seed),
-        None => Pcg64::from_os_rng(),
+        None => Pcg64::try_from_rng(&mut SysRng).unwrap(),
     };
     let mut blocks = Vec::new();
     {
@@ -681,7 +682,7 @@ where
     }
     let mut rng: Pcg64 = match seed {
         Some(seed) => Pcg64::seed_from_u64(seed),
-        None => Pcg64::from_os_rng(),
+        None => Pcg64::try_from_rng(&mut SysRng).unwrap(),
     };
     let mut graph = G::with_capacity(num_nodes, num_nodes);
 
@@ -784,7 +785,7 @@ where
     }
     let mut rng: Pcg64 = match seed {
         Some(seed) => Pcg64::seed_from_u64(seed),
-        None => Pcg64::from_os_rng(),
+        None => Pcg64::try_from_rng(&mut SysRng).unwrap(),
     };
     let mut graph = match initial_graph {
         Some(initial_graph) => initial_graph,
@@ -889,7 +890,7 @@ where
 
     let mut rng: Pcg64 = match seed {
         Some(seed) => Pcg64::seed_from_u64(seed),
-        None => Pcg64::from_os_rng(),
+        None => Pcg64::try_from_rng(&mut SysRng).unwrap(),
     };
     let mut graph = G::with_capacity(num_l_nodes + num_r_nodes, num_l_nodes + num_r_nodes);
 
@@ -991,7 +992,7 @@ where
 
     let mut rng: Pcg64 = match seed {
         Some(seed) => Pcg64::seed_from_u64(seed),
-        None => Pcg64::from_os_rng(),
+        None => Pcg64::try_from_rng(&mut SysRng).unwrap(),
     };
     let mut graph = G::with_capacity(num_nodes, num_nodes);
     if graph.is_directed() {

--- a/rustworkx-core/src/token_swapper.rs
+++ b/rustworkx-core/src/token_swapper.rs
@@ -11,6 +11,7 @@
 // under the License.
 
 use rand::prelude::*;
+use rand::rngs::SysRng;
 use rand_distr::{StandardUniform, Uniform};
 use rand_pcg::Pcg64;
 use std::error::Error;
@@ -161,7 +162,7 @@ where
         // into a Vec based on the given seed
         let outer_rng: Pcg64 = match self.seed {
             Some(rng_seed) => Pcg64::seed_from_u64(rng_seed),
-            None => Pcg64::from_os_rng(),
+            None => Pcg64::try_from_rng(&mut SysRng).unwrap(),
         };
         let trial_seeds_vec: Vec<u64> = outer_rng
             .sample_iter(&StandardUniform)

--- a/rustworkx-core/src/traversal/random_walk.rs
+++ b/rustworkx-core/src/traversal/random_walk.rs
@@ -18,6 +18,7 @@ use std::hash::Hash;
 use hashbrown::HashMap;
 
 use rand::prelude::*;
+use rand::rngs::SysRng;
 use rand_pcg::Pcg64;
 
 /// Return a random path (or random walk) on the graph.
@@ -63,7 +64,7 @@ where
 {
     let mut rng: Pcg64 = match seed {
         Some(seed) => Pcg64::seed_from_u64(seed),
-        None => Pcg64::from_os_rng(),
+        None => Pcg64::try_from_rng(&mut SysRng).unwrap(),
     };
 
     let mut degrees: HashMap<G::NodeId, usize> = HashMap::new();

--- a/src/layout/random.rs
+++ b/src/layout/random.rs
@@ -13,6 +13,7 @@
 use petgraph::EdgeType;
 
 use rand::prelude::*;
+use rand::rngs::SysRng;
 use rand_pcg::Pcg64;
 
 use crate::StablePyGraph;
@@ -25,7 +26,7 @@ pub fn random_layout<Ty: EdgeType>(
 ) -> Pos2DMapping {
     let mut rng: Pcg64 = match seed {
         Some(seed) => Pcg64::seed_from_u64(seed),
-        None => Pcg64::from_os_rng(),
+        None => Pcg64::try_from_rng(&mut SysRng).unwrap(),
     };
 
     Pos2DMapping {

--- a/src/layout/spring.rs
+++ b/src/layout/spring.rs
@@ -26,6 +26,7 @@ use petgraph::prelude::*;
 use petgraph::visit::{IntoEdgeReferences, NodeIndexable};
 
 use rand::prelude::*;
+use rand::rngs::SysRng;
 use rand_distr::{Distribution, Uniform};
 use rand_pcg::Pcg64;
 
@@ -322,7 +323,7 @@ where
 
     let mut rng: Pcg64 = match seed {
         Some(seed) => Pcg64::seed_from_u64(seed),
-        None => Pcg64::from_os_rng(),
+        None => Pcg64::try_from_rng(&mut SysRng).unwrap(),
     };
 
     let dist = Uniform::new(0.0, 1.0)

--- a/src/random_graph.rs
+++ b/src/random_graph.rs
@@ -27,6 +27,7 @@ use petgraph::prelude::*;
 use numpy::PyReadonlyArray2;
 
 use rand::prelude::*;
+use rand::rngs::SysRng;
 use rand_distr::{Distribution, Uniform};
 use rand_pcg::Pcg64;
 
@@ -500,7 +501,7 @@ pub fn random_geometric_graph(
     let radius_p = pnorm(radius, p);
     let mut rng: Pcg64 = match seed {
         Some(seed) => Pcg64::seed_from_u64(seed),
-        None => Pcg64::from_os_rng(),
+        None => Pcg64::try_from_rng(&mut SysRng).unwrap(),
     };
 
     let dist = Uniform::new(0.0, 1.0)


### PR DESCRIPTION
This commit bumps the rand crates used in Qiskit to the current latest releases. There is constellation of crates for rand, including the core library, specific generators, and distributions. These all have to be upgraded in lockstep for compatibility. Dependabot isn't able to reason about this correctly and doesn't handle this case. Additionally the rand crate upgrades often have breaking api changes that require manual intervention. This release is no different as the way to instantiate a random number generator from system entropy has changed yet again (this is the second or third such change I can remember). This updates all the usage of rand crates in qiskit to be compatible with the new releases.

Closes #1600

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
