### PR TITLE
Raise RuntimeError instead of PanicException when pruning on finish_vertex

### DIFF
--- a/releasenotes/notes/prunesearch-finish-vertex-runtimeerror-9c4a1e7b2f83d605.yaml
+++ b/releasenotes/notes/prunesearch-finish-vertex-runtimeerror-9c4a1e7b2f83d605.yaml
@@ -1,0 +1,13 @@
+---
+fixes:
+  - |
+    Fixed :func:`~rustworkx.bfs_search`, :func:`~rustworkx.dfs_search` and
+    :func:`~rustworkx.dijkstra_search` raising a
+    ``pyo3_runtime.PanicException`` when a visitor raises
+    :class:`~rustworkx.visit.PruneSearch` from its ``finish_vertex`` event.
+    Pruning is not possible once a vertex is finished, so this was always an
+    error, but ``PanicException`` inherits from ``BaseException`` instead of
+    ``Exception``, so it was not caught by an ``except Exception`` block, and a
+    panic message was printed to ``stderr`` alongside the Python traceback. A
+    ``RuntimeError`` is now raised instead. Refer to
+    `#1383 <https://github.com/Qiskit/rustworkx/issues/1383>`__ for more details.

--- a/rustworkx/__init__.py
+++ b/rustworkx/__init__.py
@@ -1834,8 +1834,8 @@ def bfs_search(graph, source, visitor):
 
     .. note::
 
-        An exception is raised if the :class:`~rustworkx.visit.PruneSearch` is
-        raised in the :class:`~rustworkx.visit.BFSVisitor.finish_vertex` event.
+        A ``RuntimeError`` is raised if :class:`~rustworkx.visit.PruneSearch` is
+        raised in the :meth:`~rustworkx.visit.BFSVisitor.finish_vertex` event.
 
 
     :param graph: The graph to be used. This can be a :class:`~rustworkx.PyGraph`
@@ -1930,8 +1930,8 @@ def dfs_search(graph, source, visitor):
 
     .. note::
 
-        An exception is raised if the :class:`~rustworkx.visit.PruneSearch` is
-        raised in the :class:`~rustworkx.visit.DFSVisitor.finish_vertex` event.
+        A ``RuntimeError`` is raised if :class:`~rustworkx.visit.PruneSearch` is
+        raised in the :meth:`~rustworkx.visit.DFSVisitor.finish_vertex` event.
 
     :param graph: The graph to be used. This can be a :class:`~rustworkx.PyGraph`
         or a :class:`~rustworkx.PyDiGraph`
@@ -2042,8 +2042,8 @@ def dijkstra_search(graph, source, weight_fn, visitor):
 
     .. note::
 
-        An exception is raised if the :class:`~rustworkx.visit.PruneSearch` is
-        raised in the :class:`~rustworkx.visit.DijkstraVisitor.finish_vertex` event.
+        A ``RuntimeError`` is raised if :class:`~rustworkx.visit.PruneSearch` is
+        raised in the :meth:`~rustworkx.visit.DijkstraVisitor.finish_vertex` event.
 
     :param graph: The graph to be used. This can be a :class:`~rustworkx.PyGraph`
         or a :class:`~rustworkx.PyDiGraph`.

--- a/src/traversal/bfs_visit.rs
+++ b/src/traversal/bfs_visit.rs
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
 use petgraph::stable_graph::NodeIndex;
