### PR TITLE
Fix undirected_gnm_random_graph so it does not return a multigraph

### DIFF
--- a/releasenotes/notes/fix-undirected-gnm-parallel-edges-7b3c1e9a4f2d8065.yaml
+++ b/releasenotes/notes/fix-undirected-gnm-parallel-edges-7b3c1e9a4f2d8065.yaml
@@ -1,0 +1,13 @@
+---
+fixes:
+  - |
+    Fixed :func:`~rustworkx.undirected_gnm_random_graph` (and the corresponding
+    ``gnm_random_graph`` generator in ``rustworkx-core``) so that it no longer
+    returns a graph containing parallel edges. Previously a randomly drawn edge
+    ``(v, u)`` was not recognized as a duplicate of an already-added edge
+    ``(u, v)``, so undirected graphs could be returned with more than one edge
+    between the same pair of nodes, contradicting the documented behavior that
+    the generator does not produce a multigraph. This is also a performance
+    improvement - O(m) scan of edges replaced with O(1) set membership lookup.
+    See `#1640 <https://github.com/Qiskit/rustworkx/issues/1640>`__.
+

--- a/releasenotes/notes/fix-undirected-gnm-parallel-edges-7b3c1e9a4f2d8065.yaml
+++ b/releasenotes/notes/fix-undirected-gnm-parallel-edges-7b3c1e9a4f2d8065.yaml
@@ -1,13 +1,9 @@
 ---
 fixes:
   - |
-    Fixed :func:`~rustworkx.undirected_gnm_random_graph` (and the corresponding
-    ``gnm_random_graph`` generator in ``rustworkx-core``) so that it no longer
-    returns a graph containing parallel edges. Previously a randomly drawn edge
-    ``(v, u)`` was not recognized as a duplicate of an already-added edge
-    ``(u, v)``, so undirected graphs could be returned with more than one edge
-    between the same pair of nodes, contradicting the documented behavior that
-    the generator does not produce a multigraph. This is also a performance
-    improvement - O(m) scan of edges replaced with O(1) set membership lookup.
-    See `#1640 <https://github.com/Qiskit/rustworkx/issues/1640>`__.
-
+    Fixed :func:`~rustworkx.undirected_gnm_random_graph` generating parallel
+    edges. In some cases, the random graph could contain two parallel
+    edges between a pair of nodes. It now contains at most one
+    edge per pair of nodes.
+    See `#1640 <https://github.com/Qiskit/rustworkx/issues/1640>`__ for
+    further details.

--- a/rustworkx-core/src/generators/random_graph.rs
+++ b/rustworkx-core/src/generators/random_graph.rs
@@ -20,8 +20,8 @@ use std::hash::Hash;
 use ndarray::ArrayView2;
 use petgraph::data::{Build, Create};
 use petgraph::visit::{
-    Data, GraphBase, GraphProp, IntoEdgeReferences, IntoEdgesDirected,
-    IntoNodeIdentifiers, NodeCount, NodeIndexable,
+    Data, GraphBase, GraphProp, IntoEdgeReferences, IntoEdgesDirected, IntoNodeIdentifiers,
+    NodeCount, NodeIndexable,
 };
 use petgraph::{Incoming, Outgoing};
 
@@ -451,7 +451,7 @@ where
             let u = between.sample(&mut rng);
             let v = between.sample(&mut rng);
             let key = if directed || u <= v { (u, v) } else { (v, u) };
