### PR TITLE
Downgrade macOS x86-64 support from Tier 1 to Tier 4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,6 @@ jobs:
         rust: [stable]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         platform: [
-          { os: "macos-15-intel", python-architecture: "x64", rust-target: "x86_64-apple-darwin" },
           { os: "macOS-14", python-architecture: "arm64", rust-target: "aarch64-apple-darwin" },
           { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" },
           { os: "ubuntu-24.04-arm", python-architecture: "arm64", rust-target: "aarch64-unknown-linux-gnu" },

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-15-intel, macos-14, ubuntu-24.04-arm]
+        os: [ubuntu-latest, windows-latest, macos-14, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -70,6 +70,48 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: deploy
+  build_macos_intel_wheels:
+    name: Build macOS Intel wheels
+    runs-on: macos-14
+    environment: release
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: '3.12'
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-apple-darwin
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install -U --group releaseinfra
+      - name: Build wheels
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_ARCHS_MACOS: x86_64
+          CIBW_TEST_SKIP: "*"
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: wheel-builds-macos-intel
+  upload_macos_intel_wheels:
+    name: Upload macOS Intel wheels
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    needs: ["build_macos_intel_wheels", "upload_shared_wheels"]
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheel-builds-macos-intel
+          path: wheelhouse
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheelhouse/
   build_wheels_ppc64le:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -77,6 +77,22 @@ source.
      - aarch64
      - :ref:`tier-1`
      - Distributions compatible with the `manylinux 2014`_ packaging specification
+   * - macOS (11 or newer)
+     - arm64
+     - :ref:`tier-1`
+     -
+   * - Windows 64bit
+     - x86_64
+     - :ref:`tier-1`
+     -
+   * - Linux (musl)
+     - x86_64
+     - :ref:`tier-2`
+     -
+   * - Linux (musl)
+     - aarch64
+     - :ref:`tier-2`
+     -
    * - Linux
      - i686 
      - :ref:`tier-4`
@@ -89,26 +105,10 @@ source.
      - s390x
      - :ref:`tier-4`
      - Distributions compatible with the `manylinux 2014`_ packaging specification
-   * - Linux (musl)
-     - x86_64
-     - :ref:`tier-2`
-     -
-   * - Linux (musl)
-     - aarch64
-     - :ref:`tier-2`
-     - 
    * - macOS (10.12 or newer)
      - x86_64
-     - :ref:`tier-1`
-     -
-   * - macOS (11 or newer)
-     - arm64
-     - :ref:`tier-1`
-     -
-   * - Windows 64bit
-     - x86_64
-     - :ref:`tier-1`
-     -
+     - :ref:`tier-4`
+     - Wheels are cross-compiled on arm64 and are not tested
    * - Windows 32bit 
      - i686 or x86_64
      - :ref:`tier-4`

--- a/releasenotes/notes/macos-intel-tier-4-7bd1859fc94a623e.yaml
+++ b/releasenotes/notes/macos-intel-tier-4-7bd1859fc94a623e.yaml
@@ -1,0 +1,5 @@
+upgrade:
+  - |
+    Support for macOS x86_64 has been downgraded from tier 1 to tier 4. Wheels
+    will continue to be published, but they will be cross-compiled on arm64
+    and will not be tested.


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

This is perhaps one of the biggest tier drops we have had. However, I think it is reasonable for us to prepare for the day GitHub to stop offering the macOS intel runners.

Fortunately, we don't need to fully remove the macOS Intel wheel. We can cross-compile from the (now standard) macOS runners. This just means that the platform drops from Tier 1 to Tier 4. It's a big drop, but it's not dead.

I'd like to focus the CI resources we gain from dropping macOS Intel towards abi3t jobs for other platforms in the future.
