### PR TITLE
Bump manylinux version to manylinux 2_28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,8 +129,11 @@ extend-ignore-words-re = [
 ]
 
 [tool.cibuildwheel]
-manylinux-x86_64-image = "manylinux2014"
-manylinux-i686-image = "manylinux2014"
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-i686-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+manylinux-ppc64le-image = "manylinux_2_28"
+manylinux-s390x-image = "manylinux_2_28"
 skip = "pp* cp314t-win* c*t-*i686 cp314t-*s390x *win32 *musllinux*i686"
 test-requires = "networkx"
 test-command = "python -m unittest discover {project}/tests"

--- a/releasenotes/notes/bump-manylinux-5d134d4239bf0a9b.yaml
+++ b/releasenotes/notes/bump-manylinux-5d134d4239bf0a9b.yaml
@@ -1,0 +1,15 @@
+---
+upgrade:
+  - |
+    The pre-compiled wheel package files for rustworkx published on pypi.org has
+    changed the manylinux tag used from manylinux 2014 to manylinux 2_28. This
+    means that the published rustworkx packages for Linux are compatible with
+    Linux distributions using glibc 2.28 or later. This includes:
+
+      * Debian 10+
+      * Ubuntu 18.10+
+      * Fedora 29+
+      * CentOS/RHEL 8+
+
+    This change was necessary because newer releases of NumPy already require
+    manylinux 2_28.


### PR DESCRIPTION
During the run up to the rustworkx 0.18.1 we realized that the latest numpy releases were using manylinux 2_28 for their published wheels while rustworkx was building with manylinux 2014. This was forcing rustworkx's wheel build job to build numpy from source as there was no compatible precompiled version available. Additionally, starting in numpy 2.5.0 the version of GCC required to build numpy was newer than the version included in the manylinux 2014 image. This commit opts to raise the manylinux version we use for building qiskit to manylinux 2_28 to bring it inline with numpy, our only python dependency. This means functionally the precompiled packages for rustworkx just require glibc 2.28 or newer (up from glibc 2.17 in manylinux 2014). Glibc 2.28 was released in 2018 so it is sufficiently old that most of our user base should already be on a compatible linux distro.

<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I ran rustfmt locally
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