-            // avoid self-loops and parallel edges
+            // avoid self-loops and multi-graphs
             if u != v && existing_edges.insert(key) {
                 let u_index = graph.from_index(u);
                 let v_index = graph.from_index(v);
@@ -1114,8 +1114,9 @@ mod tests {
     #[test]
     fn test_gnm_random_graph_undirected_has_no_parallel_edges() {
         let n = 20;
-        let m = 150;  // m < n(n-1)/2 so we get random edges
-        for seed in 0..20 {  // sweep multiple random seeds to reduce the odds of lucky draws
+        let m = 150; // m < n(n-1)/2 so we get random edges
+        for seed in 0..20 {
+            // sweep multiple random seeds to reduce the odds of lucky draws
             let g: petgraph::graph::UnGraph<(), ()> =
                 gnm_random_graph(n, m, Some(seed), || (), || ()).unwrap();
             assert_eq!(g.edge_count(), m);

--- a/rustworkx-core/src/generators/random_graph.rs
+++ b/rustworkx-core/src/generators/random_graph.rs
@@ -15,7 +15,7 @@
 use crate::dictmap::DictMap;
 use hashbrown::HashSet;
 use indexmap::IndexSet;
-use std::hash::Hash;
+use std::{cmp::min, hash::Hash};
 
 use ndarray::ArrayView2;
 use petgraph::data::{Build, Create};
@@ -450,7 +450,11 @@ where
         while created_edges < num_edges {
             let u = between.sample(&mut rng);
             let v = between.sample(&mut rng);
-            let key = if directed || u <= v { (u, v) } else { (v, u) };
+            let key = if directed {
+                (u, v)
+            } else {
+                min((u, v), (v, u))
+            };
             // avoid self-loops and multi-graphs
             if u != v && existing_edges.insert(key) {
                 let u_index = graph.from_index(u);
@@ -1025,7 +1029,7 @@ mod tests {
         sbm_random_graph,
     };
     use crate::petgraph;
-    use std::collections::HashSet;
+    use hashbrown::HashSet;
 
     // Test gnp_random_graph
     #[test]

--- a/rustworkx-core/src/generators/random_graph.rs
+++ b/rustworkx-core/src/generators/random_graph.rs
@@ -13,13 +13,14 @@
 #![allow(clippy::float_cmp)]
 
 use crate::dictmap::DictMap;
+use hashbrown::HashSet;
 use indexmap::IndexSet;
 use std::hash::Hash;
 
 use ndarray::ArrayView2;
 use petgraph::data::{Build, Create};
 use petgraph::visit::{
-    Data, EdgeRef, GraphBase, GraphProp, IntoEdgeReferences, IntoEdgesDirected,
+    Data, GraphBase, GraphProp, IntoEdgeReferences, IntoEdgesDirected,
     IntoNodeIdentifiers, NodeCount, NodeIndexable,
 };
 use petgraph::{Incoming, Outgoing};
@@ -416,21 +417,6 @@ where
         return Err(InvalidInputError {});
     }
 
-    fn find_edge<G>(graph: &G, source: usize, target: usize) -> bool
-    where
-        G: GraphBase + NodeIndexable,
-        for<'b> &'b G: GraphBase<NodeId = G::NodeId> + IntoEdgeReferences,
-    {
-        let mut found = false;
-        for edge in graph.edge_references() {
-            if graph.to_index(edge.source()) == source && graph.to_index(edge.target()) == target {
-                found = true;
-                break;
-            }
-        }
-        found
-    }
-
     let mut rng: Pcg64 = match seed {
         Some(seed) => Pcg64::seed_from_u64(seed),
         None => Pcg64::try_from_rng(&mut SysRng).unwrap(),
@@ -458,14 +444,17 @@ where
         }
     } else {
         let mut created_edges: usize = 0;
+        // edge set keyed by smaller node first (if undirected)
+        let mut existing_edges: HashSet<(usize, usize)> = HashSet::with_capacity(num_edges);
         let between = Uniform::new(0, num_nodes).unwrap();
         while created_edges < num_edges {
             let u = between.sample(&mut rng);
             let v = between.sample(&mut rng);
-            let u_index = graph.from_index(u);
-            let v_index = graph.from_index(v);
-            // avoid self-loops and multi-graphs
-            if u != v && !find_edge(&graph, u, v) {
+            let key = if directed || u <= v { (u, v) } else { (v, u) };
+            // avoid self-loops and parallel edges
+            if u != v && existing_edges.insert(key) {
+                let u_index = graph.from_index(u);
+                let v_index = graph.from_index(v);
                 graph.add_edge(u_index, v_index, default_edge_weight());
                 created_edges += 1;
             }
@@ -1036,6 +1025,7 @@ mod tests {
         sbm_random_graph,
     };
     use crate::petgraph;
+    use std::collections::HashSet;
 
     // Test gnp_random_graph
     #[test]
@@ -1119,6 +1109,30 @@ mod tests {
             gnm_random_graph(20, 100, None, || (), || ()).unwrap();
         assert_eq!(g.node_count(), 20);
         assert_eq!(g.edge_count(), 100);
+    }
+
+    #[test]
+    fn test_gnm_random_graph_undirected_has_no_parallel_edges() {
+        let n = 20;
+        let m = 150;  // m < n(n-1)/2 so we get random edges
+        for seed in 0..20 {  // sweep multiple random seeds to reduce the odds of lucky draws
+            let g: petgraph::graph::UnGraph<(), ()> =
+                gnm_random_graph(n, m, Some(seed), || (), || ()).unwrap();
+            assert_eq!(g.edge_count(), m);
+            let distinct_edges: HashSet<(usize, usize)> = g
+                .edge_indices()
+                .map(|e| {
+                    let (a, b) = g.edge_endpoints(e).unwrap();
+                    let (a, b) = (a.index(), b.index());
+                    (a.min(b), a.max(b))
+                })
+                .collect();
+            assert_eq!(
+                distinct_edges.len(),
+                m,
+                "undirected gnm produced parallel edges for seed {seed}"
+            );
+        }
     }
 
     #[test]

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -185,6 +185,16 @@ class TestGNMRandomGraph(unittest.TestCase):
         graph_s2 = rustworkx.undirected_gnm_random_graph(20, 100, seed=10)
         self.assertEqual(graph_s1.edge_list(), graph_s2.edge_list())
 
+    def test_random_gnm_undirected_has_no_parallel_edges(self):
+        n = 20
+        m = 150
+        # sweep many seeds to reduce the odds of a lucky draw
+        for seed in range(20):
+            graph = rustworkx.undirected_gnm_random_graph(n, m, seed=seed)
+            self.assertEqual(len(graph.edges()), m)
+            distinct = {tuple(sorted(edge)) for edge in graph.edge_list()}
+            self.assertEqual(len(distinct), m, f"parallel edges for seed {seed}")
+
     def test_random_gnm_undirected_empty_graph(self):
         graph = rustworkx.undirected_gnm_random_graph(20, 0)
         self.assertEqual(len(graph), 20)


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Fixes https://github.com/Qiskit/rustworkx/issues/1640

See issue for root cause / discussion.
