### PR TITLE
Add longest_path_length to rustworkx_core::dag_algo

### DIFF
--- a/releasenotes/notes/dag-longest-path-length-no-path-c91b30519ad22fcc.yaml
+++ b/releasenotes/notes/dag-longest-path-length-no-path-c91b30519ad22fcc.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Added a new rustworkx-core function ``longest_path_length`` to the module ``dag_algo``. This
+    function computes the length of the longest path in a directed acyclic graph without storing
+    the actual path or returning it. This differs from the existing ``longest_path`` which
+    internally stores the path and returns it.

--- a/rustworkx-core/src/dag_algo.rs
+++ b/rustworkx-core/src/dag_algo.rs
@@ -245,7 +245,10 @@ type LongestPathResult<G, T, E> = Result<Option<(Vec<NodeId<G>>, T)>, E>;
 ///
 /// This function computes the longest path by weight in a given DAG. It will return the longest path
 /// along with its total weight, or `None` if the graph contains cycles which make the longest path
-/// computation undefined.
+/// computation undefined. This differs from [`longest_path_length`] in that this method stores the path
+/// internally and returns it. In applications where the actual path doesn't matter and you're only
+/// concerned with the longest path's length you should use [`longest_path_length`], otherwise you
+/// should use this function.
 ///
 /// # Arguments
 /// * `graph`: Reference to a directed graph.
@@ -336,6 +339,98 @@ where
     let path_weight = dist[first].0; // The total weight of the longest path
 
     Ok(Some((path, path_weight)))
+}
+
+/// Calculates the longest path length in a directed acyclic graph (DAG).
+///
+/// This function computes the longest path by weight in a given DAG. It will return the longest path
+/// along with its total weight, or `None` if the graph contains cycles which make the longest path
+/// computation undefined. This differs from [`longest_path`] in this method does not store the path
+/// internally or return it. In applications where the actual path doesn't matter and you're only
+/// concerned with the longest path's length this function should be used instead.
+///
+/// # Arguments
+/// * `graph`: Reference to a directed graph.
+/// * `weight_fn` - An input callable that will be passed the `EdgeRef` for each edge in the graph.
+///   The callable should return the weight of the edge as `Result<T, E>`. The weight must be a type that implements
+///   `Num`, `Zero`, `PartialOrd`, and `Copy`.
+///
+/// # Type Parameters
+/// * `G`: Type of the graph. Must be a directed graph.
+/// * `F`: Type of the weight function.
+/// * `T`: The type of the edge weight. Must implement `Num`, `Zero`, `PartialOrd`, and `Copy`.
+/// * `E`: The type of the error that the weight function can return.
+///
+/// # Returns
+/// * `None` if the graph contains a cycle.
+/// * `Some(T)` representing the longest path as a sequence of nodes and its total weight.
+/// * `Err(E)` if there is an error computing the weight of any edge.
+///
+/// # Example
+/// ```
+/// use petgraph::graph::DiGraph;
+/// use petgraph::Directed;
+/// use rustworkx_core::dag_algo::longest_path_length;
+///
+/// let mut graph: DiGraph<(), i32> = DiGraph::new();
+/// let n0 = graph.add_node(());
+/// let n1 = graph.add_node(());
+/// let n2 = graph.add_node(());
+/// graph.add_edge(n0, n1, 1);
+/// graph.add_edge(n0, n2, 3);
+/// graph.add_edge(n1, n2, 1);
+///
+/// let weight_fn = |edge: petgraph::graph::EdgeReference<i32>| Ok::<i32, &str>(*edge.weight());
+/// let result = longest_path_length(&graph, weight_fn).unwrap();
+/// assert_eq!(result, Some(3));
+/// ```
+pub fn longest_path_length<G, F, T, E>(graph: G, mut weight_fn: F) -> Result<Option<T>, E>
+where
+    G: GraphProp<EdgeType = Directed>
+        + IntoNodeIdentifiers
+        + IntoEdgesDirected
+        + Visitable
+        + NodeIndexable,
+    F: FnMut(G::EdgeRef) -> Result<T, E>,
+    T: Num + Zero + PartialOrd + Copy,
+    <G as GraphBase>::NodeId: Hash + Eq + PartialOrd,
+{
+    let nodes = match algo::toposort(graph, None) {
+        Ok(nodes) => nodes,
+        Err(_) => return Ok(None), // Return None if the graph contains a cycle
+    };
+
+    if nodes.is_empty() {
+        return Ok(Some(T::zero()));
+    }
+
+    let mut dist: Vec<Option<(T, G::NodeId)>> = vec![None; graph.node_bound()]; // Stores the distance and the previous node
+
+    // Iterate over nodes in topological order
+    for node in nodes {
+        let max_path = graph
+            .edges_directed(node, petgraph::Direction::Incoming)
+            .try_fold((T::zero(), node), |longest, p_edge| -> Result<_, E> {
+                let p_node = p_edge.source();
+                let weight: T = weight_fn(p_edge)?;
+                let length = dist[graph.to_index(p_node)].unwrap().0 + weight;
+                if length >= longest.0 {
+                    Ok((length, p_node))
+                } else {
+                    Ok(longest)
+                }
+            })?;
+
+        // Store the maximum distance and the corresponding parent node for the current node
+        dist[graph.to_index(node)] = Some(max_path);
+    }
+    let (path_weight, _) = dist
+        .iter()
+        .filter_map(|x| x.as_ref())
+        .max_by(|a, b| a.partial_cmp(b).unwrap())
+        .unwrap();
+
+    Ok(Some(*path_weight))
 }
 
 /// Return an iterator of graph layers