@@ -33,6 +34,11 @@ pub fn bfs_handler(
     vis: &PyBfsVisitor,
     event: BfsEvent<NodeIndex, &Py<PyAny>>,
 ) -> PyResult<Control<()>> {
+    // There is nothing left to prune once a vertex is finished, and the core
+    // traversal panics on a `Prune` for that event. Catch it here instead, so
+    // Python callers get a regular exception.
+    let is_finish = matches!(&event, BfsEvent::Finish(..));
+
     let res = match event {
         BfsEvent::Discover(u) => vis.discover_vertex.call1(py, (u.index(),)),
         BfsEvent::TreeEdge(u, v, weight) => {
@@ -57,7 +63,13 @@ pub fn bfs_handler(
     match res {
         Err(e) => {
             if e.is_instance_of::<PruneSearch>(py) {
-                Ok(Control::Prune)
+                if is_finish {
+                    Err(PyRuntimeError::new_err(
+                        "Pruning on the `finish_vertex` event is not supported",
+                    ))
+                } else {
+                    Ok(Control::Prune)
+                }
             } else if e.is_instance_of::<StopSearch>(py) {
                 Ok(Control::Break(()))
             } else {

--- a/src/traversal/dfs_visit.rs
+++ b/src/traversal/dfs_visit.rs
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
 use petgraph::stable_graph::NodeIndex;
@@ -32,6 +33,11 @@ pub fn dfs_handler(
     vis: &PyDfsVisitor,
     event: DfsEvent<NodeIndex, &Py<PyAny>>,
 ) -> PyResult<Control<()>> {
+    // There is nothing left to prune once a vertex is finished, and the core
+    // traversal panics on a `Prune` for that event. Catch it here instead, so
+    // Python callers get a regular exception.
+    let is_finish = matches!(&event, DfsEvent::Finish(..));
+
     let res = match event {
         DfsEvent::Discover(u, Time(t)) => vis.discover_vertex.call1(py, (u.index(), t)),
         DfsEvent::TreeEdge(u, v, weight) => {
@@ -52,7 +58,13 @@ pub fn dfs_handler(
     match res {
         Err(e) => {
             if e.is_instance_of::<PruneSearch>(py) {
-                Ok(Control::Prune)
+                if is_finish {
+                    Err(PyRuntimeError::new_err(
+                        "Pruning on the `finish_vertex` event is not supported",
+                    ))
+                } else {
+                    Ok(Control::Prune)
+                }
             } else {
                 Err(e)
             }

--- a/src/traversal/dijkstra_visit.rs
+++ b/src/traversal/dijkstra_visit.rs
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
 use petgraph::stable_graph::NodeIndex;
@@ -32,6 +33,11 @@ pub fn dijkstra_handler(
     vis: &PyDijkstraVisitor,
     event: DijkstraEvent<NodeIndex, &Py<PyAny>, f64>,
 ) -> PyResult<Control<()>> {
+    // There is nothing left to prune once a vertex is finished, and the core
+    // traversal panics on a `Prune` for that event. Catch it here instead, so
+    // Python callers get a regular exception.
+    let is_finish = matches!(&event, DijkstraEvent::Finish(..));
+
     let res = match event {
         DijkstraEvent::Discover(u, score) => vis.discover_vertex.call1(py, (u.index(), score)),
         DijkstraEvent::ExamineEdge(u, v, weight) => {
@@ -52,7 +58,13 @@ pub fn dijkstra_handler(
     match res {
         Err(e) => {
             if e.is_instance_of::<PruneSearch>(py) {
-                Ok(Control::Prune)
+                if is_finish {
+                    Err(PyRuntimeError::new_err(
+                        "Pruning on the `finish_vertex` event is not supported",
+                    ))
+                } else {
+                    Ok(Control::Prune)
+                }
             } else if e.is_instance_of::<StopSearch>(py) {
                 Ok(Control::Break(()))
             } else {

--- a/src/traversal/mod.rs
+++ b/src/traversal/mod.rs
@@ -416,8 +416,8 @@ pub fn descendants(graph: &digraph::PyDiGraph, node: usize) -> PyResult<HashSet<
 ///
 /// .. note::
 ///
-///     An exception is raised if the :class:`~rustworkx.visit.PruneSearch` is
-///     raised in the :class:`~rustworkx.visit.BFSVisitor.finish_vertex` event.
+///     A ``RuntimeError`` is raised if :class:`~rustworkx.visit.PruneSearch` is
+///     raised in the :meth:`~rustworkx.visit.BFSVisitor.finish_vertex` event.
 ///
 ///
 /// :param PyDiGraph graph: The graph to be used.
@@ -562,8 +562,8 @@ pub fn digraph_bfs_search(
 ///
 ///
 /// .. note::
-///     An exception is raised if the :class:`~rustworkx.visit.PruneSearch` is raised in the
-///     :class:`~rustworkx.visit.BFSVisitor.finish_vertex` event.
+///     A ``RuntimeError`` is raised if :class:`~rustworkx.visit.PruneSearch` is raised in the
+///     :meth:`~rustworkx.visit.BFSVisitor.finish_vertex` event.
 ///
 ///
 /// :param PyGraph graph: The graph to be used.
@@ -679,8 +679,8 @@ pub fn graph_bfs_search(
 ///
 ///
 /// .. note::
-///     An exception is raised if the :class:`~rustworkx.visit.PruneSearch` is
-///     raised in the :class:`~rustworkx.visit.DFSVisitor.finish_vertex` event.
+///     A ``RuntimeError`` is raised if :class:`~rustworkx.visit.PruneSearch` is
+///     raised in the :meth:`~rustworkx.visit.DFSVisitor.finish_vertex` event.
 ///
 /// :param PyDiGraph graph: The graph to be used.
 /// :param source: An optional list of node indices to use as the starting nodes
@@ -795,8 +795,8 @@ pub fn digraph_dfs_search(
 ///
 ///
 /// .. note::
-///     An exception is raised if the :class:`~rustworkx.visit.PruneSearch` is
-///     raised in the :class:`~rustworkx.visit.DFSVisitor.finish_vertex` event.
+///     A ``RuntimeError`` is raised if :class:`~rustworkx.visit.PruneSearch` is
+///     raised in the :meth:`~rustworkx.visit.DFSVisitor.finish_vertex` event.
 ///
 /// :param PyGraph graph: The graph to be used.
 /// :param source: An optional list of node indices to use as the starting nodes
@@ -929,8 +929,8 @@ pub fn graph_dfs_search(
 ///
 /// .. note::
 ///
-///    An exception is raised if the :class:`~rustworkx.visit.PruneSearch` is
-///    raised in the :class:`~rustworkx.visit.DijkstraVisitor.finish_vertex` event.
+///    A ``RuntimeError`` is raised if :class:`~rustworkx.visit.PruneSearch` is
+///    raised in the :meth:`~rustworkx.visit.DijkstraVisitor.finish_vertex` event.
 ///
 /// :param PyDiGraph graph: The graph to be used.
 /// :param source: An optional list of node indices to use as the starting nodes
@@ -1072,8 +1072,8 @@ pub fn digraph_dijkstra_search(
 ///
 /// .. note::
 ///
-///    An exception is raised if the :class:`~rustworkx.visit.PruneSearch` is
-///    raised in the :class:`~rustworkx.visit.DijkstraVisitor.finish_vertex` event.
+///    A ``RuntimeError`` is raised if :class:`~rustworkx.visit.PruneSearch` is
+///    raised in the :meth:`~rustworkx.visit.DijkstraVisitor.finish_vertex` event.
 ///
 /// :param PyGraph graph: The graph to be used.
 /// :param source: An optional list of node indices to use as the starting nodes

--- a/tests/digraph/test_bfs_search.py
+++ b/tests/digraph/test_bfs_search.py
@@ -158,6 +158,51 @@ class TestBfsSearch(unittest.TestCase):
         vis = PruneGrayTargetEdge()
         rustworkx.digraph_bfs_search(self.graph, [0], vis)
 
+    def test_digraph_prune_finish_vertex(self):
+        class PruneFinishVertex(rustworkx.visit.BFSVisitor):
+            def finish_vertex(self, v):
+                raise rustworkx.visit.PruneSearch
+
+        vis = PruneFinishVertex()
+        with self.assertRaisesRegex(RuntimeError, "finish_vertex"):
+            rustworkx.digraph_bfs_search(self.graph, [0], vis)
+
+    def test_digraph_prune_finish_vertex_mid_traversal(self):
+        class PruneSecondFinish(rustworkx.visit.BFSVisitor):
+            def __init__(self):
+                self.finished = []
+
+            def finish_vertex(self, v):
+                self.finished.append(v)
+                if len(self.finished) == 2:
+                    raise rustworkx.visit.PruneSearch
+
+        vis = PruneSecondFinish()
+        with self.assertRaisesRegex(RuntimeError, "finish_vertex"):
+            rustworkx.digraph_bfs_search(self.graph, [0], vis)
+        self.assertEqual(vis.finished, [0, 2])
+
+    def test_digraph_prune_finish_vertex_no_starting_point(self):
+        class PruneFinishVertex(rustworkx.visit.BFSVisitor):
+            def finish_vertex(self, v):
+                raise rustworkx.visit.PruneSearch
+
+        with self.assertRaisesRegex(RuntimeError, "finish_vertex"):
+            rustworkx.digraph_bfs_search(self.graph, None, PruneFinishVertex())
+
+    def test_digraph_stop_search_finish_vertex(self):
+        class StopFinishVertex(rustworkx.visit.BFSVisitor):
+            def __init__(self):
+                self.finished = []
+
+            def finish_vertex(self, v):
+                self.finished.append(v)
+                raise rustworkx.visit.StopSearch
+
+        vis = StopFinishVertex()
+        rustworkx.digraph_bfs_search(self.graph, [0], vis)
+        self.assertEqual(vis.finished, [0])
+
     def test_invalid_source(self):
         graph = rustworkx.PyDiGraph()
         with self.assertRaises(IndexError):

--- a/tests/digraph/test_dfs_search.py
+++ b/tests/digraph/test_dfs_search.py
@@ -103,6 +103,52 @@ class TestDfsSearch(unittest.TestCase):
             pass
         self.assertEqual(vis.reconstruct_path(), [0, 2, 5, 3])
 
+    def test_digraph_prune_finish_vertex(self):
+        class PruneFinishVertex(rustworkx.visit.DFSVisitor):
+            def finish_vertex(self, v, t):
+                raise rustworkx.visit.PruneSearch
+
+        vis = PruneFinishVertex()
+        with self.assertRaisesRegex(RuntimeError, "finish_vertex"):
+            rustworkx.digraph_dfs_search(self.graph, [0], vis)
+
+    def test_digraph_prune_finish_vertex_mid_traversal(self):
+        class PruneSecondFinish(rustworkx.visit.DFSVisitor):
+            def __init__(self):
+                self.finished = []
+
+            def finish_vertex(self, v, t):
+                self.finished.append(v)
+                if len(self.finished) == 2:
+                    raise rustworkx.visit.PruneSearch
+
+        vis = PruneSecondFinish()
+        with self.assertRaisesRegex(RuntimeError, "finish_vertex"):
+            rustworkx.digraph_dfs_search(self.graph, [0], vis)
+        self.assertEqual(vis.finished, [6, 3])
+
+    def test_digraph_prune_finish_vertex_no_starting_point(self):
+        class PruneFinishVertex(rustworkx.visit.DFSVisitor):
+            def finish_vertex(self, v, t):
+                raise rustworkx.visit.PruneSearch
+
+        with self.assertRaisesRegex(RuntimeError, "finish_vertex"):
+            rustworkx.digraph_dfs_search(self.graph, None, PruneFinishVertex())
+
+    def test_digraph_stop_search_finish_vertex(self):
+        class StopFinishVertex(rustworkx.visit.DFSVisitor):
+            def __init__(self):
+                self.finished = []
+
+            def finish_vertex(self, v, t):
+                self.finished.append(v)
+                raise rustworkx.visit.StopSearch
+
+        vis = StopFinishVertex()
+        with self.assertRaises(rustworkx.visit.StopSearch):
+            rustworkx.digraph_dfs_search(self.graph, [0], vis)
+        self.assertEqual(vis.finished, [6])
+
     def test_invalid_source(self):
         graph = rustworkx.PyDiGraph()
         with self.assertRaises(IndexError):

--- a/tests/digraph/test_dijkstra_search.py
+++ b/tests/digraph/test_dijkstra_search.py
@@ -185,6 +185,51 @@ class TestDijkstraSearch(unittest.TestCase):
         vis = PruneEdgeNotRelaxed()
         rustworkx.digraph_dijkstra_search(self.graph, [0], float, vis)
 
+    def test_digraph_prune_finish_vertex(self):
+        class PruneFinishVertex(rustworkx.visit.DijkstraVisitor):
+            def finish_vertex(self, v):
+                raise rustworkx.visit.PruneSearch
+
+        vis = PruneFinishVertex()
+        with self.assertRaisesRegex(RuntimeError, "finish_vertex"):
+            rustworkx.digraph_dijkstra_search(self.graph, [0], float, vis)
+
+    def test_digraph_prune_finish_vertex_mid_traversal(self):
+        class PruneSecondFinish(rustworkx.visit.DijkstraVisitor):
+            def __init__(self):
+                self.finished = []
+
+            def finish_vertex(self, v):
+                self.finished.append(v)
+                if len(self.finished) == 2:
+                    raise rustworkx.visit.PruneSearch
+
+        vis = PruneSecondFinish()
+        with self.assertRaisesRegex(RuntimeError, "finish_vertex"):
+            rustworkx.digraph_dijkstra_search(self.graph, [0], float, vis)
+        self.assertEqual(vis.finished, [0, 1])
+
+    def test_digraph_prune_finish_vertex_no_starting_point(self):
+        class PruneFinishVertex(rustworkx.visit.DijkstraVisitor):
+            def finish_vertex(self, v):
+                raise rustworkx.visit.PruneSearch
+
+        with self.assertRaisesRegex(RuntimeError, "finish_vertex"):
+            rustworkx.digraph_dijkstra_search(self.graph, None, float, PruneFinishVertex())
+
+    def test_digraph_stop_search_finish_vertex(self):
+        class StopFinishVertex(rustworkx.visit.DijkstraVisitor):
+            def __init__(self):
+                self.finished = []
+
+            def finish_vertex(self, v):
+                self.finished.append(v)
+                raise rustworkx.visit.StopSearch
+
+        vis = StopFinishVertex()
+        rustworkx.digraph_dijkstra_search(self.graph, [0], float, vis)
+        self.assertEqual(vis.finished, [0])
+
     def test_invalid_source(self):
         graph = rustworkx.PyDiGraph()
         with self.assertRaises(IndexError):

--- a/tests/graph/test_bfs_search.py
+++ b/tests/graph/test_bfs_search.py
@@ -158,6 +158,51 @@ class TestBfsSearch(unittest.TestCase):
         vis = PruneGrayTargetEdge()
         rustworkx.graph_bfs_search(self.graph, [0], vis)
 
+    def test_graph_prune_finish_vertex(self):
+        class PruneFinishVertex(rustworkx.visit.BFSVisitor):
+            def finish_vertex(self, v):
+                raise rustworkx.visit.PruneSearch
+
+        vis = PruneFinishVertex()
+        with self.assertRaisesRegex(RuntimeError, "finish_vertex"):
+            rustworkx.graph_bfs_search(self.graph, [0], vis)
+
+    def test_graph_prune_finish_vertex_mid_traversal(self):
+        class PruneSecondFinish(rustworkx.visit.BFSVisitor):
+            def __init__(self):
+                self.finished = []
+
+            def finish_vertex(self, v):
+                self.finished.append(v)
+                if len(self.finished) == 2:
+                    raise rustworkx.visit.PruneSearch
+
+        vis = PruneSecondFinish()
+        with self.assertRaisesRegex(RuntimeError, "finish_vertex"):
+            rustworkx.graph_bfs_search(self.graph, [0], vis)
+        self.assertEqual(vis.finished, [0, 2])
+
+    def test_graph_prune_finish_vertex_no_starting_point(self):
+        class PruneFinishVertex(rustworkx.visit.BFSVisitor):
+            def finish_vertex(self, v):
+                raise rustworkx.visit.PruneSearch
+
+        with self.assertRaisesRegex(RuntimeError, "finish_vertex"):
+            rustworkx.graph_bfs_search(self.graph, None, PruneFinishVertex())
+
+    def test_graph_stop_search_finish_vertex(self):
+        class StopFinishVertex(rustworkx.visit.BFSVisitor):
+            def __init__(self):
+                self.finished = []
+
+            def finish_vertex(self, v):
+                self.finished.append(v)
+                raise rustworkx.visit.StopSearch
+
+        vis = StopFinishVertex()
+        rustworkx.graph_bfs_search(self.graph, [0], vis)
+        self.assertEqual(vis.finished, [0])
+
     def test_invalid_source(self):
         graph = rustworkx.PyGraph()
         with self.assertRaises(IndexError):

--- a/tests/graph/test_dfs_search.py
+++ b/tests/graph/test_dfs_search.py
@@ -103,6 +103,52 @@ class TestDfsSearch(unittest.TestCase):
             pass
         self.assertEqual(vis.reconstruct_path(), [0, 2, 5, 3])
 
+    def test_graph_prune_finish_vertex(self):
+        class PruneFinishVertex(rustworkx.visit.DFSVisitor):
+            def finish_vertex(self, v, t):
+                raise rustworkx.visit.PruneSearch
+
+        vis = PruneFinishVertex()
+        with self.assertRaisesRegex(RuntimeError, "finish_vertex"):
+            rustworkx.graph_dfs_search(self.graph, [0], vis)
+
+    def test_graph_prune_finish_vertex_mid_traversal(self):
+        class PruneSecondFinish(rustworkx.visit.DFSVisitor):
+            def __init__(self):
+                self.finished = []
+
+            def finish_vertex(self, v, t):
+                self.finished.append(v)
+                if len(self.finished) == 2:
+                    raise rustworkx.visit.PruneSearch
+
+        vis = PruneSecondFinish()
+        with self.assertRaisesRegex(RuntimeError, "finish_vertex"):
+            rustworkx.graph_dfs_search(self.graph, [0], vis)
+        self.assertEqual(vis.finished, [6, 1])
+
+    def test_graph_prune_finish_vertex_no_starting_point(self):
+        class PruneFinishVertex(rustworkx.visit.DFSVisitor):
+            def finish_vertex(self, v, t):
+                raise rustworkx.visit.PruneSearch
+
+        with self.assertRaisesRegex(RuntimeError, "finish_vertex"):
+            rustworkx.graph_dfs_search(self.graph, None, PruneFinishVertex())
+
+    def test_graph_stop_search_finish_vertex(self):
+        class StopFinishVertex(rustworkx.visit.DFSVisitor):
+            def __init__(self):
+                self.finished = []
+
+            def finish_vertex(self, v, t):
+                self.finished.append(v)
+                raise rustworkx.visit.StopSearch
+
+        vis = StopFinishVertex()
+        with self.assertRaises(rustworkx.visit.StopSearch):
+            rustworkx.graph_dfs_search(self.graph, [0], vis)
+        self.assertEqual(vis.finished, [6])
+
     def test_invalid_source(self):
         graph = rustworkx.PyGraph()
         with self.assertRaises(IndexError):

--- a/tests/graph/test_dijkstra_search.py
+++ b/tests/graph/test_dijkstra_search.py
@@ -185,6 +185,51 @@ class TestDijkstraSearch(unittest.TestCase):
         vis = PruneEdgeNotRelaxed()
         rustworkx.graph_dijkstra_search(self.graph, [0], float, vis)
 
+    def test_graph_prune_finish_vertex(self):
+        class PruneFinishVertex(rustworkx.visit.DijkstraVisitor):
+            def finish_vertex(self, v):
+                raise rustworkx.visit.PruneSearch
+
+        vis = PruneFinishVertex()
+        with self.assertRaisesRegex(RuntimeError, "finish_vertex"):
+            rustworkx.graph_dijkstra_search(self.graph, [0], float, vis)
+
+    def test_graph_prune_finish_vertex_mid_traversal(self):
+        class PruneSecondFinish(rustworkx.visit.DijkstraVisitor):
+            def __init__(self):
+                self.finished = []
+
+            def finish_vertex(self, v):
+                self.finished.append(v)
+                if len(self.finished) == 2:
+                    raise rustworkx.visit.PruneSearch
+
+        vis = PruneSecondFinish()
+        with self.assertRaisesRegex(RuntimeError, "finish_vertex"):
+            rustworkx.graph_dijkstra_search(self.graph, [0], float, vis)
+        self.assertEqual(vis.finished, [0, 1])
+
+    def test_graph_prune_finish_vertex_no_starting_point(self):
+        class PruneFinishVertex(rustworkx.visit.DijkstraVisitor):
+            def finish_vertex(self, v):
+                raise rustworkx.visit.PruneSearch
+
+        with self.assertRaisesRegex(RuntimeError, "finish_vertex"):
+            rustworkx.graph_dijkstra_search(self.graph, None, float, PruneFinishVertex())
+
+    def test_graph_stop_search_finish_vertex(self):
+        class StopFinishVertex(rustworkx.visit.DijkstraVisitor):
+            def __init__(self):
+                self.finished = []
+
+            def finish_vertex(self, v):
+                self.finished.append(v)
+                raise rustworkx.visit.StopSearch
+
+        vis = StopFinishVertex()
+        rustworkx.graph_dijkstra_search(self.graph, [0], float, vis)
+        self.assertEqual(vis.finished, [0])
+
     def test_invalid_source(self):
         graph = rustworkx.PyGraph()
         with self.assertRaises(IndexError):


### PR DESCRIPTION
Fixes #1383.

Raising `PruneSearch` from the `finish_vertex` event reached `rustworkx-core`, which panics because there is nothing left to prune once a vertex is finished. The resulting `PanicException` derives from `BaseException`, so it was not caught by a plain `except Exception`, and a panic message was printed to stderr next to the Python traceback:

```
thread '<unnamed>' panicked at rustworkx-core/src/traversal/dfs_visit.rs:270:25:
Pruning on the `DfsEvent::Finish` is not supported!
pyo3_runtime.PanicException: Pruning on the `DfsEvent::Finish` is not supported!
```

The issue proposes raising a `RuntimeError` instead, which is what this does. The event is checked in the PyO3 handlers, before the control flow value reaches the core, so the core never panics and the stderr message is gone as well. `rustworkx-core` is left untouched: its `panic!` stays as an assertion for Rust callers, where returning `Prune` on `Finish` really is a programming error.

The panic was reachable from all three traversals, not just DFS (`dfs_visit.rs:270`, `bfs_visit.rs:243`, `dijkstra_visit.rs:283`), so all three handlers are fixed.

I checked the whole event surface to make sure the change is neither too narrow nor too wide: every event of the three traversals, with both `PruneSearch` and `StopSearch`, on `PyGraph` and `PyDiGraph`. `PruneSearch` on `finish_vertex` is the only combination that panicked, pruning on every other event still prunes, and `StopSearch` is unaffected. DFS propagating `StopSearch` back to the caller is existing documented behaviour and is left alone.

### Documentation

The docstrings for the three searches already noted that an exception was raised in that event but did not name the type, which is now `RuntimeError`. That note is duplicated in `rustworkx/__init__.py`, which is what `help()` and the published docs show, so both copies are updated. Those lines also referred to `finish_vertex` with `:class:` rather than `:meth:`, fixed in passing since they were being rewritten anyway.

### Tests

24 tests across the six `test_{bfs,dfs,dijkstra}_search.py` files, in `tests/graph/` and `tests/digraph/`:

- `prune_finish_vertex` — a `RuntimeError` is raised.
- `prune_finish_vertex_mid_traversal` — the visitor prunes on its second `finish_vertex`, which pins the exact finish order up to that point and shows the error is not raised eagerly.
- `prune_finish_vertex_no_starting_point` — same with `source=None`, so more than one component is walked.
- `stop_search_finish_vertex` — a guard that `StopSearch` in the same event is unaffected.

Reverting only the three handler files to `main` and rebuilding, **18 of the 24 fail** with the old `PanicException`; the 6 `stop_search_finish_vertex` tests pass either way, which is what makes them useful as guards.

`cargo test --workspace` is 524 passed and the Python suite is 2418 passed / 32 skipped, with `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `ruff format`, `ruff check`, `find_stray_release_notes.py` and `cargo doc -p rustworkx-core` with `-D warnings` all clean.
