### PR TITLE
Stop publishing i686 and win32 wheels; start publishing Windows arm64 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,7 +59,7 @@ jobs:
     environment: release
     permissions:
       id-token: write
-    needs: ["build_wheels", "build-win32-wheels"]
+    needs: ["build_wheels"]
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -207,31 +207,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: wheelhouse/
-  build-win32-wheels:
-    name: Build wheels on win32
-    runs-on: windows-latest
-    environment: release
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        name: Install Python
-        with:
-          python-version: '3.12'
-          architecture: 'x86'
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: i686-pc-windows-msvc
-      - name: Force win32 rust
-        run: rustup default stable-i686-pc-windows-msvc
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install -U --group releaseinfra
-      - name: Build wheels
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_SKIP: pp* c*t-win* *amd64 *musl*
-      - uses: actions/upload-artifact@v4
-        with:
-          path: ./wheelhouse/*.whl
-          name: shared-wheel-builds-win32

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -70,6 +70,49 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: deploy
+  build_wheels_windows_arm64:
+    name: Build Windows ARM64 wheels
+    runs-on: windows-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: '3.12'
+          architecture: x64
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-pc-windows-msvc
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install -U --group releaseinfra
+      - name: Build wheels
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_ARCHS_WINDOWS: ARM64
+          CIBW_TEST_SKIP: "*"
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: wheel-builds-windows-arm64
+  upload_wheels_windows_arm64:
+    name: Upload Windows ARM64 wheels
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    needs: ["build_wheels_windows_arm64", "upload_shared_wheels"]
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheel-builds-windows-arm64
+          path: wheelhouse
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheelhouse/
   build_wheels_ppc64le:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ rustworkx.dijkstra_shortest_paths(graph, a, c, weight_fn=float)
 
 ## Installing rustworkx
 
-rustworkx is published on [PyPI](https://pypi.org/project/rustworkx/) so on x86\_64, i686, ppc64le, s390x, and
-aarch64 Linux systems, x86\_64 on Mac OSX, and 32 and 64 bit Windows
+rustworkx is published on [PyPI](https://pypi.org/project/rustworkx/) so on x86\_64, ppc64le, s390x, and
+aarch64 Linux systems, x86\_64 on Mac OSX, and 64-bit Windows
 installing is as simple as running:
 
 ```bash

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,8 +24,8 @@ inherent performance and safety. While this provides numerous advantages
 including significantly improved performance it does mean that the library
 needs to be compiled when being installed from source (as opposed to a pure
 Python library which can just be installed). rustworkx supports and publishes
-pre-compiled binaries for Linux on x86, x86_64, aarch64, s390x, and ppc64le,
-MacOS on x86_64, and arm64, and Windows 32bit and 64bit systems. However, if
+pre-compiled binaries for Linux on x86_64, aarch64, s390x, and ppc64le,
+MacOS on x86_64 and arm64, and 64-bit Windows systems. However, if
 you are not running on one of these platforms, you will need a rust compiler
 to install rustworkx.
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -10,8 +10,8 @@ application.
 Installing Rustworkx
 ====================
 
-rustworkx is published on pypi so on x86_64, i686, ppc64le, s390x, and aarch64
-Linux systems, x86_64 and arm64 on macOS, and 32 and 64 bit Windows
+rustworkx is published on pypi so on x86_64, ppc64le, s390x, and aarch64
+Linux systems, x86_64 and arm64 on macOS, and 64-bit Windows
 installing is as simple as running::
 
     pip install rustworkx
@@ -78,10 +78,6 @@ source.
      - :ref:`tier-1`
      - Distributions compatible with the `manylinux 2014`_ packaging specification
    * - Linux
-     - i686 
-     - :ref:`tier-4`
-     - Distributions compatible with the `manylinux 2014`_ packaging specification
-   * - Linux
      - pp64le
      - :ref:`tier-4`
      - Distributions compatible with the `manylinux 2014`_ packaging specification
@@ -108,10 +104,6 @@ source.
    * - Windows 64bit
      - x86_64
      - :ref:`tier-1`
-     -
-   * - Windows 32bit 
-     - i686 or x86_64
-     - :ref:`tier-4`
      -
    * - Pyodide 
      - WASM (Emscripten)

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -105,6 +105,10 @@ source.
      - x86_64
      - :ref:`tier-1`
      -
+   * - Windows 64bit
+     - ARM64 (aarch64)
+     - :ref:`tier-4`
+     - Wheels are cross-compiled on AMD64 and are not tested
    * - Pyodide 
      - WASM (Emscripten)
      - :ref:`tier-experimental`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,15 +130,14 @@ extend-ignore-words-re = [
 
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux_2_28"
-manylinux-i686-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
 manylinux-ppc64le-image = "manylinux_2_28"
 manylinux-s390x-image = "manylinux_2_28"
-skip = "pp* cp314t-win* c*t-*i686 cp314t-*s390x *win32 *musllinux*i686"
+skip = "pp* *i686 cp314t-win* cp314t-*s390x *win32"
 test-requires = "networkx"
 test-command = "python -m unittest discover {project}/tests"
 before-build = 'pip install -U "maturin>=1.9.0,<2.0"'
-test-skip = "*linux_s390x *ppc64le *i686 *win32"
+test-skip = "*linux_s390x *ppc64le"
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y wget && {package}/tools/install_rust.sh"

--- a/releasenotes/notes/drop-i686-win32-48bf532a7d1ec609.yaml
+++ b/releasenotes/notes/drop-i686-win32-48bf532a7d1ec609.yaml
@@ -1,0 +1,4 @@
+upgrade:
+  - |
+    Precompiled wheels are no longer published for Linux i686 or 32-bit
+    Windows.

--- a/releasenotes/notes/windows-arm64-wheels-369fde2ca8417b50.yaml
+++ b/releasenotes/notes/windows-arm64-wheels-369fde2ca8417b50.yaml
@@ -1,0 +1,4 @@
+features:
+  - |
+    Tier 4 precompiled wheels are now published for Windows ARM64. These wheels
+    are cross-compiled on AMD64 and are not tested.


### PR DESCRIPTION
<!--
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I ran rustfmt locally
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

Related to #1662 

This PR adds Windows arm64 wheels and removes win32 and i686 wheels.

i686 is the strongest candidate to be removed. NumPy has not published i686 wheels for NumPy 2.x, so realistically that already narrows the amount of people that benefit from a pre-compiled wheel.

win32 still has NumPy wheels, but the situation of the Rust `numpy` crate for bridging Python and Rust has been best-effort for a while. So I am ok with removing it.

Lastly, there's Windows arm64. This is a new niche platform, but I think it would be reasonable to at least start publishing wheels for it. They'd be analogous to the macOS Intel wheels after #1662: tier 4 and cross-compiled, without tests. Adding the wheel is not hard. Maybe as time goes they become more useful for end-users.