@@ -892,6 +987,134 @@ mod test_longest_path {
             |edge: petgraph::stable_graph::EdgeReference<'_, i32>| Ok::<i32, &str>(*edge.weight());
         let result = longest_path(&graph, weight_fn);
         assert_eq!(result, Ok(Some((vec![n0, n2], 3))));
+    }
+
+    #[test]
+    fn test_error_handling() {
+        let mut graph: DiGraph<(), i32> = DiGraph::new();
+        let n0 = graph.add_node(());
+        let n1 = graph.add_node(());
+        let n2 = graph.add_node(());
+        graph.add_edge(n0, n1, 1);
+        graph.add_edge(n0, n2, 2);
+        graph.add_edge(n1, n2, 1);
+        let weight_fn = |edge: petgraph::graph::EdgeReference<i32>| {
+            if *edge.weight() == 2 {
+                Err("Error: edge weight is 2")
+            } else {
+                Ok::<i32, &str>(*edge.weight())
+            }
+        };
+        let result = longest_path(&graph, weight_fn);
+        assert_eq!(result, Err("Error: edge weight is 2"));
+    }
+}
+
+// Tests for longest_path_length
+#[cfg(test)]
+mod test_longest_path_length {
+    use super::*;
+    use petgraph::graph::DiGraph;
+    use petgraph::stable_graph::StableDiGraph;
+
+    #[test]
+    fn test_empty_graph() {
+        let graph: DiGraph<(), ()> = DiGraph::new();
+        let weight_fn = |_: petgraph::graph::EdgeReference<()>| Ok::<i32, &str>(0);
+        let result = longest_path_length(&graph, weight_fn);
+        assert_eq!(result, Ok(Some(0)));
+    }
+
+    #[test]
+    fn test_single_node_graph() {
+        let mut graph: DiGraph<(), ()> = DiGraph::new();
+        graph.add_node(());
+        let weight_fn = |_: petgraph::graph::EdgeReference<()>| Ok::<i32, &str>(0);
+        let result = longest_path_length(&graph, weight_fn);
+        assert_eq!(result, Ok(Some(0)));
+    }
+
+    #[test]
+    fn test_dag_with_multiple_paths() {
+        let mut graph: DiGraph<(), i32> = DiGraph::new();
+        let n0 = graph.add_node(());
+        let n1 = graph.add_node(());
+        let n2 = graph.add_node(());
+        let n3 = graph.add_node(());
+        let n4 = graph.add_node(());
+        let n5 = graph.add_node(());
+        graph.add_edge(n0, n1, 3);
+        graph.add_edge(n0, n2, 2);
+        graph.add_edge(n1, n2, 1);
+        graph.add_edge(n1, n3, 4);
+        graph.add_edge(n2, n3, 2);
+        graph.add_edge(n3, n4, 2);
+        graph.add_edge(n2, n5, 1);
+        graph.add_edge(n4, n5, 3);
+        let weight_fn = |edge: petgraph::graph::EdgeReference<i32>| Ok::<i32, &str>(*edge.weight());
+        let result = longest_path_length(&graph, weight_fn);
+        assert_eq!(result, Ok(Some(12)));
+    }
+
+    #[test]
+    fn test_graph_with_cycle() {
+        let mut graph: DiGraph<(), i32> = DiGraph::new();
+        let n0 = graph.add_node(());
+        let n1 = graph.add_node(());
+        graph.add_edge(n0, n1, 1);
+        graph.add_edge(n1, n0, 1); // Creates a cycle
+
+        let weight_fn = |edge: petgraph::graph::EdgeReference<i32>| Ok::<i32, &str>(*edge.weight());
+        let result = longest_path_length(&graph, weight_fn);
+        assert_eq!(result, Ok(None));
+    }
+
+    #[test]
+    fn test_negative_weights() {
+        let mut graph: DiGraph<(), i32> = DiGraph::new();
+        let n0 = graph.add_node(());
+        let n1 = graph.add_node(());
+        let n2 = graph.add_node(());
+        graph.add_edge(n0, n1, -1);
+        graph.add_edge(n0, n2, 2);
+        graph.add_edge(n1, n2, -2);
+        let weight_fn = |edge: petgraph::graph::EdgeReference<i32>| Ok::<i32, &str>(*edge.weight());
+        let result = longest_path_length(&graph, weight_fn);
+        assert_eq!(result, Ok(Some(2)));
+    }
+
+    #[test]
+    fn test_longest_path_in_stable_digraph() {
+        let mut graph: StableDiGraph<(), i32> = StableDiGraph::new();
+        let n0 = graph.add_node(());
+        let n1 = graph.add_node(());
+        let n2 = graph.add_node(());
+        graph.add_edge(n0, n1, 1);
+        graph.add_edge(n0, n2, 3);
+        graph.add_edge(n1, n2, 1);
+        let weight_fn =
+            |edge: petgraph::stable_graph::EdgeReference<'_, i32>| Ok::<i32, &str>(*edge.weight());
+        let result = longest_path_length(&graph, weight_fn);
+        assert_eq!(result, Ok(Some(3)));
+    }
+
+    #[test]
+    fn test_longest_path_in_stable_digraph_with_node_holes() {
+        let mut graph: StableDiGraph<(), i32> = StableDiGraph::new();
+        let n0 = graph.add_node(());
+        let n1 = graph.add_node(());
+        let n2 = graph.add_node(());
+        let n3 = graph.add_node(());
+        let n4 = graph.add_node(());
+        graph.add_edge(n0, n3, 1);
+        graph.add_edge(n0, n4, 3);
+        graph.add_edge(n3, n4, 1);
+        graph.remove_node(n1);
+        graph.remove_node(n2);
+        let weight_fn =
+            |edge: petgraph::stable_graph::EdgeReference<'_, i32>| Ok::<i32, &str>(*edge.weight());
+        let result = longest_path_length(&graph, weight_fn);
+        assert_eq!(result, Ok(Some(3)));
     }
 
     #[test]

--- a/rustworkx-core/src/dag_algo.rs
+++ b/rustworkx-core/src/dag_algo.rs
@@ -353,7 +353,12 @@ where
 /// * `graph`: Reference to a directed graph.
 /// * `weight_fn` - An input callable that will be passed the `EdgeRef` for each edge in the graph.
 ///   The callable should return the weight of the edge as `Result<T, E>`. The weight must be a type that implements
-///   `Num`, `Zero`, `PartialOrd`, and `Copy`.
+///   `Num`, `Zero`, `PartialOrd`, and `Copy`. In the presence of floating point types or other
+///   `PartialOrd` types that are not `Ord` it is recommended for the callable to handle weights
+///   that are no comparable, because if the weights along the longest path are not comparable this
+///   will result in a None being returned. For example, if there is a f64::NaN weight this could
+///   be converted to something semantically equivalent for your use case to avoid having None
+///   returned because the path length can't be evaluated.
 ///
 /// # Type Parameters
 /// * `G`: Type of the graph. Must be a directed graph.
@@ -362,7 +367,8 @@ where
 /// * `E`: The type of the error that the weight function can return.
 ///
 /// # Returns
-/// * `None` if the graph contains a cycle.
+/// * `None` if the graph contains a cycle or a comparison between node weights can't be made (e.g.
+///   f64::NaN comparisons).
 /// * `Some(T)` representing the longest path as a sequence of nodes and its total weight.
 /// * `Err(E)` if there is an error computing the weight of any edge.
 ///
@@ -424,13 +430,23 @@ where
         // Store the maximum distance and the corresponding parent node for the current node
         dist[graph.to_index(node)] = Some(max_path);
     }
