### PR TITLE
Setup separate rustworkx-core publish job with trusted publishers

### DIFF
--- a/.github/workflows/cargo_publish.yml
+++ b/.github/workflows/cargo_publish.yml
@@ -1,0 +1,23 @@
+---
+name: Publish rustworkx-core to crates.io
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  rustworkx-core:
+    name: Publish rustworkx-core
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - name: Run cargo publish
+        run: |
+          cd rustworkx-core
+          cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,18 +5,6 @@ on:
     tags:
       - '*'
 jobs:
-  rustworkx-core:
-    name: Publish rustworkx-core
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Run cargo publish
-        run: |
-          cd rustworkx-core
-          cargo publish
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   sdist:
     name: Build sdist
     runs-on: ubuntu-latest


### PR DESCRIPTION
This commit splits out the release publish job for the rustworkx-core crate to crates.io from the wheels file into a separate job workflow file. This then lets us setup the cargo publish job to use the trusted publishers mechanism instead of a secret token for authentication which is more secure. The docs for using trusted publisher are located here:

https://crates.io/docs/trusted-publishing

the new cargo_publish workflow's job is updated to more closely follow the example in the docs. I've already updated the crate's configuration on crates.io to use cargo_publish.yml for the trusted publisher mechanism.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
