### PR TITLE
Fix longest_path panic / wrong result on incomparable weights (#1579, #1580)

### DIFF
--- a/releasenotes/notes/fix-longest-path-incomparable-weights-9c4430b18effb60a.yaml
+++ b/releasenotes/notes/fix-longest-path-incomparable-weights-9c4430b18effb60a.yaml
@@ -1,0 +1,16 @@
+---
+fixes:
+  - |
+    Fixed :func:`rustworkx_core::dag_algo::longest_path` panicking when the graph's
+    ``NodeId`` type implements ``PartialOrd`` but not ``Ord``. The function no longer
+    compares node ids (ties are broken by node index instead), so its ``NodeId`` bound
+    is relaxed from ``PartialOrd`` to just ``Hash + Eq``.
+    See `#1579 <https://github.com/Qiskit/rustworkx/issues/1579>`__.
+  - |
+    Fixed :func:`rustworkx_core::dag_algo::longest_path` and
+    :func:`rustworkx_core::dag_algo::longest_path_length` silently returning a shorter
+    path (or its length) when the edge weights include values that are not comparable,
+    such as ``f64::NAN``. Consistent with the documented behavior and with the handling
+    of cyclic graphs, both functions now return ``Ok(None)`` when the longest path is
+    not well-defined because two cumulative weights cannot be compared.
+    See `#1580 <https://github.com/Qiskit/rustworkx/issues/1580>`__.

--- a/rustworkx-core/src/dag_algo.rs
+++ b/rustworkx-core/src/dag_algo.rs
@@ -287,10 +287,14 @@ type LongestPathResult<G, T, E> = Result<Option<(Vec<NodeId<G>>, T)>, E>;
 /// ```
 pub fn longest_path<G, F, T, E>(graph: G, mut weight_fn: F) -> LongestPathResult<G, T, E>
 where
-    G: GraphProp<EdgeType = Directed> + IntoNodeIdentifiers + IntoEdgesDirected + Visitable,
+    G: GraphProp<EdgeType = Directed>
+        + IntoNodeIdentifiers
+        + IntoEdgesDirected
+        + Visitable
+        + NodeIndexable,
     F: FnMut(G::EdgeRef) -> Result<T, E>,
     T: Num + Zero + PartialOrd + Copy,
-    <G as GraphBase>::NodeId: Hash + Eq + PartialOrd,
+    <G as GraphBase>::NodeId: Hash + Eq,
 {
     let mut path: Vec<NodeId<G>> = Vec::new();
     let nodes = match algo::toposort(graph, None) {
@@ -306,27 +310,55 @@ where
 
     // Iterate over nodes in topological order
     for node in nodes {
+        // Tracks whether an incomparable pair of weights (e.g. `f64::NaN`) was seen while
+        // choosing the incoming edge with the greatest cumulative weight.
+        let mut incomparable = false;
         let max_path = graph
             .edges_directed(node, petgraph::Direction::Incoming)
             .try_fold((T::zero(), node), |longest, p_edge| -> Result<_, E> {
                 let p_node = p_edge.source();
                 let weight: T = weight_fn(p_edge)?;
                 let length = dist[&p_node].0 + weight;
-                if length >= longest.0 {
-                    Ok((length, p_node))
-                } else {
-                    Ok(longest)
+                match length.partial_cmp(&longest.0) {
+                    Some(Ordering::Greater) | Some(Ordering::Equal) => Ok((length, p_node)),
+                    Some(Ordering::Less) => Ok(longest),
+                    // Incomparable weights mean the longest path is not well-defined.
+                    None => {
+                        incomparable = true;
+                        Ok(longest)
+                    }
                 }
             })?;
+        if incomparable {
+            return Ok(None);
+        }
 
         // Store the maximum distance and the corresponding parent node for the current node
         dist.insert(node, max_path);
     }
-    let (first, _) = dist
-        .iter()
-        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
-        .unwrap();
-    let mut v = *first;
+    // Select the node with the greatest cumulative distance.  Ties are broken by node index so
+    // the result is deterministic without requiring `NodeId: Ord`, and if any two distances are
+    // incomparable the longest path is not well-defined, so we return `None` (as for a cycle).
+    let mut best: Option<(T, G::NodeId)> = None;
+    for (node, (distance, _)) in dist.iter() {
+        best = Some(match best {
+            None => (*distance, *node),
+            Some(current) => match distance.partial_cmp(&current.0) {
+                Some(Ordering::Greater) => (*distance, *node),
+                Some(Ordering::Less) => current,
+                Some(Ordering::Equal) if graph.to_index(*node) > graph.to_index(current.1) => {
+                    (*distance, *node)
+                }
+                Some(Ordering::Equal) => current,
+                None => return Ok(None),
+            },
+        });
+    }
+    // `dist` is non-empty because `nodes` is non-empty (checked above), so `best` is `Some`.
+    let Some((_, first)) = best else {
+        return Ok(Some((path, T::zero())));
+    };
+    let mut v = first;
     let mut u: Option<G::NodeId> = None;
     // Backtrack from this node to find the path
     #[allow(clippy::unnecessary_map_or)]
@@ -336,7 +368,7 @@ where
         v = dist[&v].1;
     }
     path.reverse(); // Reverse the path to get the correct order
-    let path_weight = dist[first].0; // The total weight of the longest path
+    let path_weight = dist[&first].0; // The total weight of the longest path
 
     Ok(Some((path, path_weight)))
 }
@@ -399,7 +431,7 @@ where
         + NodeIndexable,
     F: FnMut(G::EdgeRef) -> Result<T, E>,
     T: Num + Zero + PartialOrd + Copy,
-    <G as GraphBase>::NodeId: Hash + Eq + PartialOrd,
+    <G as GraphBase>::NodeId: Hash + Eq,
 {
     let nodes = match algo::toposort(graph, None) {
         Ok(nodes) => nodes,
@@ -414,18 +446,28 @@ where
 
     // Iterate over nodes in topological order
     for node in nodes {
+        // Tracks whether an incomparable pair of weights (e.g. `f64::NaN`) was seen while
+        // choosing the incoming edge with the greatest cumulative weight.
+        let mut incomparable = false;
         let max_path = graph
             .edges_directed(node, petgraph::Direction::Incoming)
             .try_fold((T::zero(), node), |longest, p_edge| -> Result<_, E> {
                 let p_node = p_edge.source();
                 let weight: T = weight_fn(p_edge)?;
                 let length = dist[graph.to_index(p_node)].unwrap().0 + weight;
-                if length >= longest.0 {
-                    Ok((length, p_node))
-                } else {
-                    Ok(longest)
+                match length.partial_cmp(&longest.0) {
+                    Some(Ordering::Greater) | Some(Ordering::Equal) => Ok((length, p_node)),
+                    Some(Ordering::Less) => Ok(longest),
+                    // Incomparable weights mean the longest path is not well-defined.
+                    None => {
+                        incomparable = true;
+                        Ok(longest)
+                    }
                 }
             })?;
+        if incomparable {
+            return Ok(None);
+        }
 
         // Store the maximum distance and the corresponding parent node for the current node
         dist[graph.to_index(node)] = Some(max_path);
@@ -939,6 +981,23 @@ mod test_longest_path {
     }
 
     #[test]
+    fn test_incomparable_weights_return_none() {
+        // gh #1580: when weights are not comparable (e.g. NaN), the longest path is not
+        // well-defined, so the function must return Ok(None) rather than silently dropping
+        // the incomparable path and returning a shorter one.
+        let mut graph: DiGraph<(), f64> = DiGraph::new();
+        let n0 = graph.add_node(());
+        let n1 = graph.add_node(());
+        let n2 = graph.add_node(());
+        graph.add_edge(n0, n1, 1.0);
+        graph.add_edge(n0, n2, f64::NAN);
+        graph.add_edge(n1, n2, 1.0);
+        let weight_fn = |edge: petgraph::graph::EdgeReference<f64>| Ok::<f64, &str>(*edge.weight());
+        let result = longest_path(&graph, weight_fn);
+        assert_eq!(result, Ok(None));
+    }
+
+    #[test]
     fn test_dag_with_multiple_paths() {
         let mut graph: DiGraph<(), i32> = DiGraph::new();
         let n0 = graph.add_node(());
@@ -1045,6 +1104,23 @@ mod test_longest_path_length {
         let weight_fn = |_: petgraph::graph::EdgeReference<()>| Ok::<i32, &str>(0);
         let result = longest_path_length(&graph, weight_fn);
         assert_eq!(result, Ok(Some(0)));
+    }
+
+    #[test]
+    fn test_incomparable_weights_return_none() {
+        // gh #1580: mirror `longest_path` — incomparable weights (e.g. NaN) mean the longest
+        // path length is not well-defined, so return Ok(None) rather than a suppressed shorter
+        // length, keeping the two functions consistent.
+        let mut graph: DiGraph<(), f64> = DiGraph::new();
+        let n0 = graph.add_node(());
+        let n1 = graph.add_node(());
+        let n2 = graph.add_node(());
+        graph.add_edge(n0, n1, 1.0);
+        graph.add_edge(n0, n2, f64::NAN);
+        graph.add_edge(n1, n2, 1.0);
+        let weight_fn = |edge: petgraph::graph::EdgeReference<f64>| Ok::<f64, &str>(*edge.weight());
+        let result = longest_path_length(&graph, weight_fn);
+        assert_eq!(result, Ok(None));
     }
 
     #[test]


### PR DESCRIPTION
### Summary

Fixes #1579 and #1580, two related issues in `rustworkx_core::dag_algo::longest_path`.

The final node selection did:

```rust
let (first, _) = dist.iter().max_by(|a, b| a.1.partial_cmp(b.1).unwrap()).unwrap();
```

which compares `(distance, NodeId)` tuples and unwraps the `Option` from `partial_cmp`. This has two failure modes:

- **#1579** — if `NodeId` is `PartialOrd` but not `Ord`, the tie-break comparison can return `None` and the `unwrap()` panics.
- **#1580** — the inner per-node loop used `if length >= longest.0`, which for incomparable weights (e.g. `f64::NAN`) is always `false`, so the incomparable path was silently dropped and a shorter path returned instead of signalling that the longest path is undefined.

### Changes

- Select the maximum-distance node by comparing **distances only**, breaking ties by **node index** (`NodeIndexable::to_index`). Node ids are no longer compared, so the `NodeId` bound is relaxed from `Hash + Eq + PartialOrd` to `Hash + Eq` — which is what fixes #1579 structurally. (`NodeIndexable` is added to the bounds; the sibling `longest_path_length` already required it.)
- When two cumulative weights are **incomparable**, both `longest_path` and `longest_path_length` now return `Ok(None)`. This matches the documented behaviour (the `longest_path_length` docs already state a `NaN` weight yields `None`) and mirrors the existing cyclic-graph handling, exactly as requested in #1580. I applied the fix to `longest_path_length` too so the two stay consistent (its inner loop had the same `>=` suppression).
- Added regression tests for both functions (NaN weights → `Ok(None)`) and a release note.

### Note for reviewers

The `NodeId: Ord` question in #1579 is resolved by no longer comparing node ids at all. A direct runtime test would need a bespoke graph type whose `NodeId` is `PartialOrd`-but-not-`Ord` (no petgraph built-in has one); I relied on the relaxed bound + the removal of the comparison instead, but happy to add such a type if you'd like explicit coverage.

Scope is limited to `rustworkx-core`, matching the issues. One downstream consequence worth flagging: the Python `dag_longest_path` / `dag_weighted_longest_path` wrappers map `Ok(None)` to `DAGHasCycle("The graph contains a cycle")`, so with this change a `NaN` weight would raise that (somewhat mislabelled) error rather than returning a wrong path. I left the Python layer untouched since changing that error's type/message is an API-facing decision — happy to broaden the message or raise a distinct exception in a follow-up if you'd prefer.

---

*Disclosure: this change was developed with the assistance of Claude Code (model Opus 4.8). I've reviewed the change and can explain and defend it.*