-    let (path_weight, _) = dist
-        .iter()
-        .filter_map(|x| x.as_ref())
-        .max_by(|a, b| a.partial_cmp(b).unwrap())
-        .unwrap();
-
-    Ok(Some(*path_weight))
+    let mut dist_iter = dist.into_iter();
+    let first = dist_iter
+        .next()
+        .flatten()
+        .map(|(a, b)| (a, graph.to_index(b)));
+    Ok(dist_iter
+        .filter_map(|x| x.map(|(a, b)| (a, graph.to_index(b))))
+        .fold(first, |a, b| {
+            let a = a?;
+            match a.partial_cmp(&b) {
+                Some(Ordering::Greater) => Some(a),
+                Some(Ordering::Equal) => Some(b),
+                Some(Ordering::Less) => Some(b),
+                None => None,
+            }
+        })
+        .map(|x| x.0))
 }
 
 /// Return an iterator of graph layers

--- a/src/dag_algo/mod.rs
+++ b/src/dag_algo/mod.rs
@@ -23,6 +23,7 @@ use rustworkx_core::dag_algo::collect_bicolor_runs as core_collect_bicolor_runs;
 use rustworkx_core::dag_algo::collect_runs as core_collect_runs;
 use rustworkx_core::dag_algo::lexicographical_topological_sort as core_lexico_topo_sort;
 use rustworkx_core::dag_algo::longest_path as core_longest_path;
