### PR TITLE
Avoid having to manually bump documentation versions

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,8 +14,10 @@
 # rustworkx documentation build configuration file
 #
 
-import sys, os
+import os
 import subprocess
+import tomllib
+from pathlib import Path
 
 # General configuration:
 
@@ -23,10 +25,11 @@ project = 'rustworkx'
 copyright = '2021, rustworkx Contributors'
 docs_url_prefix = ""
 
+with (Path(__file__).resolve().parents[2] / "pyproject.toml").open("rb") as project_file:
+    release = tomllib.load(project_file)["project"]["version"]
+
 # The short X.Y version.
-version = '0.17'
-# The full version, including alpha/beta/rc tags.
-release = '0.17.1'
+version = ".".join(release.split(".")[:2])
 
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.autosummary',


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

See https://github.com/Qiskit/rustworkx/pull/1653#issuecomment-5085327017

These days, Python ships with built-in support to read TOML files, so I think we can avoid this all together.