+use rustworkx_core::dag_algo::longest_path_length as core_longest_path_length;
 use rustworkx_core::traversal::dfs_edges;
 
 use pyo3::IntoPyObjectExt;
@@ -79,6 +80,30 @@ where
     };
 
     Ok((path, path_weight))
+}
+
+fn longest_path_length<F, T>(graph: &digraph::PyDiGraph, mut weight_fn: F) -> PyResult<T>
+where
+    F: FnMut(usize, usize, &Py<PyAny>) -> PyResult<T>,
+    T: Num + Zero + PartialOrd + Copy,
+{
+    let dag = &graph.graph;
+
+    // Create a new weight function that matches the required signature
+    let edge_cost = |edge_ref: EdgeReference<'_, Py<PyAny>>| -> Result<T, PyErr> {
+        let source = edge_ref.source().index();
+        let target = edge_ref.target().index();
+        let weight = edge_ref.weight();
+        weight_fn(source, target, weight)
+    };
+
+    let path_weight = match core_longest_path_length(dag, edge_cost) {
+        Ok(Some(path_weight)) => path_weight,
+        Ok(None) => return Err(DAGHasCycle::new_err("The graph contains a cycle")),
+        Err(e) => return Err(e),
+    };
+
+    Ok(path_weight)
 }
 
 /// Return a pair of [`petgraph::Direction`] values corresponding to the "forwards" and "backwards"
@@ -168,7 +193,7 @@ pub fn dag_longest_path_length(
                 None => Ok(1),
             }
         };
-    let (_, path_weight) = longest_path(graph, edge_weight_callable)?;
+    let path_weight = longest_path_length(graph, edge_weight_callable)?;
     Ok(path_weight)
 }
 
@@ -253,7 +278,7 @@ pub fn dag_weighted_longest_path_length(
             }
             Ok(float_res)
         };
-    let (_, path_weight) = longest_path(graph, edge_weight_callable)?;
+    let path_weight = longest_path_length(graph, edge_weight_callable)?;
     Ok(path_weight)
 }
 


### PR DESCRIPTION
This commit builds off of #1577 which improved the performance of the `longest_path` function to avoid allocating on each iteration of the loop. It was pointed out in that PR and #1563 that storing and returning a path for applications that only care about the length is unnecessary overhead. To provide an option for such cases a new function is added to offer a better alternative for these use cases.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
